### PR TITLE
Improve browser mock happy paths

### DIFF
--- a/src/renderer/src/browserMock.ts
+++ b/src/renderer/src/browserMock.ts
@@ -1,7 +1,7 @@
 import type { AppApi } from '@shared/api.js';
 import type { AppSettings, DependencyDiagnostic, DependencyId, ProgressEvent, QueueItem, StatusEvent, UpdateAvailablePayload, WarmUpOutput, WarmupProgressEvent } from '@shared/types.js';
 import { QUEUE_STATUS, STATUS_KEY } from '@shared/schemas.js';
-import { buildScenarioAppApiState, getScenario, readScenarioIdFromUrl, readUrlParams, type BrowserMockScenario } from './dev/browserMockScenarios.js';
+import { buildScenarioAppApiState, getScenario, normalVideoProbe, playlistProbe, readScenarioIdFromUrl, readUrlParams, type BrowserMockScenario } from './dev/browserMockScenarios.js';
 import { applyThemeLive, readKnobs, RTL_LANGS } from './dev/browserMockKnobs.js';
 
 const BROWSER_MOCK_LAUNCH_MODES = ['ready', 'cold-loading', 'cold-error'] as const;
@@ -320,28 +320,9 @@ export function installBrowserMock(): void {
               return 12;
             }
           })();
-          const entries = Array.from({ length: itemCount }, (_, i) => ({
-            id: `mock${i + 1}`,
-            url: `https://www.youtube.com/watch?v=mock${i + 1}`,
-            title: `Mock playlist item ${i + 1} — ${i % 3 === 0 ? 'a longer title that should ellipsize gracefully when the row is narrow' : 'short title'}`,
-            thumbnail: i % 5 === 0 ? '' : 'https://i.ytimg.com/vi/jfKfPfyJRdk/mqdefault.jpg',
-            duration: 90 + i * 47,
-            playlistIndex: i + 1,
-            videoId: `mockid${i + 1}`
-          }));
           return {
             ok: true,
-            data: {
-              kind: 'playlist',
-              extractor: 'youtube:tab',
-              extractorKey: 'YoutubeTab',
-              webpageUrl: input.url,
-              isAudioOnlySource: false,
-              isMultiVideo: false,
-              playlistId: 'PLmock_browser',
-              playlistTitle: 'Mock Browser Playlist',
-              entries
-            }
+            data: playlistProbe(itemCount, { webpageUrl: input.url })
           };
         }
 
@@ -370,152 +351,10 @@ export function installBrowserMock(): void {
 
         return {
           ok: true,
-          data: {
-            kind: 'video',
-            extractor: 'youtube',
-            extractorKey: 'Youtube',
+          data: normalVideoProbe({
             webpageUrl: input.url,
-            isAudioOnlySource: false,
-            isLive: false,
-            hasDrm: false,
-            duration: 60 * 60 * 24,
-            title: 'Mock Video — Lo-fi Hip Hop Radio 24/7',
-            thumbnail: 'https://i.ytimg.com/vi/jfKfPfyJRdk/hqdefault.jpg',
-            ...(simulateBotWall ? { degraded: { reasons: ['botWall' as const] } } : {}),
-            formats: [
-              {
-                formatId: '313',
-                label: '2160p | webm | 30fps | 2.2 GB',
-                ext: 'webm',
-                resolution: '2160p',
-                fps: 30,
-                filesize: 2_400_000_000,
-                isVideoOnly: true,
-                isAudioOnly: false
-              },
-              {
-                formatId: '271',
-                label: '1440p | webm | 30fps | 906.2 MB',
-                ext: 'webm',
-                resolution: '1440p',
-                fps: 30,
-                filesize: 950_000_000,
-                isVideoOnly: true,
-                isAudioOnly: false
-              },
-              {
-                formatId: '137',
-                label: '1080p | mp4 | 30fps | 515.0 MB',
-                ext: 'mp4',
-                resolution: '1080p',
-                fps: 30,
-                filesize: 540_000_000,
-                isVideoOnly: true,
-                isAudioOnly: false
-              },
-              {
-                formatId: '248',
-                label: '1080p | webm | 30fps | 400.5 MB',
-                ext: 'webm',
-                resolution: '1080p',
-                fps: 30,
-                filesize: 420_000_000,
-                isVideoOnly: true,
-                isAudioOnly: false
-              },
-              {
-                formatId: '136',
-                label: '720p | mp4 | 30fps | 209.8 MB',
-                ext: 'mp4',
-                resolution: '720p',
-                fps: 30,
-                filesize: 220_000_000,
-                isVideoOnly: true,
-                isAudioOnly: false
-              },
-              {
-                formatId: '247',
-                label: '720p | webm | 30fps | 171.7 MB',
-                ext: 'webm',
-                resolution: '720p',
-                fps: 30,
-                filesize: 180_000_000,
-                isVideoOnly: true,
-                isAudioOnly: false
-              },
-              {
-                formatId: '135',
-                label: '480p | mp4 | 30fps | 104.9 MB',
-                ext: 'mp4',
-                resolution: '480p',
-                fps: 30,
-                filesize: 110_000_000,
-                isVideoOnly: true,
-                isAudioOnly: false
-              },
-              {
-                formatId: '134',
-                label: '360p | mp4 | 30fps | 62.0 MB',
-                ext: 'mp4',
-                resolution: '360p',
-                fps: 30,
-                filesize: 65_000_000,
-                isVideoOnly: true,
-                isAudioOnly: false
-              },
-              {
-                formatId: '251',
-                label: 'webm · Opus · 132 kbps · 5.0 MB',
-                ext: 'webm',
-                resolution: 'audio only',
-                abr: 132,
-                filesize: 5_200_000,
-                isVideoOnly: false,
-                isAudioOnly: true
-              },
-              {
-                formatId: '140',
-                label: 'm4a · AAC · 129 kbps · 4.8 MB',
-                ext: 'm4a',
-                resolution: 'audio only',
-                abr: 129,
-                filesize: 5_000_000,
-                isVideoOnly: false,
-                isAudioOnly: true
-              },
-              {
-                formatId: '249',
-                label: 'webm · Opus · 50 kbps · 2.0 MB',
-                ext: 'webm',
-                resolution: 'audio only',
-                abr: 50,
-                filesize: 2_000_000,
-                isVideoOnly: false,
-                isAudioOnly: true
-              },
-              {
-                formatId: '139',
-                label: 'm4a · AAC · 48 kbps · 1.8 MB',
-                ext: 'm4a',
-                resolution: 'audio only',
-                abr: 48,
-                filesize: 1_900_000,
-                isVideoOnly: false,
-                isAudioOnly: true
-              }
-            ],
-            subtitles: {
-              en: [{ ext: 'vtt', name: 'English' }],
-              es: [{ ext: 'vtt', name: 'Español' }]
-            },
-            // Note: in real yt-dlp output, `automatic_captions` includes BOTH the actual
-            // generated track (key ends with `-orig`) AND many on-demand translation
-            // options (e.g. `hy`, `eu`). ProbeService filters the latter for YouTube — the
-            // mock simulates post-filter state, so only `-orig` entries are present here.
-            automaticCaptions: {
-              'en-orig': [{ ext: 'vtt', name: 'English (auto)' }]
-            }
-          }
+            degraded: simulateBotWall ? { reasons: ['botWall' as const] } : undefined
+          })
         };
       },
 

