### PR TITLE
feat(playlist): stable filenames, sync-with-folder, and M3U generation

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,6 +20,8 @@ import { YtDlp } from '@main/services/YtDlp.js';
 import { RecentJobsStore } from '@main/stores/RecentJobsStore.js';
 import { SettingsStore } from '@main/stores/SettingsStore.js';
 import { QueueStore } from '@main/stores/QueueStore.js';
+import { PlaylistManifestStore } from '@main/stores/PlaylistManifestStore.js';
+import { writePlaylistM3u } from '@main/services/playlistM3u.js';
 import { ClipboardWatcher, watcherWindowFromBrowserWindow } from '@main/services/ClipboardWatcher.js';
 import { HiddenWindowTokenProvider } from '@main/token/providers/HiddenWindowTokenProvider.js';
 import { MockTokenProvider } from '@main/token/providers/MockTokenProvider.js';
@@ -166,6 +168,7 @@ if (hasSingleInstanceLock) {
     };
     const recentJobsStore = new RecentJobsStore(userDataPath);
     const queueStore = new QueueStore(userDataPath);
+    const playlistManifestStore = new PlaylistManifestStore(userDataPath);
     const binaryManager = new BinaryManager(userDataPath, {
       overridesProvider: () => settingsStore.getSync().common.binaryOverrides
     });
@@ -174,7 +177,7 @@ if (hasSingleInstanceLock) {
     const ytDlp = new YtDlp(binaryManager, tokenService, settingsStore);
     const downloadService = new DownloadService(ytDlp, recentJobsStore, isMockBackend);
     const probeService = new ProbeService(ytDlp, isMockBackend);
-    const queueService = new QueueService(queueStore, downloadService);
+    const queueService = new QueueService(queueStore, downloadService, undefined, undefined, { manifestStore: playlistManifestStore, writeM3u: writePlaylistM3u });
     await queueService.init();
 
     // Headless smoke mode — exercises PoT scrape + 3-attempt ladder against
@@ -318,7 +321,8 @@ if (hasSingleInstanceLock) {
       queueService,
       tokenService,
       languageRef,
-      clipboardWatcher
+      clipboardWatcher,
+      playlistManifestStore
     });
 
     registerUpdaterHandlers(mainWindow);

--- a/src/main/ipc/playlistHandlers.ts
+++ b/src/main/ipc/playlistHandlers.ts
@@ -1,0 +1,42 @@
+import { promises as fsPromises } from 'node:fs';
+import { z } from 'zod';
+import { IPC_CHANNELS } from '@shared/ipc.js';
+import { playlistManifestSchema } from '@shared/schemas.js';
+import { ok } from '@shared/result.js';
+import type { PlaylistManifestStore } from '@main/stores/PlaylistManifestStore.js';
+import { handle, toUnknownFailure } from './utils.js';
+
+const scanInputSchema = z.object({ outputDir: z.string().min(1), videoIds: z.array(z.string()) });
+
+// Match `[<id>]` as a delimited substring. Brackets make fixed-width ids
+// collision-safe. Note: ids are matched raw — for YouTube (alnum/-/_) this
+// equals yt-dlp's sanitized form; slug-id extractors may differ and fall
+// through to a worst-case re-download (documented in the spec).
+export async function scanFolderForVideoIds(outputDir: string, videoIds: string[]): Promise<string[]> {
+  let names: string[];
+  try {
+    names = await fsPromises.readdir(outputDir);
+  } catch {
+    return [];
+  }
+  return videoIds.filter((id) => names.some((n) => n.includes(`[${id}]`)));
+}
+
+export function registerPlaylistHandlers(manifestStore: PlaylistManifestStore): void {
+  handle(IPC_CHANNELS.playlistScanFolder, scanInputSchema, async ({ outputDir, videoIds }) => {
+    try {
+      return ok({ matchedIds: await scanFolderForVideoIds(outputDir, videoIds) });
+    } catch (err) {
+      return toUnknownFailure(err);
+    }
+  });
+
+  handle(IPC_CHANNELS.playlistRegisterManifest, playlistManifestSchema, async (manifest) => {
+    try {
+      await manifestStore.save(manifest);
+      return ok(undefined);
+    } catch (err) {
+      return toUnknownFailure(err);
+    }
+  });
+}

--- a/src/main/ipc/registerIpcHandlers.ts
+++ b/src/main/ipc/registerIpcHandlers.ts
@@ -7,6 +7,7 @@ import type { TokenService } from '@main/services/TokenService.js';
 import type { SettingsStore } from '@main/stores/SettingsStore.js';
 import type { QueueService } from '@main/services/QueueService.js';
 import type { ClipboardWatcher } from '@main/services/ClipboardWatcher.js';
+import type { PlaylistManifestStore } from '@main/stores/PlaylistManifestStore.js';
 import { DownloadEventBridge } from '@main/services/DownloadEventBridge.js';
 import { QueueEventBridge } from '@main/services/QueueEventBridge.js';
 import { WarmupService } from '@main/services/WarmupService.js';
@@ -18,6 +19,7 @@ import { registerFileHandlers } from './fileHandlers.js';
 import { registerQueueHandlers } from './queueHandlers.js';
 import { registerAnalyticsHandlers } from './analyticsHandlers.js';
 import { registerDiagnosticsHandlers } from './diagnosticsHandlers.js';
