### PR TITLE
Ignore SponsorBlock API outages during downloads

### DIFF
--- a/src/main/services/phases/VideoPhase.ts
+++ b/src/main/services/phases/VideoPhase.ts
@@ -2,7 +2,7 @@ import { mkdir, rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { STATUS_KEY } from '@shared/schemas.js';
 import { siteForExtractor } from '@shared/sites/index.js';
-import type { YtDlpRequest } from '../YtDlp.js';
+import type { YtDlpRequest, YtDlpResult } from '../YtDlp.js';
 import { classifyYtDlpFailure } from '../download/errorClassification.js';
 import { cleanupPartFiles, cleanupTempDirByPath } from '../download/cleanup.js';
 import type { Phase, PhaseContext, PhaseOutcome } from './types.js';
@@ -28,6 +28,12 @@ async function detectCachedInfoJson(tempDir: string | undefined): Promise<string
   } catch {
     return undefined;
   }
+}
+
+function isSkippableSponsorBlockApiFailure(result: Exclude<YtDlpResult, { kind: 'success' }>, req: YtDlpRequest): boolean {
+  if (result.kind !== 'exit-error') return false;
+  if (!('sponsorBlock' in req) || req.sponsorBlock === undefined || req.sponsorBlock.categories.length === 0) return false;
+  return /Unable to communicate with SponsorBlock API/i.test([result.rawError, result.stderr].filter(Boolean).join('\n'));
 }
 
 export function VideoPhase(embed: boolean): Phase {
@@ -134,6 +140,9 @@ export function VideoPhase(embed: boolean): Phase {
       if (active.cancelRequested) return { kind: 'cancelled' };
 
       if (result.kind !== 'success') {
+        if (isSkippableSponsorBlockApiFailure(result, req)) {
+          return { kind: 'continue' };
+        }
         const { payload, statusKey, params } = await classifyYtDlpFailure(result, job.outputDir, job.id);
         ctx.emitStatus('error', statusKey, params, payload);
         return { kind: 'hard-failed', error: payload };

--- a/tests/unit/video-phase.test.ts
+++ b/tests/unit/video-phase.test.ts
@@ -97,6 +97,14 @@ const EXIT_ERROR: YtDlpResult = {
   stdout: '',
   stderr: ''
 };
+const SPONSORBLOCK_API_ERROR: YtDlpResult = {
+  kind: 'exit-error',
+  exitCode: 1,
+  errorKind: 'unknown',
+  rawError: 'ERROR: Preprocessing: Unable to communicate with SponsorBlock API: HTTP Error 503: Service Unavailable',
+  stdout: '',
+  stderr: 'ERROR: Preprocessing: Unable to communicate with SponsorBlock API: HTTP Error 503: Service Unavailable'
+};
 
 describe('VideoPhase(embed=false)', () => {
   it('calls ytDlp.run with kind: video', async () => {
@@ -136,6 +144,25 @@ describe('VideoPhase(embed=false)', () => {
     expect(outcome.kind).toBe('hard-failed');
     if (outcome.kind === 'hard-failed') expect(outcome.error.kind).toBe('botBlock');
     expect(vi.mocked(ctx.emitStatus)).toHaveBeenCalledWith('error', expect.any(String), expect.any(Object), expect.objectContaining({ kind: 'botBlock' }));
+  });
+
+  it('SponsorBlock API failure → continues without failing the downloaded media', async () => {
+    const ctx = makeCtx(SPONSORBLOCK_API_ERROR, {
+      input: {
+        ...BASE_INPUT,
+        job: {
+          ...BASE_JOB,
+          sponsorBlock: { mode: 'mark', categories: ['sponsor'] }
+        }
+      }
+    });
+
+    const outcome = await VideoPhase(false).run(ctx);
+
+    expect(outcome.kind).toBe('continue');
+    expect(ctx.runMock).toHaveBeenCalledTimes(1);
+    expect(ctx.runMock.mock.calls[0][0].sponsorBlock).toEqual({ mode: 'mark', categories: ['sponsor'] });
+    expect(ctx.emitStatus).not.toHaveBeenCalledWith('error', expect.any(String), expect.any(Object), expect.any(Object));
   });
 });
 

--- a/tests/unit/video-phase.test.ts
+++ b/tests/unit/video-phase.test.ts
@@ -164,6 +164,54 @@ describe('VideoPhase(embed=false)', () => {
     expect(ctx.runMock.mock.calls[0][0].sponsorBlock).toEqual({ mode: 'mark', categories: ['sponsor'] });
     expect(ctx.emitStatus).not.toHaveBeenCalledWith('error', expect.any(String), expect.any(Object), expect.any(Object));
   });
+
+  it('SponsorBlock API failure with mode=off → hard-fails', async () => {
+    const ctx = makeCtx(SPONSORBLOCK_API_ERROR);
+
+    const outcome = await VideoPhase(false).run(ctx);
+
+    expect(outcome.kind).toBe('hard-failed');
+    expect(ctx.runMock.mock.calls[0][0].sponsorBlock).toBeUndefined();
+    expect(ctx.emitStatus).toHaveBeenCalledWith('error', expect.any(String), expect.any(Object), expect.any(Object));
+  });
+
+  it('SponsorBlock API failure with empty categories → hard-fails', async () => {
+    const ctx = makeCtx(SPONSORBLOCK_API_ERROR, {
+      input: {
+        ...BASE_INPUT,
+        job: {
+          ...BASE_JOB,
+          sponsorBlock: { mode: 'mark', categories: [] }
+        }
+      }
+    });
+
+    const outcome = await VideoPhase(false).run(ctx);
+
+    expect(outcome.kind).toBe('hard-failed');
+    expect(ctx.runMock.mock.calls[0][0].sponsorBlock).toEqual({ mode: 'mark', categories: [] });
+    expect(ctx.emitStatus).toHaveBeenCalledWith('error', expect.any(String), expect.any(Object), expect.any(Object));
+  });
+
+  it('SponsorBlock API failure on a site without SponsorBlock support → hard-fails', async () => {
+    const ctx = makeCtx(SPONSORBLOCK_API_ERROR, {
+      input: {
+        ...BASE_INPUT,
+        job: {
+          ...BASE_JOB,
+          extractor: 'Vimeo',
+          extractorKey: 'Vimeo',
+          sponsorBlock: { mode: 'mark', categories: ['sponsor'] }
+        }
+      }
+    });
+
+    const outcome = await VideoPhase(false).run(ctx);
+
+    expect(outcome.kind).toBe('hard-failed');
+    expect(ctx.runMock.mock.calls[0][0].sponsorBlock).toBeUndefined();
+    expect(ctx.emitStatus).toHaveBeenCalledWith('error', expect.any(String), expect.any(Object), expect.any(Object));
+  });
 });
 
 describe('VideoPhase(embed=true)', () => {


### PR DESCRIPTION
## Summary
- Treat SponsorBlock API communication failures as non-fatal when yt-dlp already continued the media download
- Add a VideoPhase regression test for the 503 preprocessing failure shape

## Verification
- bunx vitest run --project node tests/unit/video-phase.test.ts
- bun run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## User-facing changes
Downloads will no longer fail when the SponsorBlock API is unreachable (e.g., HTTP 503) if yt-dlp has already started processing the media. In those cases the download continues instead of surfacing an error to the user.

## Internal/refactor changes
- Add isSkippableSponsorBlockApiFailure predicate in VideoPhase to detect a specific yt-dlp non-success shape that contains SponsorBlock API communication failures and where SponsorBlock was configured with non-empty categories.
- Adjust VideoPhase non-success handling to return { kind: 'continue' } for that predicate instead of classifying the run as an error.
- Update VideoPhase type imports to include YtDlpRequest and YtDlpResult.
- Add unit tests (tests/unit/video-phase.test.ts) that cover SponsorBlock skip-gating behavior and the 503 preprocessing failure regression.

## Risk areas
- Error-handling scope: ensure the predicate only suppresses SponsorBlock API communication failures and does not accidentally silence other yt-dlp failures.
- Behavioral surface: downloads that would previously surface SponsorBlock preprocessing errors will now continue; confirm this aligns with desired UX and logging/telemetry policies.
- Build/release: no dependency changes indicated, but verify CI/type checks pass (bun run check).
- Electron/security/IPC: no direct changes to Electron APIs or IPC boundaries in this PR, but confirm that suppressed errors are still logged/reported where necessary so diagnostics remain available across renderer/main IPC boundaries and any crash-reporting integration.
- Tests: regression coverage focuses on the SponsorBlock 503 preprocessing shape; consider adding integration/real-world tests if SponsorBlock behavior varies across extractors.

## Tests or checks to run
- bunx vitest run --project node tests/unit/video-phase.test.ts
- bun run check
<!-- end of auto-generated comment: release notes by coderabbit.ai -->