### PR TITLE
Fix mac x64 ffmpeg packaging

### DIFF
--- a/build/beforeBuild.mjs
+++ b/build/beforeBuild.mjs
@@ -3,23 +3,43 @@
 // build/embedded/<platform>-<arch>/{ffmpeg, ffprobe}[.exe] before the
 // extraResources copy step packs them into the artifact.
 import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 
 // electron-builder Arch enum: 0=ia32, 1=x64, 2=armv7l, 3=arm64
 const ARCH_NAMES = ['ia32', 'x64', 'armv7l', 'arm64'];
+const ARCH_NAME_SET = new Set(ARCH_NAMES);
+
+export function resolveBuilderArch(contextArch, hostArch = process.arch) {
+  if (typeof contextArch === 'string' && ARCH_NAME_SET.has(contextArch)) {
+    return contextArch;
+  }
+  if (typeof contextArch === 'number' && ARCH_NAMES[contextArch]) {
+    return ARCH_NAMES[contextArch];
+  }
+  return hostArch === 'arm64' ? 'arm64' : 'x64';
+}
+
+function assertEmbeddedPair(cwd, platform, archName) {
+  const ext = platform === 'win32' ? '.exe' : '';
+  const base = path.join(cwd, 'build', 'embedded', `${platform}-${archName}`);
+  for (const bin of ['ffmpeg', 'ffprobe']) {
+    const filePath = path.join(base, `${bin}${ext}`);
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`[beforeBuild] missing embedded ${bin} for ${platform}-${archName}: ${filePath}`);
+    }
+  }
+}
 
 export default async function beforeBuild(context) {
   const platform = context.platform.nodeName; // 'win32' | 'darwin' | 'linux'
-  // context.arch reflects the host arch in cross-compile scenarios (e.g. --arm64
-  // flag on an x64 runner) rather than the target arch. Log the raw value so
-  // mismatches are visible. The dist:mac:*:dir scripts pre-fetch the correct
-  // arch explicitly, so this hook is the fallback for non-dir builds.
-  const archName = ARCH_NAMES[context.arch] ?? (process.arch === 'arm64' ? 'arm64' : 'x64');
+  const archName = resolveBuilderArch(context.arch);
   console.log(`[beforeBuild] context.arch=${context.arch} → ${archName} (host=${process.arch})`);
   const cwd = context.appDir ?? process.cwd();
   const script = path.join(cwd, 'scripts', 'build', 'fetch-embedded.sh');
   console.log(`[beforeBuild] fetch ffmpeg/ffprobe for ${platform}-${archName} (context.arch=${context.arch}, host=${process.arch})`);
   execFileSync('bash', [script, platform, archName], { stdio: 'inherit', cwd });
+  assertEmbeddedPair(cwd, platform, archName);
   // Returning falsy here makes electron-builder treat node_modules as
   // "handled externally" and skip the prod-deps install/copy entirely
   // (app-builder-lib/out/packager.js — _nodeModulesHandledExternally),

--- a/tests/unit/before-build-arch.test.ts
+++ b/tests/unit/before-build-arch.test.ts
@@ -14,12 +14,23 @@ describe('beforeBuild arch resolution', () => {
 
     expect(resolveBuilderArch('x64', 'arm64')).toBe('x64');
     expect(resolveBuilderArch('arm64', 'x64')).toBe('arm64');
+    expect(resolveBuilderArch('ia32', 'x64')).toBe('ia32');
+    expect(resolveBuilderArch('armv7l', 'arm64')).toBe('armv7l');
   });
 
   it('keeps compatibility with numeric electron-builder arch enum values', async () => {
     const { resolveBuilderArch } = await loadBeforeBuild();
 
+    // electron-builder Arch enum: 1=x64, 3=arm64
     expect(resolveBuilderArch(1, 'arm64')).toBe('x64');
     expect(resolveBuilderArch(3, 'x64')).toBe('arm64');
+  });
+
+  it('falls back to the host architecture when context.arch is absent or unsupported', async () => {
+    const { resolveBuilderArch } = await loadBeforeBuild();
+
+    expect(resolveBuilderArch(undefined, 'x64')).toBe('x64');
+    expect(resolveBuilderArch(null, 'arm64')).toBe('arm64');
+    expect(resolveBuilderArch('unsupported', 'arm64')).toBe('arm64');
   });
 });