--- a/src/renderer/src/dev/ScenarioGallery.tsx
+++ b/src/renderer/src/dev/ScenarioGallery.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from 'rea
 import { ChevronDown, RotateCcw, TestTube2 } from 'lucide-react';
 import { SUPPORTED_LANGS, YT_DLP_ERROR_KINDS } from '@shared/schemas.js';
 import type { SupportedLang, YtDlpErrorKind } from '@shared/schemas.js';
-import { BROWSER_MOCK_SCENARIOS, getScenario, isHappyPathScenario, mockStepForScenario, PLAYLIST_NORMAL_MOCK_STEPS, readScenarioIdFromUrl, readUrlParams, SINGLE_NORMAL_MOCK_STEPS, type BrowserMockScenario, type BrowserMockScenarioGroup, type BrowserMockStep } from './browserMockScenarios.js';
+import { BROWSER_MOCK_SCENARIOS, getScenario, isHappyPathScenario, mockStepForScenario, mockStepsForScenario, readScenarioIdFromUrl, readUrlParams, type BrowserMockScenario, type BrowserMockScenarioGroup, type BrowserMockStep } from './browserMockScenarios.js';
 import { applyThemeLive, knobUrl, MOCK_PLATFORM_LABELS, MOCK_PLATFORMS, readKnobs, type MockPlatform } from './browserMockKnobs.js';
 import type { UiTheme } from '@shared/schemas.js';
 import { cn } from '../lib/utils.js';