+import { registerPlaylistHandlers } from './playlistHandlers.js';
 
 export interface IpcDependencies {
   mainWindow: BrowserWindow;
@@ -29,13 +31,14 @@ export interface IpcDependencies {
   tokenService: TokenService;
   languageRef: { current: SupportedLang };
   clipboardWatcher: ClipboardWatcher;
+  playlistManifestStore: PlaylistManifestStore;
 }
 
 let activeDownloadBridge: DownloadEventBridge | null = null;
 let activeQueueBridge: QueueEventBridge | null = null;
 
 export function registerIpcHandlers(deps: IpcDependencies): void {
-  const { mainWindow, downloadService, probeService, settingsStore, queueService, binaryManager, tokenService, languageRef, clipboardWatcher } = deps;
+  const { mainWindow, downloadService, probeService, settingsStore, queueService, binaryManager, tokenService, languageRef, clipboardWatcher, playlistManifestStore } = deps;
 
   const warmupService = new WarmupService({ binaryManager, tokenService, window: mainWindow });
   registerAppHandlers({ warmupService, languageRef });
@@ -46,6 +49,7 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
   registerQueueHandlers(queueService);
   registerAnalyticsHandlers();
   registerDiagnosticsHandlers();
+  registerPlaylistHandlers(playlistManifestStore);
 
   activeDownloadBridge?.detach();
   activeDownloadBridge = new DownloadEventBridge(downloadService, mainWindow);

--- a/src/main/services/ProbeService.ts
+++ b/src/main/services/ProbeService.ts
@@ -188,7 +188,12 @@ function buildEntryUrl(entry: InfoDict): string | null {
   return null;
 }
 
-function mapPlaylistEntries(entries: readonly InfoDict[], jobUrl: string, site: Site): PlaylistEntry[] {
+export function mapPlaylistEntries(entries: readonly InfoDict[], jobUrl: string, siteOrExtractor: Site | string): PlaylistEntry[] {
+  const site = typeof siteOrExtractor === 'string' ? siteForExtractor(siteOrExtractor) : siteOrExtractor;
+  return mapPlaylistEntriesInner(entries, jobUrl, site);
+}
+
+function mapPlaylistEntriesInner(entries: readonly InfoDict[], jobUrl: string, site: Site): PlaylistEntry[] {
   // First pass: detect whether the result set contains any real video entry
   // (id without a known container prefix). If yes, the heterogeneous-result
   // case applies and we'll filter containers out below. If no (all nested),
@@ -249,7 +254,8 @@ function mapPlaylistEntries(entries: readonly InfoDict[], jobUrl: string, site: 
       title,
       thumbnail: pickEntryThumbnail(entry),
       duration: typeof v.duration === 'number' ? Math.round(v.duration) : undefined,
-      playlistIndex
+      playlistIndex,
+      videoId: idStr.length > 0 ? idStr : null
     });
     fallbackIndex++;
   }

--- a/src/main/services/QueueService.ts
+++ b/src/main/services/QueueService.ts
@@ -22,15 +22,21 @@ import log from 'electron-log/main.js';
 import { fail, ok, type Result } from '@shared/result.js';
 import { createAppError } from '@main/utils/errorFactory.js';
 import { nowIso } from '@main/utils/clock.js';
-import { QUEUE_STATUS, STATUS_KEY, type QueueLane, type StatusKey } from '@shared/schemas.js';
+import { QUEUE_STATUS, STATUS_KEY, type QueueItemStatus, type QueueLane, type StatusKey } from '@shared/schemas.js';
 import { transition, illegalTransition, type QueueEvent } from '@shared/queueTransition.js';
 import { ProgressFormatter, nextMonotonicPercent } from '@shared/progressFormat.js';
 import { INTER_JOB_SLEEP_MS, MAX_CONCURRENT_DOWNLOADS, NORMAL_LANE_CAP } from '@shared/constants.js';
 import type { ProgressEvent, QueueItem, StatusEvent } from '@shared/types.js';
 import type { QueueStore } from '@main/stores/QueueStore.js';
+import type { PlaylistManifestStore } from '@main/stores/PlaylistManifestStore.js';
+import type { PlaylistManifest } from '@shared/playlistManifest.js';
 import type { DownloadService } from './DownloadService.js';
 
 const logger = log.scope('queue');
+
+function isTerminalStatus(s: QueueItemStatus): boolean {
+  return s === QUEUE_STATUS.done || s === QUEUE_STATUS.error || s === QUEUE_STATUS.cancelled;
+}
 
 // Discriminated union covering every shape a mutation can take. commit()
 // is the only writer; new mutation kinds add a case here (compile-checked
@@ -76,7 +82,11 @@ export class QueueService extends EventEmitter {
     private readonly queueStore: QueueStore,
     private readonly downloadService: DownloadService,
     private readonly normalCap = NORMAL_LANE_CAP,
-    private readonly maxConcurrent = MAX_CONCURRENT_DOWNLOADS
+    private readonly maxConcurrent = MAX_CONCURRENT_DOWNLOADS,
+    private readonly playlist?: {
+      manifestStore: PlaylistManifestStore;
+      writeM3u: (manifest: PlaylistManifest) => Promise<void>;
+    }
   ) {
     super();
     this.downloadService.on('status', (event: StatusEvent) => this.consumeStatusEvent(event));
@@ -478,6 +488,9 @@ export class QueueService extends EventEmitter {
         const next = transition(prev, mutation.evt);
         this.items[idx] = next;
         this.persist();
+        if (isTerminalStatus(next.status) && next.playlistGroupId) {
+          void this.maybeWritePlaylistM3u(next.playlistGroupId);
+        }
         if (mutation.evt.kind === 'progress') this.emitProgress(next);
         else this.emitImmediate(next);
         break;
@@ -625,6 +638,16 @@ export class QueueService extends EventEmitter {
 
   private findByJobId(jobId: string): QueueItem | undefined {
     return this.items.find((i) => i.lastJobId === jobId);
+  }
+
+  private async maybeWritePlaylistM3u(playlistGroupId: string): Promise<void> {
+    if (!this.playlist) return;
+    const group = this.items.filter((i) => i.playlistGroupId === playlistGroupId);
+    const allTerminal = group.every((i) => isTerminalStatus(i.status));
+    if (!allTerminal) return;
+    const manifest = this.playlist.manifestStore.get(playlistGroupId);
+    if (!manifest) return;
+    await this.playlist.writeM3u(manifest);
   }
 
   // Persist gate: short-circuits when a bulk op (cancelAll, clearCompleted)

--- a/src/main/services/YtDlp.ts
+++ b/src/main/services/YtDlp.ts
@@ -409,7 +409,7 @@ function effectiveSubtitleFormat(req: { writeAutoSubs?: boolean; subtitleFormat:
 function buildSubtitleArgs(req: Extract<YtDlpRequest, { kind: 'subtitle' }>): string[] {
   const subOutputDir = req.subtitleMode === 'subfolder' ? `${req.outputDir}/subtitles` : req.outputDir;
   const fmt = effectiveSubtitleFormat(req);
-  const template = req.outputTemplate ?? '%(title)s.%(ext)s';
+  const template = req.outputTemplate ?? '%(title).200B.%(ext)s';
   return ['--skip-download', '--no-playlist', '--write-subs', '--sub-langs', req.subtitleLanguages.join(','), ...(req.writeAutoSubs ? ['--write-auto-subs'] : []), '--sleep-subtitles', '3', '--sub-format', `${fmt}/best`, '--convert-subs', fmt, '-o', `${subOutputDir}/${template}`, req.url];
 }
 
@@ -487,7 +487,7 @@ function buildVideoArgs(req: Extract<YtDlpRequest, { kind: 'video' | 'video+embe
   } else if (req.formatId) {
     args.push('-f', req.formatId);
   }
-  const template = req.outputTemplate ?? '%(title)s.%(ext)s';
+  const template = req.outputTemplate ?? '%(title).200B.%(ext)s';
   if (req.tempDir) {
     args.push('--paths', `home:${req.outputDir}`, '--paths', `temp:${req.tempDir}`, '-o', template);
   } else {

--- a/src/main/services/playlistM3u.ts
+++ b/src/main/services/playlistM3u.ts
@@ -1,0 +1,37 @@
+import { promises as fsPromises } from 'node:fs';
+import path from 'node:path';
+import { safeFolderName } from '@shared/subfolder.js';
+import type { PlaylistManifest } from '@shared/playlistManifest.js';
+
+// Pure: given the manifest and the dir listing, produce extended-M3U text.
+// Entries are emitted in playlist order; an item is included only when it has
+// a videoId AND a file in `files` contains `[<videoId>]`.
+export function buildM3u(manifest: PlaylistManifest, files: string[]): string {
+  const lines = ['#EXTM3U'];
+  for (const item of manifest.items) {
+    if (!item.videoId) continue;
+    const match = files.find((n) => n.includes(`[${item.videoId}]`));
+    if (!match) continue;
+    lines.push(`#EXTINF:${item.duration ?? -1},${item.title}`);
+    lines.push(match);
+  }
+  return lines.join('\n') + '\n';
+}
+
+// I/O: read the dir, build, overwrite `<sanitized title>.m3u`. Best-effort —
+// failures are swallowed (M3U is a convenience artifact, never blocks a job).
+export async function writePlaylistM3u(manifest: PlaylistManifest): Promise<void> {
+  let files: string[];
+  try {
+    files = await fsPromises.readdir(manifest.outputDir);
+  } catch {
+    return;
+  }
+  const body = buildM3u(manifest, files);
+  const fileName = `${safeFolderName(manifest.playlistTitle || 'Playlist')}.m3u`;
+  try {
+    await fsPromises.writeFile(path.join(manifest.outputDir, fileName), body, 'utf8');
+  } catch {
+    /* best-effort */
+  }
+}

--- a/src/main/stores/PlaylistManifestStore.ts
+++ b/src/main/stores/PlaylistManifestStore.ts
@@ -1,0 +1,42 @@
+import Store from 'electron-store';
+import type { PlaylistManifest } from '@shared/playlistManifest.js';
+import { playlistManifestSchema } from '@shared/schemas.js';
+
+interface ManifestData {
+  byGroup: Record<string, PlaylistManifest>;
+}
+
+export class PlaylistManifestStore {
+  private readonly store: Store<ManifestData>;
+
+  constructor(userDataPath: string) {
+    this.store = new Store<ManifestData>({
+      name: 'playlist-manifests',
+      cwd: userDataPath,
+      defaults: { byGroup: {} },
+      clearInvalidConfig: true
+    });
+  }
+
+  async save(manifest: PlaylistManifest): Promise<void> {
+    const parsed = playlistManifestSchema.safeParse(manifest);
+    if (!parsed.success) {
+      throw new Error(`PlaylistManifestStore.save: invalid manifest — ${parsed.error.issues[0]?.message ?? 'schema mismatch'}`);
+    }
+    const byGroup = { ...this.store.get('byGroup'), [parsed.data.playlistGroupId]: parsed.data };
+    this.store.set('byGroup', byGroup);
+  }
+
+  get(playlistGroupId: string): PlaylistManifest | null {
+    const raw = this.store.get('byGroup')[playlistGroupId];
+    if (!raw) return null;
+    const parsed = playlistManifestSchema.safeParse(raw);
+    return parsed.success ? parsed.data : null;
+  }
+
+  async remove(playlistGroupId: string): Promise<void> {
+    const byGroup = { ...this.store.get('byGroup') };
+    delete byGroup[playlistGroupId];
+    this.store.set('byGroup', byGroup);
+  }
+}

--- a/src/preload/createPreloadApi.ts
+++ b/src/preload/createPreloadApi.ts
@@ -147,6 +147,10 @@ export function createPreloadApi(ipcRenderer: PreloadIpcRenderer): AppApi {
     },
     diagnostics: {
       logWizardStep: (snapshot) => ipcRenderer.send(IPC_CHANNELS.diagnosticsLogWizardStep, snapshot)
+    },
+    playlist: {
+      scanFolder: (input) => ipcRenderer.invoke(IPC_CHANNELS.playlistScanFolder, input),
+      registerManifest: (manifest) => ipcRenderer.invoke(IPC_CHANNELS.playlistRegisterManifest, manifest)
     }
   };
 }

--- a/src/renderer/src/browserMock.ts
+++ b/src/renderer/src/browserMock.ts
@@ -292,7 +292,8 @@ export function installBrowserMock(): void {
             title: `Mock playlist item ${i + 1} — ${i % 3 === 0 ? 'a longer title that should ellipsize gracefully when the row is narrow' : 'short title'}`,
             thumbnail: i % 5 === 0 ? '' : 'https://i.ytimg.com/vi/jfKfPfyJRdk/mqdefault.jpg',
             duration: 90 + i * 47,
-            playlistIndex: i + 1
+            playlistIndex: i + 1,
+            videoId: `mockid${i + 1}`
           }));
           return {
             ok: true,
@@ -682,6 +683,14 @@ export function installBrowserMock(): void {
 
     diagnostics: {
       logWizardStep: (snapshot) => console.log('[mock] wizard step', snapshot)
+    },
+
+    playlist: {
+      scanFolder: async () => {
+        await delay(150);
+        return { ok: true as const, data: { matchedIds: [] } };
+      },
+      registerManifest: () => Promise.resolve({ ok: true as const, data: undefined })
     }
   };
 

--- a/src/renderer/src/components/wizard/StepPlaylistItems.tsx
+++ b/src/renderer/src/components/wizard/StepPlaylistItems.tsx
@@ -19,10 +19,11 @@ function formatEntryDuration(seconds: number | undefined, liveLabel: string): st
 
 export function StepPlaylistItems(): JSX.Element {
   const { t } = useTranslation();
-  const { playlistItems, selectedPlaylistItemIds, playlistTitle, playlistProbeLoading, setPlaylistItemSelected, selectAllPlaylistItems, selectNonePlaylistItems, selectPlaylistRange, confirmPlaylistSelection, back, wizardExtractor } = useAppStore();
+  const { playlistItems, selectedPlaylistItemIds, playlistTitle, playlistProbeLoading, syncedDownloadedIds, wizardOutputDir, setPlaylistItemSelected, selectAllPlaylistItems, selectNonePlaylistItems, selectPlaylistRange, confirmPlaylistSelection, back, wizardExtractor, syncWithFolder, chooseWizardFolder } = useAppStore();
 
   const [rangeFrom, setRangeFrom] = useState('');
   const [rangeTo, setRangeTo] = useState('');
+  const [syncOpen, setSyncOpen] = useState(false);
 
   const parentRef = useRef<HTMLDivElement>(null);
   // eslint-disable-next-line react-hooks/incompatible-library
@@ -60,12 +61,15 @@ export function StepPlaylistItems(): JSX.Element {
         <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">{t('wizard.playlist.loadingItems')}</div>
       ) : (
         <>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-wrap">
             <Button type="button" variant="outline" size="sm" onClick={selectAllPlaylistItems}>
               {t('wizard.playlist.selectAll')}
             </Button>
             <Button type="button" variant="outline" size="sm" onClick={selectNonePlaylistItems}>
               {t('wizard.playlist.selectNone')}
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={() => setSyncOpen((v) => !v)}>
+              {t('wizard.playlist.syncWithFolder')}
             </Button>
             <div className="ml-auto flex items-center gap-1">
               <span className="text-xs text-muted-foreground">{t('wizard.playlist.rangeFrom')}</span>
@@ -78,11 +82,30 @@ export function StepPlaylistItems(): JSX.Element {
             </div>
           </div>
 
+          {syncOpen && (
+            <div className="rounded-md border border-border bg-muted/30 px-3 py-2 flex flex-col gap-2">
+              <div className="flex items-center gap-2 text-xs">
+                <span className="text-muted-foreground shrink-0">{t('wizard.playlist.syncPanelDir')}</span>
+                <span className="flex-1 truncate font-mono text-[11px]">{wizardOutputDir || '—'}</span>
+                <Button type="button" variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={() => void chooseWizardFolder()}>
+                  {t('wizard.playlist.syncChange')}
+                </Button>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button type="button" variant="outline" size="sm" onClick={() => void syncWithFolder()}>
+                  {t('wizard.playlist.syncApply')}
+                </Button>
+                {syncedDownloadedIds.length === 0 && <span className="text-xs text-muted-foreground">{t('wizard.playlist.syncNoPriorDownloads')}</span>}
+              </div>
+            </div>
+          )}
+
           <div ref={parentRef} className="h-[calc(100vh-280px)] min-h-[300px] overflow-y-auto rounded-md border border-border">
             <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
               {virtualizer.getVirtualItems().map((virtualRow) => {
                 const entry = playlistItems[virtualRow.index];
                 const checked = selectedPlaylistItemIds.includes(entry.id);
+                const isAlreadyDownloaded = !!(entry.videoId && syncedDownloadedIds.includes(entry.videoId));
                 return (
                   <div
                     key={entry.id}
@@ -101,6 +124,7 @@ export function StepPlaylistItems(): JSX.Element {
                     <Checkbox checked={checked} onCheckedChange={(v) => setPlaylistItemSelected(entry.id, !!v)} onClick={(e) => e.stopPropagation()} />
                     {hasAnyThumbnail ? entry.thumbnail ? <img src={entry.thumbnail} alt={t('wizard.playlist.thumbnailAlt')} referrerPolicy="no-referrer" className="h-8 w-[56px] shrink-0 rounded-sm object-cover" loading="lazy" /> : <div className="h-8 w-[56px] shrink-0 rounded-sm bg-muted" /> : null}
                     <span className="flex-1 truncate text-sm">{entry.title}</span>
+                    {isAlreadyDownloaded && <span className="shrink-0 rounded-sm bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{t('wizard.playlist.alreadyDownloaded')}</span>}
                     <span className="shrink-0 text-xs text-muted-foreground">{formatEntryDuration(entry.duration, liveLabel)}</span>
                   </div>
                 );

--- a/src/renderer/src/store/queueSlice.ts
+++ b/src/renderer/src/store/queueSlice.ts
@@ -100,9 +100,8 @@ function buildQueueItem(get: GetState, lane: QueueLane): QueueItem | null {
   };
 }
 
-function padPlaylistIndex(index: number, maxIndex: number): string {
-  const width = Math.max(2, String(maxIndex).length);
-  return String(index).padStart(width, '0');
+export function playlistOutputTemplate(): string {
+  return '%(title).200B [%(id)s].%(ext)s';
 }
 
 function buildPlaylistQueueItem(entry: PlaylistEntry, get: GetState, playlistGroupId: string, lane: QueueLane): QueueItem {
@@ -113,8 +112,7 @@ function buildPlaylistQueueItem(entry: PlaylistEntry, get: GetState, playlistGro
   const baseDir = wizardSubfolderEnabled && wizardSubfolderName ? joinSubfolder(wizardOutputDir, wizardSubfolderName) : joinSubfolder(wizardOutputDir, safeFolderName(state.playlistTitle || 'Playlist'));
 
   const formatLabel = i18next.t(`playlistPresets.${selectedPlaylistPreset}.label` as const);
-  const maxPlaylistIndex = state.playlistItems.reduce((max, item) => Math.max(max, item.playlistIndex), 0);
-  const outputTemplate = `${padPlaylistIndex(entry.playlistIndex, maxPlaylistIndex)} - %(title)s.%(ext)s`;
+  const outputTemplate = playlistOutputTemplate();
 
   const embed: EmbedOptions = {
     chapters: state.wizardEmbedChapters,
@@ -168,6 +166,13 @@ async function submitWizardToQueue(set: SetState, get: GetState, lane: QueueLane
       const groupId = generateId();
       const selected = playlistItems.filter((e) => selectedPlaylistItemIds.includes(e.id));
       const items = selected.map((e) => buildPlaylistQueueItem(e, get, groupId, lane));
+      const baseDir = items[0]?.outputDir ?? get().wizardOutputDir;
+      await window.appApi.playlist.registerManifest({
+        playlistGroupId: groupId,
+        playlistTitle: get().playlistTitle || 'Playlist',
+        outputDir: baseDir,
+        items: playlistItems.map((e) => ({ videoId: e.videoId, title: e.title, duration: e.duration }))
+      });
       await window.appApi.queue.cmd.add(items);
     } else {
       const item = buildQueueItem(get, lane);

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -50,6 +50,9 @@ export interface ProbeOrchestratorSlice {
   playlistProbeLoading: boolean;
   selectedPlaylistPreset: PlaylistPreset | null;
 
+  // videoIds matched on disk by the last syncWithFolder call
+  syncedDownloadedIds: string[];
+
   setWizardUrl: (url: string) => void;
   submitUrl: () => Promise<void>;
   dismissMixedPrompt: (choice: 'video' | 'playlist') => Promise<void>;
@@ -59,6 +62,7 @@ export interface ProbeOrchestratorSlice {
   selectPlaylistRange: (from: number, to: number) => void;
   confirmPlaylistSelection: () => void;
   setPlaylistPreset: (p: PlaylistPreset) => void;
+  syncWithFolder: () => Promise<void>;
   advance: () => void;
   back: () => void;
   skipSubtitles: () => void;

--- a/src/renderer/src/store/wizard/commands.ts
+++ b/src/renderer/src/store/wizard/commands.ts
@@ -55,6 +55,8 @@ export const RESET_WIZARD_STATE = {
   wizardWriteThumbnail: DEFAULTS.writeThumbnail,
   wizardSubfolderEnabled: false,
   wizardSubfolderName: '',
+  // sync-with-folder
+  syncedDownloadedIds: [] as string[],
   // dialogs
   advancedAutoOpen: false,
   advancedAutoTarget: 'cookies' as const,

--- a/src/renderer/src/store/wizard/outputConfig.ts
+++ b/src/renderer/src/store/wizard/outputConfig.ts
@@ -23,14 +23,14 @@ export function createOutputConfigSlice(set: SetState, _get: GetState): OutputCo
     wizardWriteThumbnail: DEFAULTS.writeThumbnail,
 
     setWizardOutputDir: async (dir, persist = true) => {
-      set({ wizardOutputDir: dir });
+      set({ wizardOutputDir: dir, syncedDownloadedIds: [] });
       if (persist) await window.appApi.settings.update({ common: { defaultOutputDir: dir } });
     },
 
     chooseWizardFolder: async () => {
       const result = await window.appApi.dialog.chooseFolder();
       if (!result.ok || !result.data.path) return;
-      set({ wizardOutputDir: result.data.path });
+      set({ wizardOutputDir: result.data.path, syncedDownloadedIds: [] });
       await window.appApi.settings.update({ common: { defaultOutputDir: result.data.path } });
     },
 

--- a/src/renderer/src/store/wizard/probeOrchestrator.ts
+++ b/src/renderer/src/store/wizard/probeOrchestrator.ts
@@ -243,10 +243,10 @@ function applyPlaylistProbeResult(probe: Extract<ProbeResult, { kind: 'playlist'
       ? {
           ...restoreCommonWizardPrefs(settings),
           wizardSubfolderEnabled: settings?.common?.lastSubfolderEnabled ?? false,
-          wizardSubfolderName: settings?.common?.lastSubfolder ?? '',
-          selectedPlaylistPreset
+          wizardSubfolderName: settings?.common?.lastSubfolder ?? ''
         }
-      : {})
+      : {}),
+    selectedPlaylistPreset
   });
 }
 

--- a/src/renderer/src/store/wizard/probeOrchestrator.ts
+++ b/src/renderer/src/store/wizard/probeOrchestrator.ts
@@ -325,6 +325,7 @@ export function createProbeOrchestratorSlice(set: SetState, get: GetState): Prob
     playlistIsMultiVideo: RESET_WIZARD_STATE.playlistIsMultiVideo,
     playlistProbeLoading: RESET_WIZARD_STATE.playlistProbeLoading,
     selectedPlaylistPreset: RESET_WIZARD_STATE.selectedPlaylistPreset,
+    syncedDownloadedIds: RESET_WIZARD_STATE.syncedDownloadedIds,
 
     setWizardUrl: (url) => set({ wizardUrl: url }),
 
@@ -378,6 +379,19 @@ export function createProbeOrchestratorSlice(set: SetState, get: GetState): Prob
     },
 
     setPlaylistPreset: (p) => set({ selectedPlaylistPreset: p, wizardSubtitleSkipped: false }),
+
+    syncWithFolder: async () => {
+      const { wizardOutputDir, playlistItems, selectedPlaylistItemIds } = get();
+      const videoIds = playlistItems.map((e) => e.videoId).filter((v): v is string => v !== null);
+      const res = await window.appApi.playlist.scanFolder({ outputDir: wizardOutputDir, videoIds });
+      if (!res.ok) return;
+      const matched = new Set(res.data.matchedIds);
+      const stillSelected = selectedPlaylistItemIds.filter((id) => {
+        const entry = playlistItems.find((e) => e.id === id);
+        return !entry?.videoId || !matched.has(entry.videoId);
+      });
+      set({ syncedDownloadedIds: res.data.matchedIds, selectedPlaylistItemIds: stillSelected });
+    },
 
     advance: () => {
       const state = get();

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1,6 +1,7 @@
 import type { Result } from './result.js';
 import type { SupportedLang } from './i18n/types.js';
 import type { AppSettings, CancelDownloadInput, CancelDownloadOutput, CommonSettings, DependencyId, DownloadJob, PauseDownloadInput, PauseDownloadOutput, PlaylistPrefs, ProbeError, ProbeInput, ProbeResult, ProgressEvent, QueueItem, QueueLane, SinglePrefs, StartDownloadInput, StartDownloadOutput, StatusEvent, UpdateAvailablePayload, UpdateInstallResult, WarmUpOutput, WarmupProgressEvent, WizardStepSnapshot } from './types.js';
+import type { PlaylistManifest } from './playlistManifest.js';
 
 export interface SettingsPatch {
   common?: Partial<CommonSettings>;
@@ -85,5 +86,9 @@ export interface AppApi {
   };
   diagnostics: {
     logWizardStep(snapshot: WizardStepSnapshot): void;
+  };
+  playlist: {
+    scanFolder(input: { outputDir: string; videoIds: string[] }): Promise<Result<{ matchedIds: string[] }>>;
+    registerManifest(manifest: PlaylistManifest): Promise<Result<void>>;
   };
 }

--- a/src/shared/i18n/locales/en.ts
+++ b/src/shared/i18n/locales/en.ts
@@ -106,7 +106,13 @@ const en = {
       noSelection: 'Select at least one video to continue',
       loadingItems: 'Fetching playlist…',
       thumbnailAlt: 'Video thumbnail',
-      durationUnknown: 'live'
+      durationUnknown: 'live',
+      syncWithFolder: 'Sync with folder',
+      syncPanelDir: 'Folder',
+      syncChange: 'Change…',
+      syncApply: 'Apply sync',
+      syncNoPriorDownloads: 'No prior downloads found in this folder',
+      alreadyDownloaded: 'Already downloaded'
     },
     mixedPrompt: {
       title: 'This link has a playlist',

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -49,5 +49,7 @@ export const IPC_CHANNELS = {
   diagnosticsLogWizardStep: 'diagnostics:logWizardStep',
   warmupProgress: 'warmup:progress',
   dialogChooseExecutable: 'dialog:chooseExecutable',
-  shellOpenBinariesDir: 'shell:openBinariesDir'
+  shellOpenBinariesDir: 'shell:openBinariesDir',
+  playlistScanFolder: 'playlist:scanFolder',
+  playlistRegisterManifest: 'playlist:registerManifest'
 } as const;

--- a/src/shared/playlistManifest.ts
+++ b/src/shared/playlistManifest.ts
@@ -1,0 +1,12 @@
+export interface PlaylistManifestItem {
+  videoId: string | null;
+  title: string;
+  duration?: number;
+}
+
+export interface PlaylistManifest {
+  playlistGroupId: string;
+  playlistTitle: string;
+  outputDir: string;
+  items: PlaylistManifestItem[]; // FULL ordered probe list (not just selected)
+}

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -378,6 +378,19 @@ export const queueItemSchema = z.object({
 
 export const queueArraySchema = z.array(queueItemSchema);
 
+const playlistManifestItemSchema = z.object({
+  videoId: z.string().nullable(),
+  title: z.string(),
+  duration: z.number().optional()
+});
+
+export const playlistManifestSchema = z.object({
+  playlistGroupId: z.string().min(1),
+  playlistTitle: z.string(),
+  outputDir: z.string().min(1),
+  items: z.array(playlistManifestItemSchema)
+});
+
 // yt-dlp info_dict shape lives in `./ytdlp/infoDict.ts` — the spec port that
 // validates `--dump-single-json` output. Schemas here are app-internal contracts
 // (settings, prefs, queue items); yt-dlp's contract is its own thing.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -187,6 +187,7 @@ export interface PlaylistEntry {
   thumbnail: string;
   duration?: number;
   playlistIndex: number;
+  videoId: string | null; // raw yt-dlp %(id)s; null when extractor yields none
 }
 
 export type ProbePlaylistMode = 'auto' | 'video' | 'playlist';

--- a/tests/renderer/feedback-nudge.test.tsx
+++ b/tests/renderer/feedback-nudge.test.tsx
@@ -80,6 +80,10 @@ const mockAppApi = {
   },
   diagnostics: {
     logWizardStep: vi.fn()
+  },
+  playlist: {
+    scanFolder: vi.fn().mockResolvedValue({ ok: true, data: { matchedIds: [] } }),
+    registerManifest: vi.fn().mockResolvedValue({ ok: true, data: undefined })
   }
 };
 

--- a/tests/renderer/footer-feedback.test.tsx
+++ b/tests/renderer/footer-feedback.test.tsx
@@ -85,6 +85,10 @@ const mockAppApi = {
   },
   diagnostics: {
     logWizardStep: vi.fn()
+  },
+  playlist: {
+    scanFolder: vi.fn().mockResolvedValue({ ok: true, data: { matchedIds: [] } }),
+    registerManifest: vi.fn().mockResolvedValue({ ok: true, data: undefined })
   }
 };
 

--- a/tests/renderer/playlist-defects.test.tsx
+++ b/tests/renderer/playlist-defects.test.tsx
@@ -7,9 +7,9 @@ import { ok } from '../shared/fixtures.js';
 import type { PlaylistEntry } from '@shared/types.js';
 
 const PLAYLIST_ENTRIES: PlaylistEntry[] = [
-  { id: 'p1', url: 'https://youtube.com/watch?v=p1', title: 'Vid 1', thumbnail: '', playlistIndex: 1 },
-  { id: 'p2', url: 'https://youtube.com/watch?v=p2', title: 'Vid 2', thumbnail: '', playlistIndex: 2 },
-  { id: 'p3', url: 'https://youtube.com/watch?v=p3', title: 'Vid 3', thumbnail: '', playlistIndex: 3 }
+  { id: 'p1', url: 'https://youtube.com/watch?v=p1', title: 'Vid 1', thumbnail: '', playlistIndex: 1, videoId: 'p1' },
+  { id: 'p2', url: 'https://youtube.com/watch?v=p2', title: 'Vid 2', thumbnail: '', playlistIndex: 2, videoId: 'p2' },
+  { id: 'p3', url: 'https://youtube.com/watch?v=p3', title: 'Vid 3', thumbnail: '', playlistIndex: 3, videoId: 'p3' }
 ];
 
 function buildMockApi(settingsUpdateMock?: ReturnType<typeof vi.fn>) {
@@ -61,7 +61,11 @@ function buildMockApi(settingsUpdateMock?: ReturnType<typeof vi.fn>) {
       install: vi.fn()
     },
     analytics: { track: vi.fn() },
-    diagnostics: { logWizardStep: vi.fn() }
+    diagnostics: { logWizardStep: vi.fn() },
+    playlist: {
+      scanFolder: vi.fn().mockResolvedValue({ ok: true, data: { matchedIds: [] } }),
+      registerManifest: vi.fn().mockResolvedValue({ ok: true, data: undefined })
+    }
   };
 }
 

--- a/tests/renderer/playlist-regressions.test.tsx
+++ b/tests/renderer/playlist-regressions.test.tsx
@@ -7,9 +7,9 @@ import { buildAppSettings } from '../shared/settingsFixtures.js';
 import type { PlaylistEntry, StatusEvent } from '@shared/types.js';
 
 const PLAYLIST_ENTRIES: PlaylistEntry[] = [
-  { id: 'p1', url: 'https://youtube.com/watch?v=p1', title: 'Vid 1', thumbnail: '', playlistIndex: 1 },
-  { id: 'p2', url: 'https://youtube.com/watch?v=p2', title: 'Vid 2', thumbnail: '', playlistIndex: 2 },
-  { id: 'p3', url: 'https://youtube.com/watch?v=p3', title: 'Vid 3', thumbnail: '', playlistIndex: 3 }
+  { id: 'p1', url: 'https://youtube.com/watch?v=p1', title: 'Vid 1', thumbnail: '', playlistIndex: 1, videoId: 'p1' },
+  { id: 'p2', url: 'https://youtube.com/watch?v=p2', title: 'Vid 2', thumbnail: '', playlistIndex: 2, videoId: 'p2' },
+  { id: 'p3', url: 'https://youtube.com/watch?v=p3', title: 'Vid 3', thumbnail: '', playlistIndex: 3, videoId: 'p3' }
 ];
 
 function buildMockApi(settingsOverrides: Record<string, unknown> = {}) {
@@ -69,7 +69,11 @@ function buildMockApi(settingsOverrides: Record<string, unknown> = {}) {
         onRemoved: vi.fn().mockReturnValue(() => undefined)
       }
     },
-    diagnostics: { logWizardStep: vi.fn() }
+    diagnostics: { logWizardStep: vi.fn() },
+    playlist: {
+      scanFolder: vi.fn().mockResolvedValue(ok({ matchedIds: [] as string[] })),
+      registerManifest: vi.fn().mockResolvedValue(ok(undefined))
+    }
   };
 }
 
@@ -189,7 +193,7 @@ describe('playlist regressions', () => {
     expect(useAppStore.getState().selectedPlaylistPreset).toBe('video-1080p');
   });
 
-  it('playlist outputTemplate padding scales with playlist length', async () => {
+  it('playlist outputTemplate is position-independent with id-suffix and byte-safe title', async () => {
     window.appApi = buildMockApi() as never;
 
     useAppStore.setState({
@@ -198,9 +202,9 @@ describe('playlist regressions', () => {
       wizardMode: 'playlist',
       playlistTitle: 'Big Playlist',
       playlistItems: [
-        { id: 'p9', url: 'https://youtube.com/watch?v=p9', title: 'Vid 9', thumbnail: '', playlistIndex: 9 },
-        { id: 'p10', url: 'https://youtube.com/watch?v=p10', title: 'Vid 10', thumbnail: '', playlistIndex: 10 },
-        { id: 'p100', url: 'https://youtube.com/watch?v=p100', title: 'Vid 100', thumbnail: '', playlistIndex: 100 }
+        { id: 'p9', url: 'https://youtube.com/watch?v=p9', title: 'Vid 9', thumbnail: '', playlistIndex: 9, videoId: 'p9' },
+        { id: 'p10', url: 'https://youtube.com/watch?v=p10', title: 'Vid 10', thumbnail: '', playlistIndex: 10, videoId: 'p10' },
+        { id: 'p100', url: 'https://youtube.com/watch?v=p100', title: 'Vid 100', thumbnail: '', playlistIndex: 100, videoId: 'p100' }
       ],
       selectedPlaylistItemIds: ['p9', 'p10', 'p100'],
       selectedPlaylistPreset: 'video-1080p',
@@ -213,6 +217,6 @@ describe('playlist regressions', () => {
 
     const templates = (vi.mocked(window.appApi.queue.cmd.add).mock.calls[0]?.[0] ?? []).map((item) => (item.job.kind === 'playlist-preset' ? item.job.outputTemplate : null));
 
-    expect(templates).toEqual(['009 - %(title)s.%(ext)s', '010 - %(title)s.%(ext)s', '100 - %(title)s.%(ext)s']);
+    expect(templates).toEqual(['%(title).200B [%(id)s].%(ext)s', '%(title).200B [%(id)s].%(ext)s', '%(title).200B [%(id)s].%(ext)s']);
   });
 });

--- a/tests/renderer/probe-orchestrator.test.tsx
+++ b/tests/renderer/probe-orchestrator.test.tsx
@@ -37,8 +37,8 @@ const PLAYLIST_PROBE: Extract<ProbeResult, { kind: 'playlist' }> = {
   playlistId: 'PLtest',
   isMultiVideo: false,
   entries: [
-    { id: 'e1', title: 'Entry 1', url: 'https://youtu.be/e1', thumbnail: '', duration: 60, playlistIndex: 1 },
-    { id: 'e2', title: 'Entry 2', url: 'https://youtu.be/e2', thumbnail: '', duration: 120, playlistIndex: 2 }
+    { id: 'e1', title: 'Entry 1', url: 'https://youtu.be/e1', thumbnail: '', duration: 60, playlistIndex: 1, videoId: 'e1' },
+    { id: 'e2', title: 'Entry 2', url: 'https://youtu.be/e2', thumbnail: '', duration: 120, playlistIndex: 2, videoId: 'e2' }
   ]
 };
 

--- a/tests/renderer/wizard-audio-source.test.tsx
+++ b/tests/renderer/wizard-audio-source.test.tsx
@@ -42,7 +42,7 @@ function buildPlaylistProbe(extractor: string, isAudioOnlySource: boolean): Prob
     isMultiVideo: false,
     playlistId: 'p1',
     playlistTitle: 'Playlist',
-    entries: [{ id: 'e1', url: 'https://example.com/e1', title: 'Entry 1', thumbnail: '', playlistIndex: 1 }]
+    entries: [{ id: 'e1', url: 'https://example.com/e1', title: 'Entry 1', thumbnail: '', playlistIndex: 1, videoId: 'e1' }]
   };
 }
 

--- a/tests/shared/mockAppApi.ts
+++ b/tests/shared/mockAppApi.ts
@@ -141,6 +141,10 @@ export function buildMockAppApi(options: BuildMockOptions = {}): AppApi {
     },
     diagnostics: {
       logWizardStep: vi.fn()
+    },
+    playlist: {
+      scanFolder: vi.fn().mockResolvedValue(ok({ matchedIds: [] as string[] })),
+      registerManifest: vi.fn().mockResolvedValue(ok(undefined))
     }
   };
 }

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -89,6 +89,7 @@ function makeDeps() {
     tokenService: { warmUp: vi.fn() } as never,
     languageRef: languageRef as never,
     clipboardWatcher: clipboardWatcher as never,
+    playlistManifestStore: { save: vi.fn(), get: vi.fn(), remove: vi.fn() } as never,
     _raw: { downloadService, probeService, mainWindow, queueService, settingsStore, languageRef, clipboardWatcher }
   };
 }

--- a/tests/unit/output-template.test.ts
+++ b/tests/unit/output-template.test.ts
@@ -1,0 +1,12 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { playlistOutputTemplate } from '@renderer/store/queueSlice.js';
+
+describe('playlistOutputTemplate', () => {
+  it('is position-independent and id-suffixed with byte truncation', () => {
+    expect(playlistOutputTemplate()).toBe('%(title).200B [%(id)s].%(ext)s');
+  });
+  it('contains no playlist index prefix', () => {
+    expect(playlistOutputTemplate()).not.toMatch(/%\(playlist_index\)|^\d/);
+  });
+});

--- a/tests/unit/playlist-m3u.test.ts
+++ b/tests/unit/playlist-m3u.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { buildM3u } from '@main/services/playlistM3u.js';
+import type { PlaylistManifest } from '@shared/playlistManifest.js';
+
+const manifest: PlaylistManifest = {
+  playlistGroupId: 'g',
+  playlistTitle: 'My List',
+  outputDir: '/dl',
+  items: [
+    { videoId: 'a', title: 'First', duration: 65 },
+    { videoId: 'gone', title: 'Missing', duration: 10 },
+    { videoId: null, title: 'No id' },
+    { videoId: 'b', title: 'Second' }
+  ]
+};
+
+describe('buildM3u', () => {
+  it('writes matched files in playlist order, omitting missing/id-less', () => {
+    const files = ['First [a].mp4', 'Second [b].webm', 'unrelated.txt'];
+    expect(buildM3u(manifest, files)).toBe(['#EXTM3U', '#EXTINF:65,First', 'First [a].mp4', '#EXTINF:-1,Second', 'Second [b].webm', ''].join('\n'));
+  });
+});

--- a/tests/unit/playlist-manifest-store.test.ts
+++ b/tests/unit/playlist-manifest-store.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { PlaylistManifestStore } from '@main/stores/PlaylistManifestStore.js';
+import type { PlaylistManifest } from '@shared/playlistManifest.js';
+
+async function tmpStore(): Promise<PlaylistManifestStore> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pl-manifest-'));
+  return new PlaylistManifestStore(dir);
+}
+
+const m: PlaylistManifest = {
+  playlistGroupId: 'g1',
+  playlistTitle: 'My List',
+  outputDir: '/dl/My List',
+  items: [
+    { videoId: 'a', title: 'A', duration: 10 },
+    { videoId: null, title: 'B' }
+  ]
+};
+
+describe('PlaylistManifestStore', () => {
+  it('round-trips a manifest by group id', async () => {
+    const s = await tmpStore();
+    await s.save(m);
+    expect(s.get('g1')).toEqual(m);
+  });
+  it('returns null for an unknown group', async () => {
+    const s = await tmpStore();
+    expect(s.get('nope')).toBeNull();
+  });
+  it('drops a manifest on remove', async () => {
+    const s = await tmpStore();
+    await s.save(m);
+    await s.remove('g1');
+    expect(s.get('g1')).toBeNull();
+  });
+});

--- a/tests/unit/playlist-scan-folder.test.ts
+++ b/tests/unit/playlist-scan-folder.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment node
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { scanFolderForVideoIds } from '@main/ipc/playlistHandlers.js';
+
+async function tmp(files: string[]): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'scan-'));
+  for (const f of files) await fs.writeFile(path.join(dir, f), 'x');
+  return dir;
+}
+
+describe('scanFolderForVideoIds', () => {
+  it('matches ids wrapped in brackets', async () => {
+    const dir = await tmp(['Rick Astley [dQw4w9WgXcQ].mp4', 'Other [abc123].webm']);
+    expect(await scanFolderForVideoIds(dir, ['dQw4w9WgXcQ', 'zzz'])).toEqual(['dQw4w9WgXcQ']);
+  });
+  it('returns empty for a missing dir', async () => {
+    expect(await scanFolderForVideoIds('/no/such/dir', ['x'])).toEqual([]);
+  });
+  it('does not partial-match across bracket boundaries', async () => {
+    const dir = await tmp(['v [abcd].mp4']);
+    expect(await scanFolderForVideoIds(dir, ['abc'])).toEqual([]);
+  });
+});

--- a/tests/unit/probe-service-videoid.test.ts
+++ b/tests/unit/probe-service-videoid.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { mapPlaylistEntries } from '@main/services/ProbeService.js';
+import type { InfoDict } from '@shared/schemas.js';
+
+describe('mapPlaylistEntries — videoId', () => {
+  it('exposes the raw yt-dlp id as videoId', () => {
+    const entry = { id: 'dQw4w9WgXcQ', title: 'Rick', url: 'https://youtu.be/dQw4w9WgXcQ', playlist_index: 1 } as unknown as InfoDict;
+    const out = mapPlaylistEntries([entry], 'https://youtube.com/playlist?list=x', 'youtube');
+    expect(out[0].videoId).toBe('dQw4w9WgXcQ');
+  });
+
+  it('sets videoId null when the entry has no id', () => {
+    const entry = { title: 'No id', url: 'https://example.com/v/1', playlist_index: 1 } as unknown as InfoDict;
+    const out = mapPlaylistEntries([entry], 'https://example.com/list', 'generic');
+    expect(out[0].videoId).toBeNull();
+  });
+});

--- a/tests/unit/ytdlp-args-paths.test.ts
+++ b/tests/unit/ytdlp-args-paths.test.ts
@@ -68,7 +68,7 @@ describe('YtDlp — --paths temp dir (video)', () => {
     const oIdx = args.indexOf('-o');
     expect(oIdx).toBeGreaterThan(-1);
     expect(args[oIdx + 1]).not.toContain(OUTPUT_DIR);
-    expect(args[oIdx + 1]).toBe('%(title)s.%(ext)s');
+    expect(args[oIdx + 1]).toBe('%(title).200B.%(ext)s');
   });
 
   it('when tempDir is absent: falls back to old -o <outputDir>/%(title)s.%(ext)s', async () => {

--- a/tests/unit/ytdlp-args.test.ts
+++ b/tests/unit/ytdlp-args.test.ts
@@ -135,10 +135,10 @@ describe('YtDlp — outputTemplate', () => {
     expect(args).toContain('--paths');
   });
 
-  it('video kind: omitting outputTemplate keeps default %(title)s.%(ext)s', async () => {
+  it('video kind: omitting outputTemplate keeps default %(title).200B.%(ext)s', async () => {
     await makeYtDlp().run({ kind: 'video', url: URL, outputDir: OUTPUT_DIR });
     const args = getArgs();
-    expect(args[args.indexOf('-o') + 1]).toBe(`${OUTPUT_DIR}/%(title)s.%(ext)s`);
+    expect(args[args.indexOf('-o') + 1]).toBe(`${OUTPUT_DIR}/%(title).200B.%(ext)s`);
   });
 });
 


### PR DESCRIPTION
## Summary

Playlist workflow improvements on top of `main`:

- **Stable filenames** for playlist queue items (consistent output naming across retries)
- **Sync with folder** — scan output directory and mark playlist entries already on disk
- **M3U generation** — manifest + IPC handlers (`PlaylistManifestStore`, `playlistM3u`)
- **Probe preset fix** — always set `selectedPlaylistPreset` after playlist probe (not only on `firstProbe`)

Rebased onto current `main` (network pacing #34, deps/rtk #33). Prior PRs #35/#36 closed due to stale branch history; this PR is the clean 2-commit branch.

## Commits

1. `bug fixing` — `selectedPlaylistPreset` placement in `probeOrchestrator`
2. `feat(playlist)` — stable filenames, sync-with-folder, M3U

## Test plan

- [ ] Probe a YouTube playlist → preset step → items step
- [ ] **Sync with folder** on a dir that already has some downloads
- [ ] Queue several items; confirm stable output names / manifest
- [ ] Verify generated `.m3u` beside playlist output
- [ ] Audio-only playlist host → defaults to `audio-best` preset


Made with [Cursor](https://cursor.com)