--- a/tests/unit/before-build-arch.test.ts
+++ b/tests/unit/before-build-arch.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+interface BeforeBuildModule {
+  resolveBuilderArch: (contextArch: unknown, hostArch: NodeJS.Architecture) => 'x64' | 'arm64' | 'ia32' | 'armv7l';
+}
+
+async function loadBeforeBuild(): Promise<BeforeBuildModule> {
+  return (await import(new URL('../../build/beforeBuild.mjs', import.meta.url).href)) as BeforeBuildModule;
+}
+
+describe('beforeBuild arch resolution', () => {
+  it('uses string context.arch values from electron-builder instead of falling back to host arch', async () => {
+    const { resolveBuilderArch } = await loadBeforeBuild();
+
+    expect(resolveBuilderArch('x64', 'arm64')).toBe('x64');
+    expect(resolveBuilderArch('arm64', 'x64')).toBe('arm64');
+  });
+
+  it('keeps compatibility with numeric electron-builder arch enum values', async () => {
+    const { resolveBuilderArch } = await loadBeforeBuild();
+
+    expect(resolveBuilderArch(1, 'arm64')).toBe('x64');
+    expect(resolveBuilderArch(3, 'x64')).toBe('arm64');
+  });
+});


### PR DESCRIPTION
## Summary

Fix the macOS x64 release packaging path so `beforeBuild` fetches the target architecture, not the arm64 runner host architecture. The build now fails if embedded `ffmpeg` or `ffprobe` are missing after the fetch step.

## Base branch

- [x] This PR targets `dev`, or it is a maintainer release-candidate PR targeting `main`.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [x] Build / CI / tooling
- [ ] Docs

## Checks

Run from the repo root and confirm clean:

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run knip`
- [x] `bun run test` (if your change touches code under test)

## Testing

- `bunx vitest run --project node tests/unit/before-build-arch.test.ts`
- `bun run check`

## Notes for the reviewer

Root cause: the mac release job ran on an arm64 runner. `electron-builder` passed `context.arch=x64` for the Intel target, but `beforeBuild` treated `context.arch` as a numeric enum and fell back to the host arch. That fetched `darwin-arm64` twice, leaving `build/embedded/darwin-x64` absent while electron-builder still published the x64 DMG.

The fix supports both current string arch values and older numeric enum values, then verifies the expected embedded pair exists before packaging can continue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-facing changes

Fixes incorrect FFmpeg packaging for macOS x64 builds. Previously, when the build ran on an arm64 runner, electron-builder would set `context.arch="x64"` for Intel targets, but the build system treated this as a numeric enum and defaulted to host architecture (arm64), causing darwin-arm64 artifacts to be fetched instead of darwin-x64. This resulted in missing x64 binaries while the x64 DMG was still published.

## Internal/refactor changes

**build/beforeBuild.mjs:**
- Added `resolveBuilderArch(contextArch, hostArch)` helper function that properly handles both string architecture values (e.g., `"x64"`, `"arm64"`) and legacy numeric enum values (1→`x64`, 3→`arm64`)
- Added `assertEmbeddedPair()` validation to verify that expected `build/embedded/<platform>-<arch>/ffmpeg` and `ffprobe` binaries exist after fetching, with proper error reporting
- Updated `beforeBuild` hook to use the new arch resolution and validation logic
- Added `node:fs` import

**tests/unit/before-build-arch.test.ts (new file):**
- Vitest suite testing `resolveBuilderArch` behavior with string and numeric arch inputs
- Verifies fallback to host architecture when context arch is absent or unsupported
- Tests compatibility with both current and legacy electron-builder behavior

## Risk areas

- **Build/release behavior:** Changes critical macOS packaging logic. Incorrect arch resolution could result in mismatched binaries for x64 or arm64 targets.
- **Binary verification:** New `assertEmbeddedPair()` validation adds a hard requirement that embedded FFmpeg binaries exist; missing artifacts will now fail the build rather than silently proceeding.

## Tests

Run the unit tests for architecture resolution:
```
bunx vitest run --project node tests/unit/before-build-arch.test.ts
```

Project checks:
```
bun run check
```
(includes lint, typecheck, knip, and test tasks)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->