@@ -92,9 +92,7 @@ function applyMockStep(scenario: BrowserMockScenario, step: BrowserMockStep | nu
 }
 
 function mockStepOptions(scenario: BrowserMockScenario): readonly BrowserMockStep[] {
-  if (scenario.id === 'single-normal') return SINGLE_NORMAL_MOCK_STEPS;
-  if (scenario.id === 'playlist-normal') return PLAYLIST_NORMAL_MOCK_STEPS;
-  return [];
+  return mockStepsForScenario(scenario);
 }
 
 function applyKnob(updates: { theme?: UiTheme | null; locale?: SupportedLang | null; platform?: MockPlatform | null }): void {

--- a/src/renderer/src/dev/ScenarioGallery.tsx
+++ b/src/renderer/src/dev/ScenarioGallery.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from 'rea
 import { ChevronDown, RotateCcw, TestTube2 } from 'lucide-react';
 import { SUPPORTED_LANGS, YT_DLP_ERROR_KINDS } from '@shared/schemas.js';
 import type { SupportedLang, YtDlpErrorKind } from '@shared/schemas.js';
-import { BROWSER_MOCK_SCENARIOS, getScenario, readScenarioIdFromUrl, readUrlParams, type BrowserMockScenario, type BrowserMockScenarioGroup } from './browserMockScenarios.js';
+import { BROWSER_MOCK_SCENARIOS, getScenario, isHappyPathScenario, mockStepForScenario, PLAYLIST_NORMAL_MOCK_STEPS, readScenarioIdFromUrl, readUrlParams, SINGLE_NORMAL_MOCK_STEPS, type BrowserMockScenario, type BrowserMockScenarioGroup, type BrowserMockStep } from './browserMockScenarios.js';
 import { applyThemeLive, knobUrl, MOCK_PLATFORM_LABELS, MOCK_PLATFORMS, readKnobs, type MockPlatform } from './browserMockKnobs.js';
 import type { UiTheme } from '@shared/schemas.js';
 import { cn } from '../lib/utils.js';
@@ -24,7 +24,7 @@ function activeUrlParams(): ReturnType<typeof readUrlParams> {
   try {
     return readUrlParams(window.location);
   } catch {
-    return { playlistCount: null, probeErrorKind: null };
+    return { playlistCount: null, probeErrorKind: null, mockStep: null };
   }
 }
 
@@ -40,6 +40,7 @@ function scenarioUrl(id: BrowserMockScenario['id']): string {
   const url = new URL(window.location.href);
   url.searchParams.delete('playlist');
   url.searchParams.delete('probeError');
+  url.searchParams.delete('mockStep');
   if (id === 'default') url.searchParams.delete('scenario');
   else url.searchParams.set('scenario', id);
   return `${url.pathname}${url.search}${url.hash}`;
@@ -49,6 +50,7 @@ function playlistParamUrl(count: number): string {
   const url = new URL(window.location.href);
   url.searchParams.delete('scenario');
   url.searchParams.delete('probeError');
+  url.searchParams.delete('mockStep');
   url.searchParams.set('playlist', String(count));
   return `${url.pathname}${url.search}${url.hash}`;
 }
@@ -57,8 +59,19 @@ function probeErrorParamUrl(kind: YtDlpErrorKind | null): string {
   const url = new URL(window.location.href);
   url.searchParams.delete('scenario');
   url.searchParams.delete('playlist');
+  url.searchParams.delete('mockStep');
   if (kind === null) url.searchParams.delete('probeError');
   else url.searchParams.set('probeError', kind);
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+function mockStepUrl(scenario: BrowserMockScenario, step: BrowserMockStep | null): string {
+  const url = new URL(window.location.href);
+  url.searchParams.delete('playlist');
+  url.searchParams.delete('probeError');
+  url.searchParams.set('scenario', scenario.id);
+  if (step === null) url.searchParams.delete('mockStep');
+  else url.searchParams.set('mockStep', step);
   return `${url.pathname}${url.search}${url.hash}`;
 }
 
@@ -72,6 +85,16 @@ function applyPlaylistCount(count: number): void {
 
 function applyProbeErrorKind(kind: YtDlpErrorKind | null): void {
   window.location.assign(probeErrorParamUrl(kind));
+}
+
+function applyMockStep(scenario: BrowserMockScenario, step: BrowserMockStep | null): void {
+  window.location.assign(mockStepUrl(scenario, step));
+}
+
+function mockStepOptions(scenario: BrowserMockScenario): readonly BrowserMockStep[] {
+  if (scenario.id === 'single-normal') return SINGLE_NORMAL_MOCK_STEPS;
+  if (scenario.id === 'playlist-normal') return PLAYLIST_NORMAL_MOCK_STEPS;
+  return [];
 }
 
 function applyKnob(updates: { theme?: UiTheme | null; locale?: SupportedLang | null; platform?: MockPlatform | null }): void {
@@ -106,14 +129,18 @@ export function ScenarioGallery(): JSX.Element {
   );
 
   useEffect(() => {
-    if (!initialized || autoAppliedRef.current === scenario.id) return;
-    autoAppliedRef.current = scenario.id;
+    const applyKey = `${scenario.id}:${urlParams.playlistCount ?? ''}:${urlParams.probeErrorKind ?? ''}:${urlParams.mockStep ?? ''}`;
+    if (!initialized || autoAppliedRef.current === applyKey) return;
+    autoAppliedRef.current = applyKey;
     const store = useAppStore.getState();
 
-    if (scenario.kind === 'probe') {
+    if (scenario.kind === 'probe' || urlParams.playlistCount !== null || urlParams.probeErrorKind !== null) {
       store.reset();
       store.setWizardUrl(`https://example.com/${scenario.id}`);
-      void store.submitUrl();
+      void store.submitUrl().then(() => {
+        const targetStep = mockStepForScenario(scenario, urlParams.mockStep);
+        if (targetStep !== null) useAppStore.setState({ wizardStep: targetStep });
+      });
     } else if (scenario.kind === 'dialog') {
       if (scenario.id === 'dialog-mixed-url') {
         useAppStore.setState({
@@ -124,10 +151,13 @@ export function ScenarioGallery(): JSX.Element {
         useAppStore.setState({ cookiesConfigDialogIssue: 'file-missing-path' });
       }
     }
-  }, [initialized, scenario.id, scenario.kind]);
+  }, [initialized, scenario, scenario.id, scenario.kind, urlParams.mockStep, urlParams.playlistCount, urlParams.probeErrorKind]);
 
   const isPlaylistParam = urlParams.playlistCount !== null;
   const isProbeErrorParam = urlParams.probeErrorKind !== null;
+  const currentMockStep = mockStepForScenario(scenario, urlParams.mockStep);
+  const showMockStepPicker = isHappyPathScenario(scenario) && !isPlaylistParam && !isProbeErrorParam;
+  const availableMockSteps = mockStepOptions(scenario);
 
   function activeLabel(): string {
     if (isPlaylistParam) return `Playlist ×${urlParams.playlistCount}`;
@@ -138,6 +168,7 @@ export function ScenarioGallery(): JSX.Element {
   function activeDescription(): string {
     if (isPlaylistParam) return `Playlist probe with ${urlParams.playlistCount} entries.`;
     if (isProbeErrorParam) return `Probe error: ${urlParams.probeErrorKind ?? ''}.`;
+    if (currentMockStep !== null) return `${scenario.description} Opens directly to ${currentMockStep}.`;
     return scenario.description;
   }
 
@@ -228,6 +259,32 @@ export function ScenarioGallery(): JSX.Element {
                 </div>
               </div>
             </section>
+
+            {showMockStepPicker && (
+              <section className="mb-4" data-testid="mock-step-section">
+                <h3 className="mb-2 text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--text-subtle)]">Screen</h3>
+                <div className="flex items-center gap-2">
+                  <Select value={currentMockStep ?? ''} onValueChange={(v) => applyMockStep(scenario, v === '' ? null : (v as BrowserMockStep))}>
+                    <SelectTrigger size="sm" className={cn('flex-1 text-[11px]', currentMockStep !== null ? 'border-[var(--brand)]' : '')} data-testid="mock-step-select">
+                      <SelectValue placeholder="Natural landing screen" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="">Natural landing screen</SelectItem>
+                      {availableMockSteps.map((step) => (
+                        <SelectItem key={step} value={step}>
+                          {step}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {currentMockStep !== null && (
+                    <button type="button" onClick={() => applyMockStep(scenario, null)} className="h-7 rounded border border-border px-2 text-[10px] font-medium text-muted-foreground hover:text-foreground" data-testid="mock-step-clear">
+                      Clear
+                    </button>
+                  )}
+                </div>
+              </section>
+            )}
 
             {grouped.map(({ group, scenarios }) => (
               <section key={group} className="mb-4 last:mb-0">

--- a/src/renderer/src/dev/browserMockScenarios.ts
+++ b/src/renderer/src/dev/browserMockScenarios.ts
@@ -10,9 +10,9 @@ export type BrowserMockScenarioId = (typeof BROWSER_MOCK_SCENARIO_IDS)[number];
 export type BrowserMockScenarioGroup = 'General' | 'Playlist' | 'Probe Results' | 'Probe Errors' | 'Dialogs' | 'Updates' | 'Queue' | 'Diagnostics';
 type ScenarioKind = 'default' | 'probe' | 'queue' | 'update' | 'diagnostics' | 'dialog';
 
-export const SINGLE_NORMAL_MOCK_STEPS = ['formats', 'subtitles', 'sponsorblock', 'output', 'folder', 'confirm'] as const;
-export const PLAYLIST_NORMAL_MOCK_STEPS = ['playlistItems', 'playlistPresets', 'sponsorblock', 'output', 'folder', 'confirm'] as const;
-export const BROWSER_MOCK_STEPS = [...SINGLE_NORMAL_MOCK_STEPS, ...PLAYLIST_NORMAL_MOCK_STEPS] as const;
+const SINGLE_NORMAL_MOCK_STEPS = ['formats', 'subtitles', 'sponsorblock', 'output', 'folder', 'confirm'] as const;
+const PLAYLIST_NORMAL_MOCK_STEPS = ['playlistItems', 'playlistPresets', 'sponsorblock', 'output', 'folder', 'confirm'] as const;
+export const BROWSER_MOCK_STEPS = [...new Set([...SINGLE_NORMAL_MOCK_STEPS, ...PLAYLIST_NORMAL_MOCK_STEPS])] as const;
 export type BrowserMockStep = (typeof BROWSER_MOCK_STEPS)[number];
 
 export interface BrowserMockScenario {
@@ -143,6 +143,12 @@ export function mockStepForScenario(scenario: Pick<BrowserMockScenario, 'id'>, s
   if (scenario.id === 'single-normal' && (SINGLE_NORMAL_MOCK_STEPS as readonly string[]).includes(step)) return step;
   if (scenario.id === 'playlist-normal' && (PLAYLIST_NORMAL_MOCK_STEPS as readonly string[]).includes(step)) return step;
   return null;
+}
+
+export function mockStepsForScenario(scenario: Pick<BrowserMockScenario, 'id'>): readonly BrowserMockStep[] {
+  if (scenario.id === 'single-normal') return SINGLE_NORMAL_MOCK_STEPS;
+  if (scenario.id === 'playlist-normal') return PLAYLIST_NORMAL_MOCK_STEPS;
+  return [];
 }
 
 export function buildScenarioAppApiState(scenario: BrowserMockScenario, params?: BrowserMockUrlParams, knobs?: BrowserMockKnobs): BrowserMockState {

--- a/src/renderer/src/dev/browserMockScenarios.ts
+++ b/src/renderer/src/dev/browserMockScenarios.ts
@@ -4,11 +4,16 @@ import type { AppSettings, DependencyDiagnostic, DependencyId, InstallChannel, P
 import type { YtDlpErrorKind } from '@shared/schemas.js';
 import type { BrowserMockKnobs } from './browserMockKnobs.js';
 
-export const BROWSER_MOCK_SCENARIO_IDS = ['default', 'playlist-no-thumbnails', 'playlist-long-titles', 'probe-audio-only', 'probe-with-subtitles', 'probe-no-formats', 'probe-live-stream', 'dialog-mixed-url', 'dialog-cookies-issue', 'update-direct', 'update-homebrew', 'update-scoop', 'update-portable', 'update-darwin-dmg', 'update-winget', 'update-flatpak', 'update-none', 'queue-empty', 'queue-running', 'queue-paused-active', 'queue-paused-held', 'queue-cancelled', 'queue-error', 'queue-completed', 'queue-subtitles-failed', 'queue-multi', 'diagnostics-all-ok', 'diagnostics-ytdlp-missing', 'diagnostics-ffmpeg-broken', 'diagnostics-deno-missing', 'diagnostics-ffprobe-broken', 'diagnostics-all-missing', 'diagnostics-warmup-running'] as const;
+export const BROWSER_MOCK_SCENARIO_IDS = ['default', 'single-normal', 'playlist-normal', 'playlist-no-thumbnails', 'playlist-long-titles', 'probe-audio-only', 'probe-with-subtitles', 'probe-no-formats', 'probe-live-stream', 'dialog-mixed-url', 'dialog-cookies-issue', 'update-direct', 'update-homebrew', 'update-scoop', 'update-portable', 'update-darwin-dmg', 'update-winget', 'update-flatpak', 'update-none', 'queue-empty', 'queue-running', 'queue-paused-active', 'queue-paused-held', 'queue-cancelled', 'queue-error', 'queue-completed', 'queue-subtitles-failed', 'queue-multi', 'diagnostics-all-ok', 'diagnostics-ytdlp-missing', 'diagnostics-ffmpeg-broken', 'diagnostics-deno-missing', 'diagnostics-ffprobe-broken', 'diagnostics-all-missing', 'diagnostics-warmup-running'] as const;
 
 export type BrowserMockScenarioId = (typeof BROWSER_MOCK_SCENARIO_IDS)[number];
 export type BrowserMockScenarioGroup = 'General' | 'Playlist' | 'Probe Results' | 'Probe Errors' | 'Dialogs' | 'Updates' | 'Queue' | 'Diagnostics';
 type ScenarioKind = 'default' | 'probe' | 'queue' | 'update' | 'diagnostics' | 'dialog';
+
+export const SINGLE_NORMAL_MOCK_STEPS = ['formats', 'subtitles', 'sponsorblock', 'output', 'folder', 'confirm'] as const;
+export const PLAYLIST_NORMAL_MOCK_STEPS = ['playlistItems', 'playlistPresets', 'sponsorblock', 'output', 'folder', 'confirm'] as const;
+export const BROWSER_MOCK_STEPS = [...SINGLE_NORMAL_MOCK_STEPS, ...PLAYLIST_NORMAL_MOCK_STEPS] as const;
+export type BrowserMockStep = (typeof BROWSER_MOCK_STEPS)[number];
 
 export interface BrowserMockScenario {
   id: BrowserMockScenarioId;
@@ -31,6 +36,7 @@ export interface BrowserMockState {
 export interface BrowserMockUrlParams {
   playlistCount: number | null;
   probeErrorKind: YtDlpErrorKind | null;
+  mockStep: BrowserMockStep | null;
 }
 
 export function readUrlParams(location: Pick<Location, 'search'> | URL): BrowserMockUrlParams {
@@ -42,7 +48,10 @@ export function readUrlParams(location: Pick<Location, 'search'> | URL): Browser
   const rawKind = params.get('probeError');
   const probeErrorKind = rawKind !== null && (YT_DLP_ERROR_KINDS as readonly string[]).includes(rawKind) ? (rawKind as YtDlpErrorKind) : null;
 
-  return { playlistCount, probeErrorKind };
+  const rawStep = params.get('mockStep');
+  const mockStep = rawStep !== null && (BROWSER_MOCK_STEPS as readonly string[]).includes(rawStep) ? (rawStep as BrowserMockStep) : null;
+
+  return { playlistCount, probeErrorKind, mockStep };
 }
 
 const COMMON_PATHS = {
@@ -67,7 +76,9 @@ const WIN_COMMON_PATHS = {
 
 export const BROWSER_MOCK_SCENARIOS: readonly BrowserMockScenario[] = [
   { id: 'default', group: 'General', title: 'Default app', description: 'Standard mock video flow and clean queue.', kind: 'default' },
+  { id: 'single-normal', group: 'General', title: 'Single video normal', description: 'Happy-path YouTube video with formats, subtitles, and SponsorBlock steps.', kind: 'probe' },
 
+  { id: 'playlist-normal', group: 'Playlist', title: 'Playlist normal', description: 'Happy-path playlist with thumbnails, durations, and default preset selection.', kind: 'probe' },
   { id: 'playlist-no-thumbnails', group: 'Playlist', title: 'No thumbnails', description: 'Playlist rows with no thumbnail column.', kind: 'probe' },
   { id: 'playlist-long-titles', group: 'Playlist', title: 'Long titles', description: 'Playlist rows with intentionally long titles.', kind: 'probe' },
 
@@ -123,6 +134,17 @@ export function getScenario(id: string | null | undefined): BrowserMockScenario 
   return SCENARIOS_BY_ID.get(id) ?? BROWSER_MOCK_SCENARIOS[0];
 }
 
+export function isHappyPathScenario(scenario: Pick<BrowserMockScenario, 'id'>): boolean {
+  return scenario.id === 'single-normal' || scenario.id === 'playlist-normal';
+}
+
+export function mockStepForScenario(scenario: Pick<BrowserMockScenario, 'id'>, step: BrowserMockStep | null): BrowserMockStep | null {
+  if (step === null) return null;
+  if (scenario.id === 'single-normal' && (SINGLE_NORMAL_MOCK_STEPS as readonly string[]).includes(step)) return step;
+  if (scenario.id === 'playlist-normal' && (PLAYLIST_NORMAL_MOCK_STEPS as readonly string[]).includes(step)) return step;
+  return null;
+}
+
 export function buildScenarioAppApiState(scenario: BrowserMockScenario, params?: BrowserMockUrlParams, knobs?: BrowserMockKnobs): BrowserMockState {
   const settings = buildSettings(scenario, knobs);
   return {
@@ -164,6 +186,10 @@ function buildProbeResult(scenario: BrowserMockScenario, params?: BrowserMockUrl
     return playlistProbe(params.playlistCount);
   }
   switch (scenario.id) {
+    case 'single-normal':
+      return normalVideoProbe();
+    case 'playlist-normal':
+      return playlistProbe(12, { fullThumbnails: true });
     case 'playlist-no-thumbnails':
       return playlistProbe(100, { thumbnails: false });
     case 'playlist-long-titles':
@@ -213,6 +239,45 @@ const MOCK_FORMATS = [
   { formatId: '251', label: 'webm · Opus · 132 kbps · 5.0 MB', ext: 'webm', resolution: 'audio only', abr: 132, filesize: 5_200_000, isVideoOnly: false, isAudioOnly: true },
   { formatId: '140', label: 'm4a · AAC · 129 kbps · 4.8 MB', ext: 'm4a', resolution: 'audio only', abr: 129, filesize: 5_000_000, isVideoOnly: false, isAudioOnly: true }
 ] as const;
+
+const NORMAL_VIDEO_FORMATS = [
+  { formatId: '313', label: '2160p | webm | 30fps | 2.2 GB', ext: 'webm', resolution: '2160p', fps: 30, filesize: 2_400_000_000, isVideoOnly: true, isAudioOnly: false },
+  { formatId: '271', label: '1440p | webm | 30fps | 906.2 MB', ext: 'webm', resolution: '1440p', fps: 30, filesize: 950_000_000, isVideoOnly: true, isAudioOnly: false },
+  { formatId: '137', label: '1080p | mp4 | 30fps | 515.0 MB', ext: 'mp4', resolution: '1080p', fps: 30, filesize: 540_000_000, isVideoOnly: true, isAudioOnly: false },
+  { formatId: '248', label: '1080p | webm | 30fps | 400.5 MB', ext: 'webm', resolution: '1080p', fps: 30, filesize: 420_000_000, isVideoOnly: true, isAudioOnly: false },
+  { formatId: '136', label: '720p | mp4 | 30fps | 209.8 MB', ext: 'mp4', resolution: '720p', fps: 30, filesize: 220_000_000, isVideoOnly: true, isAudioOnly: false },
+  { formatId: '247', label: '720p | webm | 30fps | 171.7 MB', ext: 'webm', resolution: '720p', fps: 30, filesize: 180_000_000, isVideoOnly: true, isAudioOnly: false },
+  { formatId: '135', label: '480p | mp4 | 30fps | 104.9 MB', ext: 'mp4', resolution: '480p', fps: 30, filesize: 110_000_000, isVideoOnly: true, isAudioOnly: false },
+  { formatId: '134', label: '360p | mp4 | 30fps | 62.0 MB', ext: 'mp4', resolution: '360p', fps: 30, filesize: 65_000_000, isVideoOnly: true, isAudioOnly: false },
+  { formatId: '251', label: 'webm · Opus · 132 kbps · 5.0 MB', ext: 'webm', resolution: 'audio only', abr: 132, filesize: 5_200_000, isVideoOnly: false, isAudioOnly: true },
+  { formatId: '140', label: 'm4a · AAC · 129 kbps · 4.8 MB', ext: 'm4a', resolution: 'audio only', abr: 129, filesize: 5_000_000, isVideoOnly: false, isAudioOnly: true },
+  { formatId: '249', label: 'webm · Opus · 50 kbps · 2.0 MB', ext: 'webm', resolution: 'audio only', abr: 50, filesize: 2_000_000, isVideoOnly: false, isAudioOnly: true },
+  { formatId: '139', label: 'm4a · AAC · 48 kbps · 1.8 MB', ext: 'm4a', resolution: 'audio only', abr: 48, filesize: 1_900_000, isVideoOnly: false, isAudioOnly: true }
+] as const;
+
+export function normalVideoProbe(options: { webpageUrl?: string; degraded?: Extract<ProbeResult, { kind: 'video' }>['degraded'] } = {}): ProbeResult {
+  return {
+    kind: 'video',
+    extractor: 'youtube',
+    extractorKey: 'Youtube',
+    webpageUrl: options.webpageUrl ?? 'https://www.youtube.com/watch?v=mock-normal',
+    isAudioOnlySource: false,
+    isLive: false,
+    hasDrm: false,
+    duration: 60 * 60 * 24,
+    title: 'Mock Video - Lo-fi Hip Hop Radio 24/7',
+    thumbnail: 'https://i.ytimg.com/vi/jfKfPfyJRdk/hqdefault.jpg',
+    ...(options.degraded ? { degraded: options.degraded } : {}),
+    formats: [...NORMAL_VIDEO_FORMATS],
+    subtitles: {
+      en: [{ ext: 'vtt', name: 'English' }],
+      es: [{ ext: 'vtt', name: 'Espanol' }]
+    },
+    automaticCaptions: {
+      'en-orig': [{ ext: 'vtt', name: 'English (auto)' }]
+    }
+  };
+}
 
 function audioOnlyProbe(): ProbeResult {
   return {
@@ -303,7 +368,7 @@ function liveStreamProbe(): ProbeResult {
   };
 }
 
-function playlistProbe(count: number, options: { thumbnails?: boolean; longTitles?: boolean } = {}): ProbeResult {
+export function playlistProbe(count: number, options: { thumbnails?: boolean; fullThumbnails?: boolean; longTitles?: boolean; webpageUrl?: string } = {}): ProbeResult {
   const entries: PlaylistEntry[] = Array.from({ length: count }, (_, i) => {
     const number = i + 1;
     const title = options.longTitles ? `Mock playlist item ${number} - an intentionally long title with extra metadata, brackets, episode numbers, and enough words to pressure every row layout` : `Mock playlist item ${number} - ${i % 3 === 0 ? 'a longer title that should ellipsize gracefully when the row is narrow' : 'short title'}`;
@@ -311,7 +376,7 @@ function playlistProbe(count: number, options: { thumbnails?: boolean; longTitle
       id: `mock${number}`,
       url: `https://www.youtube.com/watch?v=mock${number}`,
       title,
-      thumbnail: options.thumbnails === false ? '' : i % 5 === 0 ? '' : 'https://i.ytimg.com/vi/jfKfPfyJRdk/mqdefault.jpg',
+      thumbnail: options.thumbnails === false ? '' : options.fullThumbnails === true || i % 5 !== 0 ? 'https://i.ytimg.com/vi/jfKfPfyJRdk/mqdefault.jpg' : '',
       duration: 90 + i * 47,
       playlistIndex: number,
       videoId: `mockid${number}`
@@ -322,7 +387,7 @@ function playlistProbe(count: number, options: { thumbnails?: boolean; longTitle
     kind: 'playlist',
     extractor: 'youtube:tab',
     extractorKey: 'YoutubeTab',
-    webpageUrl: 'https://example.com/mock-playlist',
+    webpageUrl: options.webpageUrl ?? 'https://example.com/mock-playlist',
     isAudioOnlySource: false,
     isMultiVideo: false,
     playlistId: 'PLmock_browser',

--- a/tests/browser/scenario-gallery.spec.ts
+++ b/tests/browser/scenario-gallery.spec.ts
@@ -49,6 +49,30 @@ test('playlist count presets in gallery navigate to ?playlist=n', async ({ page 
   await expect(page.getByTestId('playlist-preset-101')).toBeVisible();
 });
 
+test('normal happy path scenarios land on their natural screens', async ({ page }) => {
+  await openScenario(page, 'single-normal');
+  await expect(page.getByTestId('step-formats')).toBeVisible({ timeout: 6_000 });
+
+  await openScenario(page, 'playlist-normal');
+  await expect(page.getByTestId('step-playlist-items')).toBeVisible({ timeout: 6_000 });
+});
+
+test('mockStep opens normal happy paths directly to confirm', async ({ page }) => {
+  await openWithParams(page, 'scenario=single-normal&mockStep=confirm');
+  await expect(page.getByTestId('step-confirm')).toBeVisible({ timeout: 6_000 });
+
+  await openWithParams(page, 'scenario=playlist-normal&mockStep=confirm');
+  await expect(page.getByTestId('step-confirm')).toBeVisible({ timeout: 6_000 });
+});
+
+test('normal happy path scenarios expose the screen picker', async ({ page }) => {
+  await openScenario(page, 'single-normal');
+  await page.getByTestId('scenario-gallery-toggle').click();
+  await expect(page.getByTestId('scenario-button-single-normal')).toBeVisible();
+  await expect(page.getByTestId('scenario-button-playlist-normal')).toBeVisible();
+  await expect(page.getByTestId('mock-step-select')).toBeVisible();
+});
+
 test('probe error dropdown shows all error kinds', async ({ page }) => {
   await openScenario(page, 'default');
   await page.getByTestId('scenario-gallery-toggle').click();

--- a/tests/unit/browser-mock-scenarios.test.ts
+++ b/tests/unit/browser-mock-scenarios.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildScenarioAppApiState, getScenario, readScenarioIdFromUrl, readUrlParams } from '@renderer/dev/browserMockScenarios.js';
+import { buildScenarioAppApiState, getScenario, mockStepForScenario, readScenarioIdFromUrl, readUrlParams } from '@renderer/dev/browserMockScenarios.js';
 
 describe('browser mock scenarios', () => {
   it('reads known scenario ids from URLs', () => {
@@ -10,8 +10,21 @@ describe('browser mock scenarios', () => {
   });
 
   it('falls back to the default scenario for unknown ids', () => {
+    expect(getScenario('single-normal').id).toBe('single-normal');
+    expect(getScenario('playlist-normal').id).toBe('playlist-normal');
     expect(getScenario('probe-audio-only').id).toBe('probe-audio-only');
     expect(getScenario('not-real').id).toBe('default');
+  });
+
+  it('parses mock step params and rejects invalid step/scenario combinations', () => {
+    expect(readUrlParams(new URL('http://localhost:5173/?scenario=single-normal&mockStep=confirm')).mockStep).toBe('confirm');
+    expect(readUrlParams(new URL('http://localhost:5173/?scenario=single-normal&mockStep=nope')).mockStep).toBeNull();
+    expect(readUrlParams(new URL('http://localhost:5173/')).mockStep).toBeNull();
+
+    expect(mockStepForScenario(getScenario('single-normal'), 'subtitles')).toBe('subtitles');
+    expect(mockStepForScenario(getScenario('single-normal'), 'playlistPresets')).toBeNull();
+    expect(mockStepForScenario(getScenario('playlist-normal'), 'playlistPresets')).toBe('playlistPresets');
+    expect(mockStepForScenario(getScenario('playlist-normal'), 'formats')).toBeNull();
   });
 
   it('builds playlist fixtures via ?playlist=n param', () => {
@@ -42,6 +55,23 @@ describe('browser mock scenarios', () => {
 
     expect(state.probeResult.entries).toHaveLength(100);
     expect(state.probeResult.entries.every((entry) => entry.thumbnail === '')).toBe(true);
+  });
+
+  it('builds normal happy-path fixtures', () => {
+    const single = buildScenarioAppApiState(getScenario('single-normal'));
+    expect(single.probeResult?.kind).toBe('video');
+    if (single.probeResult?.kind !== 'video') throw new Error('expected video probe');
+    expect(single.probeResult.extractor).toBe('youtube');
+    expect(single.probeResult.formats.length).toBeGreaterThan(6);
+    expect(Object.keys(single.probeResult.subtitles)).toContain('en');
+    expect(Object.keys(single.probeResult.automaticCaptions)).toContain('en-orig');
+
+    const playlist = buildScenarioAppApiState(getScenario('playlist-normal'));
+    expect(playlist.probeResult?.kind).toBe('playlist');
+    if (playlist.probeResult?.kind !== 'playlist') throw new Error('expected playlist probe');
+    expect(playlist.probeResult.entries).toHaveLength(12);
+    expect(playlist.probeResult.entries.every((entry) => entry.thumbnail !== '')).toBe(true);
+    expect(playlist.probeResult.entries.every((entry) => entry.duration !== undefined)).toBe(true);
   });
 
   it('builds probe errors via ?probeError=kind param', () => {


### PR DESCRIPTION
## Summary
- add explicit normal single-video and playlist browser-mock scenarios
- add a mockStep screen picker for happy-path wizard states
- reuse normal video and playlist fixtures between browserMock and scenario state

## Tests
- bunx vitest run --project node tests/unit/browser-mock-scenarios.test.ts
- bun run test:browser -- tests/browser/scenario-gallery.spec.ts
- bun run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## User-facing changes
- Adds a "Screen" selector in the Scenario Gallery UI that lets devs pick a specific wizard screen for happy-path scenarios (single-normal and playlist-normal).
- Supports deep-linking to wizard screens via the mockStep URL parameter (e.g., ?mockStep=confirm); the gallery will open directly to the selected step when applicable.
- Gallery description and navigation behavior updated to reflect mock-step selection and auto-apply behavior.

## Internal / refactor changes
- Replaced large inline mock payloads with reusable helpers: normalVideoProbe(...) and playlistProbe(...). browserMock.ts now builds probe responses via these shared helpers.
- Added two new happy-path browser mock scenarios: single-normal and playlist-normal (and corresponding mock-step lists).
- Scenario helpers and types extended:
  - BROWSER_MOCK_SCENARIO_IDS and BROWSER_MOCK_STEPS updated/derived to include happy-path steps.
  - BrowserMockUrlParams now includes mockStep: BrowserMockStep | null.
  - Added exported helpers: isHappyPathScenario, mockStepForScenario, mockStepsForScenario.
  - Updated signatures: normalVideoProbe(...) and playlistProbe(...).
- ScenarioGallery updated to:
  - Persist/parse mockStep via URL state, expose selector UI only for happy-path scenarios, clear mockStep when switching certain URL modes, and auto-apply a derived wizard step after navigating.
  - Use an idempotency key that includes mockStep when auto-applying state to avoid repeated side effects.
- Tests added/expanded to cover parsing, mapping and fixture outputs for the new happy-paths and the UI deep-link behavior.

## Risk areas
- Electron / security / IPC: changes are confined to development/testing UI and mock generation logic. No changes were made to core app IPC boundaries or production runtime code, so Electron security and IPC risk is low.
- Public API / types: exported constants and types in dev/browserMockScenarios.ts were changed (new scenario IDs/steps and BrowserMockUrlParams). This may affect any tooling or tests that import these dev exports — ensure downstream dev-only consumers are updated.
- Build/release: no new runtime dependencies added; changes touch renderer/dev code and tests only. Still run full typecheck/build to ensure no regressions from updated exported types/signatures.
- Tests/CI: increased test surface (browser tests + unit tests) may introduce flakiness if UI timing or deep-linking assumptions differ in CI environments.

## Tests / checks to run
- Unit: bunx vitest run --project node tests/unit/browser-mock-scenarios.test.ts
- Browser/Playwright: bun run test:browser -- tests/browser/scenario-gallery.spec.ts
- Local full test + checks: bun run check (lint/type checks) and the repository's standard CI job(s) to ensure gallery auto-apply behavior is stable in headless CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->