### PR TITLE
fix(playlist): apply preset on probe without clobbering retry

### DIFF
--- a/src/renderer/src/store/wizard/probeOrchestrator.ts
+++ b/src/renderer/src/store/wizard/probeOrchestrator.ts
@@ -223,7 +223,8 @@ function applyPlaylistProbeResult(probe: Extract<ProbeResult, { kind: 'playlist'
   // to `audio-best` — the user came to a music host, video presets would be
   // wrong (and yt-dlp would reject a video preset for audio-only entries).
   const persistedPreset = settings?.playlist?.lastPlaylistPreset ?? 'video-best';
-  const selectedPlaylistPreset: PlaylistPreset | null = probe.isAudioOnlySource ? 'audio-best' : persistedPreset;
+  const computedPreset: PlaylistPreset | null = probe.isAudioOnlySource ? 'audio-best' : persistedPreset;
+  const selectedPlaylistPreset = firstProbe ? computedPreset : (get().selectedPlaylistPreset ?? computedPreset);
   set({
     wizardStep: 'playlistItems',
     wizardMode: 'playlist',
@@ -243,10 +244,10 @@ function applyPlaylistProbeResult(probe: Extract<ProbeResult, { kind: 'playlist'
       ? {
           ...restoreCommonWizardPrefs(settings),
           wizardSubfolderEnabled: settings?.common?.lastSubfolderEnabled ?? false,
-          wizardSubfolderName: settings?.common?.lastSubfolder ?? '',
-          selectedPlaylistPreset
+          wizardSubfolderName: settings?.common?.lastSubfolder ?? ''
         }
-      : {})
+      : {}),
+    selectedPlaylistPreset
   });
 }
 

--- a/src/renderer/src/store/wizard/probeOrchestrator.ts
+++ b/src/renderer/src/store/wizard/probeOrchestrator.ts
@@ -223,7 +223,7 @@ function applyPlaylistProbeResult(probe: Extract<ProbeResult, { kind: 'playlist'
   // to `audio-best` — the user came to a music host, video presets would be
   // wrong (and yt-dlp would reject a video preset for audio-only entries).
   const persistedPreset = settings?.playlist?.lastPlaylistPreset ?? 'video-best';
-  const computedPreset: PlaylistPreset | null = probe.isAudioOnlySource ? 'audio-best' : persistedPreset;
+  const computedPreset: PlaylistPreset = probe.isAudioOnlySource ? 'audio-best' : persistedPreset;
   const selectedPlaylistPreset = firstProbe ? computedPreset : (get().selectedPlaylistPreset ?? computedPreset);
   set({
     wizardStep: 'playlistItems',


### PR DESCRIPTION
## Summary

Fixes playlist preset handling in `applyPlaylistProbeResult` (supersedes the partial change from closed PR #37 commit `b29daa7`).

- Always write `selectedPlaylistPreset` after a playlist probe (not only inside the `firstProbe` settings spread).
- On format **retry** (`firstProbe: false`), preserve a manually chosen preset instead of resetting to `lastPlaylistPreset` from settings.

## Test plan

- [x] `playlist-regressions` — manual preset preserved on `retryFormatProbe`
- [x] `probe-orchestrator` tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## User-Facing Changes
- Playlist preset is applied immediately after a playlist probe (applies on the initial probe step).
- On format retries (retryFormatProbe / firstProbe: false), a manually selected playlist preset is preserved instead of being reset to the persisted lastPlaylistPreset.

## Internal / Refactor Changes
- File changed: src/renderer/src/store/wizard/probeOrchestrator.ts — applyPlaylistProbeResult
  - Introduces a computedPreset (uses "audio-best" for audio-only sources; otherwise uses persisted lastPlaylistPreset).
  - selectedPlaylistPreset logic: on firstProbe use computedPreset; on retries prefer the existing selectedPlaylistPreset from state (falling back to computedPreset).
  - selectedPlaylistPreset is now always written in the state.set(...) payload during playlist probe updates; other persisted settings (shared prefs like subfolder/embed fields) remain gated by firstProbe.
- Small, targeted change (+5/-4 lines) focused on state assignment in the renderer store.

## Risk Areas
- Electron security: none introduced — change is confined to renderer state handling and does not add native APIs or permissions.
- IPC boundaries: unchanged — no new or modified IPC messages.
- Build / dependencies: none — no dependency or build-system changes.
- Behavioral risk: moderate — this changes previous behavior by preserving manual presets on retries; verify this matches UX expectations since workflows that relied on automatic reset to persisted preset will change.

## Tests / Checks to Run
- Automated: run probe-orchestrator unit tests (vitest) that cover playlist probe flow and step transitions.
- Manual:
  - Start a playlist probe (first probe) and confirm selectedPlaylistPreset is applied immediately.
  - Manually change preset, trigger a format retry (retryFormatProbe / firstProbe: false) and confirm the manual preset is preserved (not reset to persisted lastPlaylistPreset).
  - Run the playlist-regressions checklist to ensure no regressions in playlist handling and preset application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/antonio-orionus/Arroxy/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->