### PR TITLE
Add quick download button

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "check:pins": "node scripts/check-dependency-pins.mjs",
     "deps:vuln": "node scripts/check-deps-vuln.mjs",
     "deps:vuln:strict": "node scripts/check-deps-vuln.mjs --threshold moderate",
-    "check": "concurrently -c auto --kill-others-on-fail -n lint,types,knip,madge,loc,pins,test \"bun run lint\" \"bun run typecheck\" \"bun run knip\" \"bun run madge\" \"bun run check:loc\" \"bun run check:pins\" \"bun run test\"",
+    "check": "concurrently -c auto --kill-others-on-fail -n lint,types,knip,madge,loc,pins,i18n,test \"bun run lint\" \"bun run typecheck\" \"bun run knip\" \"bun run madge\" \"bun run check:loc\" \"bun run check:pins\" \"bun run check:app\" \"bun run test\"",
     "madge": "madge --circular --extensions ts,tsx src/",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/renderer/src/components/system/SplashScreen.tsx
+++ b/src/renderer/src/components/system/SplashScreen.tsx
@@ -49,7 +49,7 @@ export function SplashScreen({ initialized, warmupBlocking, warmupDiagnostics, w
     <div
       className="splash-overlay"
       data-testid="splash-overlay"
-      style={{ opacity: fading ? 0 : 1, pointerEvents: blocked ? 'auto' : 'none' }}
+      style={{ opacity: fading ? 0 : 1, pointerEvents: fading ? 'none' : 'auto' }}
       onTransitionEnd={() => {
         if (fading) setGone(true);
       }}

--- a/src/renderer/src/components/wizard/StepUrlInput.tsx
+++ b/src/renderer/src/components/wizard/StepUrlInput.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type JSX, type ReactNode } from 'react';
-import { ArrowRight, AlertTriangle, Share2, X, Video, ListVideo, Music, Tv, Smartphone, Mic, Globe, ListMusic, AudioLines, Captions } from 'lucide-react';
+import { ArrowRight, AlertTriangle, Download, Share2, X, Video, ListVideo, Music, Tv, Smartphone, Mic, Globe, ListMusic, AudioLines, Captions } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../../store/useAppStore.js';
 import { track } from '@renderer/lib/analytics.js';
@@ -7,6 +7,7 @@ import { Input } from '../ui/input.js';
 import { Button } from '../ui/button.js';
 import { Switch } from '../ui/switch.js';
 import { RadioOption } from '../ui/radio-option.js';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js';
 import { MascotBubble } from '../shared/MascotBubble.js';
 import { ClipboardConfirmDialog } from '../shared/ClipboardConfirmDialog.js';
 import { IncompleteCookiesConfigDialog } from './IncompleteCookiesConfigDialog.js';
@@ -37,12 +38,15 @@ const COOKIES_CHROME_URL = 'https://chromewebstore.google.com/detail/get-cookies
 
 export function StepUrlInput(): JSX.Element {
   const { t } = useTranslation();
-  const { wizardUrl, setWizardUrl, submitUrl, queue, settings, initialized, advancedAutoOpen, advancedAutoTarget, setAdvancedAutoOpen, setCookiesPath, setCookiesMode, setCookiesBrowser, setClipboardWatchEnabled, setIncludeIdInSingleFilenames, setCloseBehavior, setAnalyticsEnabled, setProxyUrl, setLimitRate, cookiesConfigDialogIssue, dismissCookiesConfigDialog, openCookiesSettings, openShareDialog, setShareInlineCardDismissed } = useAppStore();
+  const { wizardUrl, setWizardUrl, submitUrl, quickDownload, quickDownloadStatus, quickDownloadError, queue, settings, initialized, advancedAutoOpen, advancedAutoTarget, setAdvancedAutoOpen, setCookiesPath, setCookiesMode, setCookiesBrowser, setClipboardWatchEnabled, setIncludeIdInSingleFilenames, setCloseBehavior, setAnalyticsEnabled, setProxyUrl, setLimitRate, cookiesConfigDialogIssue, dismissCookiesConfigDialog, openCookiesSettings, openShareDialog, setShareInlineCardDismissed } = useAppStore();
   const inputRef = useRef<HTMLInputElement>(null);
   const hasActiveDownloads = queue.some((i) => i.status === 'running');
   const [pendingClipboardUrl, setPendingClipboardUrl] = useState<string | null>(null);
 
   const shareCardVisible = !(settings?.common?.shareInlineCardDismissed ?? false);
+  const quickPreparing = quickDownloadStatus === 'preparing';
+  const quickErrorText = quickDownloadError === 'wizard.url.quickSingleOnly' ? t('wizard.url.quickSingleOnly') : quickDownloadError === 'wizard.url.quickProbeFailed' ? t('wizard.url.quickProbeFailed') : quickDownloadError === 'wizard.url.quickPrepareFailed' ? t('wizard.url.quickPrepareFailed') : (quickDownloadError ?? '');
+  const quickFeedback = quickDownloadStatus === 'queued' ? t('wizard.url.quickQueued') : quickDownloadStatus === 'error' ? (quickDownloadError === 'wizard.url.quickSingleOnly' ? quickErrorText : t('wizard.url.quickFailed', { error: quickErrorText })) : null;
 
   function handleShareInlineCardClick(): void {
     openShareDialog('wizard-card');
@@ -87,6 +91,7 @@ export function StepUrlInput(): JSX.Element {
       const { wizardUrl: currentUrl, formatsLoading } = useAppStore.getState();
       if (currentUrl) return;
       if (formatsLoading) return;
+      if (useAppStore.getState().quickDownloadStatus === 'preparing') return;
       setPendingClipboardUrl(cleanUrl(url));
     });
   }, []);
@@ -118,7 +123,7 @@ export function StepUrlInput(): JSX.Element {
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>): void {
-    if (e.key === 'Enter' && wizardUrl.trim()) {
+    if (e.key === 'Enter' && wizardUrl.trim() && !quickPreparing) {
       void submitUrl();
     }
   }
@@ -157,10 +162,41 @@ export function StepUrlInput(): JSX.Element {
                 </button>
               ) : null}
             </div>
-            <Button type="button" size="lg" onClick={() => void submitUrl()} disabled={!wizardUrl.trim()} data-testid="btn-find-formats" className="shadow-[0_4px_14px_var(--brand-glow)] disabled:shadow-none gap-2">
-              {t('wizard.url.fetchFormats')} <ArrowRight size={16} className="rtl:rotate-180" />
-            </Button>
+            <Tooltip>
+              <TooltipTrigger
+                render={(props) => (
+                  <span {...props} className="inline-flex">
+                    <Button type="button" size="lg" variant="outline" onClick={() => void quickDownload()} disabled={!wizardUrl.trim() || quickPreparing} data-testid="btn-quick-download" className="gap-2">
+                      {quickPreparing ? <span className="h-4 w-4 rounded-full border-2 border-current/20 border-t-current animate-spin" aria-hidden /> : <Download size={16} />}
+                      {quickPreparing ? t('wizard.url.quickPreparing') : t('wizard.url.quickDownload')}
+                    </Button>
+                  </span>
+                )}
+              />
+              <TooltipContent className="max-w-[18rem] leading-snug" data-testid="quick-download-tooltip">
+                {t('wizard.url.quickDownloadTooltip')}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={(props) => (
+                  <span {...props} className="inline-flex">
+                    <Button type="button" size="lg" onClick={() => void submitUrl()} disabled={!wizardUrl.trim() || quickPreparing} data-testid="btn-find-formats" className="shadow-[0_4px_14px_var(--brand-glow)] disabled:shadow-none gap-2">
+                      {t('wizard.url.fetchFormats')} <ArrowRight size={16} className="rtl:rotate-180" />
+                    </Button>
+                  </span>
+                )}
+              />
+              <TooltipContent className="max-w-[18rem] leading-snug" data-testid="fetch-formats-tooltip">
+                {t('wizard.url.fetchFormatsTooltip')}
+              </TooltipContent>
+            </Tooltip>
           </div>
+          {quickFeedback ? (
+            <p role="status" aria-live="polite" data-testid="quick-download-feedback" className={quickDownloadStatus === 'error' ? 'text-[11px] text-amber-500' : 'text-[11px] text-[var(--text-subtle)]'}>
+              {quickFeedback}
+            </p>
+          ) : null}
         </div>
       </div>
 

--- a/src/renderer/src/store/queueSlice.ts
+++ b/src/renderer/src/store/queueSlice.ts
@@ -20,14 +20,14 @@ import i18next from 'i18next';
 import type { GetState, SetState, QueueSlice } from './types.js';
 import { persistFormatPrefs } from './wizard/persistFormatPrefs.js';
 
-function maybeShowQueueTip(set: SetState): void {
+export function maybeShowQueueTip(set: SetState): void {
   if (!localStorage.getItem('arroxy_seen_queue_tip')) {
     localStorage.setItem('arroxy_seen_queue_tip', '1');
     set({ drawerOpen: true, showQueueTip: true });
   }
 }
 
-function buildQueueItem(get: GetState, lane: QueueLane): QueueItem | null {
+export function buildSingleQueueItemFromState(get: GetState, lane: QueueLane): QueueItem | null {
   const state = get();
   const { wizardUrl, wizardTitle, wizardThumbnail, wizardOutputDir } = state;
   const { wizardSubfolderEnabled, wizardSubfolderName } = state;
@@ -207,7 +207,7 @@ async function submitWizardToQueue(set: SetState, get: GetState, lane: QueueLane
       }
       await window.appApi.queue.cmd.add(items);
     } else {
-      const item = buildQueueItem(get, lane);
+      const item = buildSingleQueueItemFromState(get, lane);
       if (!item) return;
       await window.appApi.queue.cmd.add([item]);
     }

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -1,5 +1,5 @@
 import type { StoreApi } from 'zustand';
-import type { AppSettings, AudioBitrate, CookiesBrowser, CookiesMode, DependencyDiagnostic, DependencyId, FormatOption, PlaylistEntry, PlaylistSelection, Preset, ProbeError, ProbeDegradationReason, QueueItem, QueueLane, SubtitleFormat, SubtitleMap, SubtitleMode, SponsorBlockMode, SponsorBlockCategory, SupportedLang, UiTheme } from '@shared/types.js';
+import type { AppSettings, AudioBitrate, CookiesBrowser, CookiesMode, DependencyDiagnostic, DependencyId, FormatOption, PlaylistEntry, PlaylistSelection, Preset, ProbeError, ProbeDegradationReason, QueueItem, QueueLane, QuickDownloadStatus, SubtitleFormat, SubtitleMap, SubtitleMode, SponsorBlockMode, SponsorBlockCategory, SupportedLang, UiTheme } from '@shared/types.js';
 import type { AudioSelection } from '@shared/schemas.js';
 import type { IncompleteCookiesConfigIssue } from '@shared/cookiesConfig.js';
 export type { AudioSelection };
@@ -50,6 +50,8 @@ export interface ProbeOrchestratorSlice {
   playlistLikelyCapped: boolean;
   playlistProbeLoading: boolean;
   playlistSelection: PlaylistSelection | null;
+  quickDownloadStatus: QuickDownloadStatus;
+  quickDownloadError: string | null;
 
   // videoIds matched on disk by the last folder scan
   syncedDownloadedIds: string[];
@@ -59,6 +61,7 @@ export interface ProbeOrchestratorSlice {
 
   setWizardUrl: (url: string) => void;
   submitUrl: () => Promise<void>;
+  quickDownload: () => Promise<void>;
   dismissMixedPrompt: (choice: 'video' | 'playlist') => Promise<void>;
   setPlaylistItemSelected: (id: string, checked: boolean) => void;
   selectAllPlaylistItems: () => void;

--- a/src/renderer/src/store/wizard/commands.ts
+++ b/src/renderer/src/store/wizard/commands.ts
@@ -34,6 +34,8 @@ export const RESET_WIZARD_STATE = {
   playlistLikelyCapped: false,
   playlistProbeLoading: false,
   playlistSelection: null as PlaylistSelection | null,
+  quickDownloadStatus: 'idle' as const,
+  quickDownloadError: null as string | null,
   // formatPicker
   wizardFormats: [] as FormatOption[],
   selectedVideoFormatId: '',

--- a/src/renderer/src/store/wizard/probeOrchestrator.ts
+++ b/src/renderer/src/store/wizard/probeOrchestrator.ts
@@ -18,6 +18,9 @@ import { resolvePlaylistDir } from './playlistDir.js';
 import { isYouTubeExtractor } from '@shared/ytdlp/extractorPredicates.js';
 import { applyPreset, restoreFormatSelection, restoreSubtitleSelection } from './formatPicker.js';
 import { WizardCommands, RESET_WIZARD_STATE } from './commands.js';
+import { persistFormatPrefs } from './persistFormatPrefs.js';
+import { buildSingleQueueItemFromState, maybeShowQueueTip } from '../queueSlice.js';
+import { formatProbeError } from '../helpers.js';
 import type { AppState, GetState, SetState, ProbeOrchestratorSlice, WizardStep } from '../types.js';
 import { type VisibleStep } from '../../components/wizard/stepNavigation.js';
 import { nextStep, type NavContext } from '../../components/wizard/nextStep.js';
@@ -166,8 +169,8 @@ function maybeBlockIncompleteCookiesConfig(url: string, set: SetState, get: GetS
   return true;
 }
 
-function applyVideoProbeResult(probe: Extract<ProbeResult, { kind: 'video' }>, set: SetState, get: GetState, firstProbe: boolean): void {
-  const settings = get().settings;
+function videoProbeState(probe: Extract<ProbeResult, { kind: 'video' }>, state: AppState, firstProbe: boolean): Partial<AppState> {
+  const settings = state.settings;
   const { formats, title, thumbnail, duration, subtitles, automaticCaptions, degraded } = probe;
   // Format/audio/subtitle/preset prefs are scoped to YouTube. Non-YT extractors
   // get fresh defaults so a YT formatId / 1080p resolution doesn't leak into a
@@ -187,8 +190,7 @@ function applyVideoProbeResult(probe: Extract<ProbeResult, { kind: 'video' }>, s
     audioSelection = audioOnlyPick.audioSelection;
     preset = 'audio-only';
   }
-  set({
-    wizardStep: 'formats',
+  return {
     wizardMode: 'single',
     wizardFormats: formats,
     wizardFormatsDegraded: degraded ?? null,
@@ -221,6 +223,13 @@ function applyVideoProbeResult(probe: Extract<ProbeResult, { kind: 'video' }>, s
     playlistTitle: '',
     playlistId: '',
     playlistIsMultiVideo: false
+  };
+}
+
+function applyVideoProbeResult(probe: Extract<ProbeResult, { kind: 'video' }>, set: SetState, get: GetState, firstProbe: boolean): void {
+  set({
+    wizardStep: 'formats',
+    ...videoProbeState(probe, get(), firstProbe)
   });
 }
 
@@ -343,10 +352,12 @@ export function createProbeOrchestratorSlice(set: SetState, get: GetState): Prob
     playlistLikelyCapped: RESET_WIZARD_STATE.playlistLikelyCapped,
     playlistProbeLoading: RESET_WIZARD_STATE.playlistProbeLoading,
     playlistSelection: RESET_WIZARD_STATE.playlistSelection,
+    quickDownloadStatus: RESET_WIZARD_STATE.quickDownloadStatus,
+    quickDownloadError: RESET_WIZARD_STATE.quickDownloadError,
     syncedDownloadedIds: RESET_WIZARD_STATE.syncedDownloadedIds,
     syncScanState: RESET_WIZARD_STATE.syncScanState,
 
-    setWizardUrl: (url) => set({ wizardUrl: url }),
+    setWizardUrl: (url) => set({ wizardUrl: url, quickDownloadStatus: 'idle', quickDownloadError: null }),
 
     submitUrl: async () => {
       const cleaned = rewriteYouTubeChannelRoot(cleanUrl(get().wizardUrl.trim()));
@@ -359,6 +370,57 @@ export function createProbeOrchestratorSlice(set: SetState, get: GetState): Prob
       }
       if (maybeBlockIncompleteCookiesConfig(cleaned, set, get)) return;
       await runProbe(cleaned, 'auto', set, get);
+    },
+
+    quickDownload: async () => {
+      if (get().quickDownloadStatus === 'preparing') return;
+      const cleaned = rewriteYouTubeChannelRoot(cleanUrl(get().wizardUrl.trim()));
+      if (!cleaned) return;
+      if (maybeBlockIncompleteCookiesConfig(cleaned, set, get)) return;
+
+      void window.appApi.downloads.probeCancel();
+      set({ wizardUrl: cleaned, quickDownloadStatus: 'preparing', quickDownloadError: null, wizardError: null, cookiesConfigDialogIssue: null });
+
+      try {
+        const result = await window.appApi.downloads.probe({ url: cleaned, playlistMode: 'video' });
+        if (!result.ok) {
+          set({ quickDownloadStatus: 'error', quickDownloadError: formatProbeError(result.error) || 'wizard.url.quickProbeFailed' });
+          return;
+        }
+
+        if (result.data.kind !== 'video') {
+          set({ quickDownloadStatus: 'error', quickDownloadError: 'wizard.url.quickSingleOnly' });
+          return;
+        }
+
+        const currentOutputDir = get().wizardOutputDir;
+        const fallbackOutputDir = get().settings?.common?.defaultOutputDir ?? '';
+
+        set({
+          wizardUrl: cleaned,
+          wizardOutputDir: currentOutputDir.trim() ? currentOutputDir : fallbackOutputDir,
+          ...videoProbeState(result.data, get(), true)
+        });
+
+        const item = buildSingleQueueItemFromState(get, 'normal');
+        if (!item) {
+          set({ quickDownloadStatus: 'error', quickDownloadError: 'wizard.url.quickPrepareFailed' });
+          return;
+        }
+
+        const addResult = await window.appApi.queue.cmd.add([item]);
+        if (!addResult.ok) {
+          set({ quickDownloadStatus: 'error', quickDownloadError: addResult.error.message });
+          return;
+        }
+
+        maybeShowQueueTip(set);
+        await persistFormatPrefs(set, get);
+        WizardCommands.resetAll(set);
+        set({ quickDownloadStatus: 'queued', quickDownloadError: null });
+      } catch (err) {
+        set({ quickDownloadStatus: 'error', quickDownloadError: err instanceof Error ? err.message : String(err) });
+      }
     },
 
     dismissMixedPrompt: async (choice) => {

--- a/src/shared/i18n/locales/am.ts
+++ b/src/shared/i18n/locales/am.ts
@@ -122,13 +122,26 @@ const am = {
       title: 'ይህ ሊንክ Playlist አለው',
       body: 'የጠቀሱትን ቪዲዮ ብቻ ይፈልጋሉ፣ ወይስ ከ Playlist ይምረጣሉ? በቀጣዩ ደረጃ የተወሰኑ ቪዲዮዎችን ወይም ክልል ይምረጣሉ።',
       singleVideo: 'ይህን ብቻ',
-      pickFromPlaylist: 'ከ Playlist ምረጥ'
+      pickFromPlaylist: 'ከ Playlist ምረጥ',
+      playlistLimit: 'የፕሌይሊስት መፈተሻ ገደብ፦ {{count}} ንጥሎች',
+      advancedSettings: 'የላቁ ቅንብሮች',
+      singleTooltip: 'yt-dlp የነጠላ ቪዲዮ ሁነታን ይጠቀማል፣ ከዚህ URL ጋር የተያያዘው playlist ይተዋል።',
+      playlistTooltip: 'yt-dlp የplaylist ሁነታን ተጠቅሞ አስመራጩን ከማሳየቱ በፊት እስከ ገደብዎ ይወስዳል።'
     },
 
     url: {
       heading: 'YouTube URL',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'ቅርጸቶችን ጫን',
+      fetchFormatsTooltip: 'ወደ ወረፋ ከመጨመርዎ በፊት ቅርጸቶችን፣ ንዑስ ጽሑፎችን፣ አቃፊን እና የፕሌይሊስት ንጥሎችን በደረጃ ይምረጡ።',
+      quickDownload: 'ፈጣን አውርድ',
+      quickDownloadTooltip: 'የተቀመጡ ወይም ነባሪ ምርጫዎችዎን ተጠቅሞ ይህን ነጠላ ቪዲዮ የማዘጋጃ ደረጃዎችን ሳይከፍት ወደ ወረፋ ያክላል።',
+      quickPreparing: 'በመዘጋጀት ላይ',
+      quickQueued: 'ወደ ወረፋ ታክሏል',
+      quickSingleOnly: 'ፈጣን አውርድ ለነጠላ ቪዲዮዎች ብቻ ነው። ለፕሌይሊስቶች እና ቻናሎች ቅርጸቶችን አምጣን ይጠቀሙ።',
+      quickProbeFailed: 'መፈተሹ አልተሳካም',
+      quickPrepareFailed: 'የወረፋ ንጥል ማዘጋጀት አልተቻለም',
+      quickFailed: 'ይህን ማከል አልተቻለም፦ {{error}}',
       features: {
         heading: 'Arroxy ምን ሊያወርድ ይችላል',
         youtube: {
@@ -234,7 +247,13 @@ const am = {
           sleepRequests: 'ምርምሮች መካከል መጠበቂያ',
           sleepInterval: 'ሚዲያ ከመጀመሩ በፊት እረፍት: ዝቅ.',
           maxSleepInterval: 'ሚዲያ ከመጀመሩ በፊት እረፍት: ከፍ.',
-          concurrentFragments: 'የዳውንሎድ ግንኙነቶች'
+          concurrentFragments: 'የዳውንሎድ ግንኙነቶች',
+          sleepSubtitles: 'ከንዑስ ጽሑፍ ፋይሎች በፊት ጠብቅ'
+        },
+        presetLabel: 'Arroxy ምን ያህል ጥንቃቄ ያድርግ?',
+        units: {
+          seconds: 'ሰከንድ',
+          threads: 'ክሮች'
         }
       },
       closeToTray: {
@@ -244,6 +263,15 @@ const am = {
       analytics: {
         toggle: 'ስም-አልባ የአጠቃቀም ስታቲስቲክስ ላክ',
         toggleDescription: 'የመተግበሪያ ማስጀመሪያዎችን ብቻ ይቆጥራል። ምንም URL፣ የፋይል ስሞች ወይም የግል መረጃ የለም።'
+      },
+      limitRate: {
+        label: 'የማውረድ ፍጥነት ገደብ',
+        description: 'ለሚዲያ ማውረዶች ባንድዊድዝ ይገድቡ። ከታች ያለው የጥያቄ እረፍት ብዙ ጊዜ የበለጠ ጠንካራ መቆጣጠሪያ ነው።',
+        off: 'ጠፍቷል',
+        custom: 'ብጁ…',
+        customPlaceholder: 'ለምሳሌ 750K ወይም 1.5M',
+        invalid: 'K ወይም M የሚከተለውን ቁጥር ይጠቀሙ (ለምሳሌ 500K, 1.5M)',
+        activeWarning: 'ንቁ ማውረዶች አሁን ያላቸውን ገደብ ይይዛሉ። ለማስፈጸም አቁም + ቀጥል።'
       }
     },
     subtitles: {
@@ -391,6 +419,10 @@ const am = {
       writeThumbnail: {
         label: 'ድንክ ምስል አስቀምጥ',
         description: 'ድንክ ምስሉን እንደ .jpg ምስል ፋይል ከዳውንሎዱ ጎን ያስቀምጣል።'
+      },
+      writeM3u: {
+        label: '.m3u playlist ፋይል ፍጠር',
+        description: 'ቪዲዮዎች በሚዲያ አጫዋች በቅደም ተከተል እንዲከፈቱ .m3u playlist ከእነሱ ጋር ያስቀምጣል።'
       }
     },
     confirm: {
@@ -445,8 +477,22 @@ const am = {
       hold: 'አቆይ',
       resume: 'ቀጥል',
       cancel: 'ሰርዝ',
-      remove: 'አስወግድ'
-    }
+      remove: 'አስወግድ',
+      pullNow: 'አሁን አውርድ — ወረፋን ዝለል',
+      priorityBadge: 'ቅድሚያ',
+      statusPending: 'በመጠበቅ ላይ',
+      statusRunning: 'በማውረድ ላይ',
+      statusHeld: 'ተይዟል',
+      statusPaused: 'ቆሟል',
+      statusDone: 'ተጠናቋል',
+      statusError: 'ስህተት',
+      statusCancelled: 'ተሰርዟል'
+    },
+    resumeAll: 'ወረፋ ቀጥል',
+    resumeAllTitle: 'የቆሙ ማውረዶችን ቀጥል እና ወረፋውን እንዲቀጥል ፍቀድ',
+    limitRate: 'ፍጥነት፦ {{value}}',
+    limitRateOff: 'ፍጥነት፦ ጠፍቷል',
+    limitRateTitle: 'ለማውረዶች የባንድዊድዝ ገደብ'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -534,24 +580,24 @@ const am = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'ለእያንዳንዱ ንጥል የሚገኝ ከፍተኛ codec',
+      mp4: 'H.264 + AAC ይመረጣል፣ MP4 ኮንቴነር · በተቻለ መጠን'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': 'እስከ 4K',
+      '1440': 'እስከ 1440p',
+      '1080': 'እስከ 1080p',
+      '720': 'እስከ 720p',
+      '480': 'እስከ 480p',
+      '360': 'እስከ 360p'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'ለእያንዳንዱ ንጥል ምርጥ ቪዲዮ + ድምጽ',
+      '2160': 'በ2160p ይገደባል፣ ለእያንዳንዱ ንጥል ዝቅ ይላል',
+      '1440': 'በ2K ይገደባል፣ ለእያንዳንዱ ንጥል ዝቅ ይላል',
+      '1080': 'በ1080p ይገደባል፣ ለእያንዳንዱ ንጥል ዝቅ ይላል',
+      '720': 'ትንሽ ፋይሎች፣ ሰፊ ተኳኋኝነት',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -562,13 +608,13 @@ const am = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'ምርጥ ነባር ድምጽ፣ ዳግም ኮድ አይደረግም',
+      mp3: 'ወደ MP3 ቀይር',
+      m4a: 'ወደ M4A (AAC) ቀይር',
+      opus: 'ወደ Opus ቀይር'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'H.264 ከ1080p በላይ በYouTube ላይ አይገኝም — በራስ-ሰር ወደ 1080p ይገደባል'
   },
   formatLabel: {
     audioFallback: 'ድምጽ',
@@ -591,7 +637,8 @@ const am = {
       message_other: '{{count}} ዳውንሎዶች እየሄዱ ናቸው',
       detail: 'መዝጋት ሁሉንም ዳውንሎዶች ይሰርዛል።',
       confirm: 'ዳውንሎዶችን ሰርዝ እና ዝጋ',
-      keep: 'ዳውንሎዱን ቀጥል'
+      keep: 'ዳውንሎዱን ቀጥል',
+      pause: 'ማውረዶችን አቁም እና ውጣ'
     },
     closeToTray: {
       message: 'Arroxy ሲዘጋ ወደ ትሬ ደብቅ?',

--- a/src/shared/i18n/locales/ar.ts
+++ b/src/shared/i18n/locales/ar.ts
@@ -122,13 +122,26 @@ const ar = {
       title: 'هذا الرابط يحتوي على Playlist',
       body: 'هل تريد الفيديو الذي اخترته فقط، أم تفضّل الاختيار من الـ Playlist؟ ستختار فيديوهات بعينها أو نطاقاً في الخطوة التالية.',
       singleVideo: 'هذا الواحد فقط',
-      pickFromPlaylist: 'اختر من الـ Playlist'
+      pickFromPlaylist: 'اختر من الـ Playlist',
+      playlistLimit: 'حد فحص قائمة التشغيل: {{count}} عنصرًا',
+      advancedSettings: 'إعدادات متقدمة',
+      singleTooltip: 'يستخدم وضع الفيديو المفرد في yt-dlp بحيث يتم تجاهل قائمة التشغيل المرتبطة بهذا الرابط.',
+      playlistTooltip: 'يستخدم وضع قائمة التشغيل في yt-dlp ويجلب العناصر حتى حد الفحص قبل عرض أداة الاختيار.'
     },
 
     url: {
       heading: 'رابط YouTube',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'جلب الصيغ',
+      fetchFormatsTooltip: 'اختر الصيغ والترجمات والمجلد وعناصر قوائم التشغيل خطوة بخطوة قبل الإضافة إلى قائمة الانتظار.',
+      quickDownload: 'تنزيل سريع',
+      quickDownloadTooltip: 'يستخدم تفضيلاتك المحفوظة أو الافتراضية ويضيف هذا الفيديو المفرد إلى قائمة الانتظار دون فتح خطوات الإعداد.',
+      quickPreparing: 'جارٍ التحضير',
+      quickQueued: 'تمت الإضافة إلى قائمة الانتظار',
+      quickSingleOnly: 'التنزيل السريع مخصص للفيديوهات المفردة فقط. استخدم جلب الصيغ لقوائم التشغيل والقنوات.',
+      quickProbeFailed: 'فشل الفحص',
+      quickPrepareFailed: 'تعذر تحضير عنصر قائمة الانتظار',
+      quickFailed: 'تعذرت إضافة هذا العنصر: {{error}}',
       features: {
         heading: 'ما الذي يستطيع Arroxy سحبه',
         youtube: {
@@ -234,7 +247,13 @@ const ar = {
           sleepRequests: 'انتظار بين فحوصات البيانات الوصفية',
           sleepInterval: 'توقف قبل بدء الوسائط: الحد الأدنى',
           maxSleepInterval: 'توقف قبل بدء الوسائط: الحد الأقصى',
-          concurrentFragments: 'اتصالات التنزيل'
+          concurrentFragments: 'اتصالات التنزيل',
+          sleepSubtitles: 'انتظار قبل ملفات الترجمة'
+        },
+        presetLabel: 'ما مدى حذر Arroxy؟',
+        units: {
+          seconds: 'ث',
+          threads: 'مسارات'
         }
       },
       closeToTray: {
@@ -244,6 +263,15 @@ const ar = {
       analytics: {
         toggle: 'إرسال إحصائيات الاستخدام المجهولة',
         toggleDescription: 'يحسب فقط مرات تشغيل التطبيق. بدون عناوين URL أو أسماء ملفات أو بيانات شخصية.'
+      },
+      limitRate: {
+        label: 'حد سرعة التنزيل',
+        description: 'يحد من النطاق الترددي لتنزيلات الوسائط. إيقاع الطلبات أدناه غالبًا هو أداة الحد الأقوى.',
+        off: 'إيقاف',
+        custom: 'مخصص…',
+        customPlaceholder: 'مثل 750K أو 1.5M',
+        invalid: 'استخدم رقمًا متبوعًا بـ K أو M (مثل 500K، 1.5M)',
+        activeWarning: 'التنزيلات النشطة تحتفظ بحدها الحالي. استخدم إيقاف مؤقت + استئناف لتطبيق التغييرات.'
       }
     },
     subtitles: {
@@ -391,6 +419,10 @@ const ar = {
       writeThumbnail: {
         label: 'حفظ الصورة المصغرة',
         description: 'يحفظ الصورة المصغرة كملف صورة .jpg بجانب التنزيل.'
+      },
+      writeM3u: {
+        label: 'إنشاء ملف قائمة تشغيل .m3u',
+        description: 'يحفظ قائمة .m3u بجانب الفيديوهات كي تفتح بالترتيب في مشغل الوسائط.'
       }
     },
     confirm: {
@@ -445,8 +477,22 @@ const ar = {
       hold: 'تأجيل',
       resume: 'استئناف',
       cancel: 'إلغاء',
-      remove: 'إزالة'
-    }
+      remove: 'إزالة',
+      pullNow: 'تنزيل الآن — تجاوز القائمة',
+      priorityBadge: 'أولوية',
+      statusPending: 'بانتظار',
+      statusRunning: 'جارٍ التنزيل',
+      statusHeld: 'معلّق',
+      statusPaused: 'متوقف مؤقتًا',
+      statusDone: 'تم',
+      statusError: 'خطأ',
+      statusCancelled: 'أُلغي'
+    },
+    resumeAll: 'استئناف القائمة',
+    resumeAllTitle: 'استئناف التنزيلات المتوقفة والسماح للقائمة بالمتابعة',
+    limitRate: 'السرعة: {{value}}',
+    limitRateOff: 'السرعة: إيقاف',
+    limitRateTitle: 'حد النطاق الترددي للتنزيلات'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -534,24 +580,24 @@ const ar = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'أعلى ترميز متاح لكل عنصر',
+      mp4: 'يفضّل H.264 + AAC، حاوية MP4 · أفضل محاولة'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': 'حتى 4K',
+      '1440': 'حتى 1440p',
+      '1080': 'حتى 1080p',
+      '720': 'حتى 720p',
+      '480': 'حتى 480p',
+      '360': 'حتى 360p'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'أفضل فيديو + صوت متاح لكل عنصر',
+      '2160': 'محدود عند 2160p ويهبط لكل عنصر عند الحاجة',
+      '1440': 'محدود عند 2K ويهبط لكل عنصر عند الحاجة',
+      '1080': 'محدود عند 1080p ويهبط لكل عنصر عند الحاجة',
+      '720': 'ملفات أصغر وتوافق واسع',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -562,13 +608,13 @@ const ar = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'أفضل صوت أصلي، بلا إعادة ترميز',
+      mp3: 'تحويل إلى MP3',
+      m4a: 'تحويل إلى M4A (AAC)',
+      opus: 'تحويل إلى Opus'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'H.264 أعلى من 1080p غير متاح على YouTube — يحد تلقائيًا إلى 1080p'
   },
   formatLabel: {
     audioFallback: 'صوت',
@@ -591,7 +637,8 @@ const ar = {
       message_other: '{{count}} تنزيلات قيد التقدم',
       detail: 'سيؤدي الإغلاق إلى إلغاء جميع التنزيلات النشطة.',
       confirm: 'إلغاء التنزيلات والخروج',
-      keep: 'الاستمرار في التنزيل'
+      keep: 'الاستمرار في التنزيل',
+      pause: 'إيقاف التنزيلات مؤقتًا والخروج'
     },
     closeToTray: {
       message: 'هل تريد إخفاء Arroxy في علبة النظام عند الإغلاق؟',

--- a/src/shared/i18n/locales/bn.ts
+++ b/src/shared/i18n/locales/bn.ts
@@ -122,13 +122,26 @@ const bn = {
       title: 'এই লিংকে একটি Playlist আছে',
       body: 'শুধু যে ভিডিওতে ক্লিক করেছিলেন সেটি চান, নাকি Playlist থেকে বেছে নিতে চান? পরে নির্দিষ্ট ভিডিও বা রেঞ্জ বেছে নেবেন।',
       singleVideo: 'শুধু এটি',
-      pickFromPlaylist: 'Playlist থেকে বেছে নিন'
+      pickFromPlaylist: 'Playlist থেকে বেছে নিন',
+      playlistLimit: 'প্লেলিস্ট প্রোব সীমা: {{count}}টি আইটেম',
+      advancedSettings: 'উন্নত সেটিংস',
+      singleTooltip: 'yt-dlp-এর একক-ভিডিও মোড ব্যবহার করে, তাই এই URL-এর সঙ্গে থাকা প্লেলিস্ট উপেক্ষা করা হয়।',
+      playlistTooltip: 'yt-dlp-এর প্লেলিস্ট মোড ব্যবহার করে এবং পিকার দেখানোর আগে আপনার সীমা পর্যন্ত আইটেম আনে।'
     },
 
     url: {
       heading: 'YouTube URL',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'ফরম্যাট আনুন',
+      fetchFormatsTooltip: 'কিউতে যোগ করার আগে ধাপে ধাপে ফরম্যাট, সাবটাইটেল, ফোল্ডার এবং প্লেলিস্ট আইটেম বেছে নিন।',
+      quickDownload: 'দ্রুত ডাউনলোড',
+      quickDownloadTooltip: 'সেভ করা বা ডিফল্ট পছন্দ ব্যবহার করে সেটআপ ধাপ না খুলেই এই একক ভিডিওটি কিউতে যোগ করে।',
+      quickPreparing: 'প্রস্তুত হচ্ছে',
+      quickQueued: 'কিউতে যোগ করা হয়েছে',
+      quickSingleOnly: 'দ্রুত ডাউনলোড শুধু একক ভিডিওর জন্য। প্লেলিস্ট ও চ্যানেলের জন্য ফরম্যাট আনুন ব্যবহার করুন।',
+      quickProbeFailed: 'প্রোব ব্যর্থ হয়েছে',
+      quickPrepareFailed: 'কিউ আইটেম প্রস্তুত করা যায়নি',
+      quickFailed: 'এটি যোগ করা যায়নি: {{error}}',
       features: {
         heading: 'Arroxy যা নামাতে পারে',
         youtube: {
@@ -250,6 +263,15 @@ const bn = {
       analytics: {
         toggle: 'বেনামী ব্যবহার পরিসংখ্যান পাঠান',
         toggleDescription: 'শুধুমাত্র অ্যাপ চালু হওয়ার সংখ্যা গণনা করে। কোনো URL, ফাইলের নাম বা ব্যক্তিগত তথ্য নেই।'
+      },
+      limitRate: {
+        label: 'ডাউনলোড গতিসীমা',
+        description: 'মিডিয়া ডাউনলোডের ব্যান্ডউইথ সীমিত করুন। নিচের রিকোয়েস্ট পেসিং সাধারণত আরও শক্তিশালী সীমা-নিয়ন্ত্রণ।',
+        off: 'বন্ধ',
+        custom: 'কাস্টম…',
+        customPlaceholder: 'যেমন 750K বা 1.5M',
+        invalid: 'K বা M সহ একটি সংখ্যা দিন (যেমন 500K, 1.5M)',
+        activeWarning: 'চলমান ডাউনলোড বর্তমান সীমা রাখে। প্রয়োগ করতে বিরতি + পুনরায় শুরু করুন।'
       }
     },
     subtitles: {
@@ -397,6 +419,10 @@ const bn = {
       writeThumbnail: {
         label: 'থাম্বনেইল সেভ করুন',
         description: 'থাম্বনেইল ডাউনলোডের পাশে .jpg ইমেজ ফাইল হিসেবে সেভ করে।'
+      },
+      writeM3u: {
+        label: '.m3u প্লেলিস্ট ফাইল তৈরি করুন',
+        description: 'ভিডিওগুলোর পাশে .m3u প্লেলিস্ট সংরক্ষণ করে যাতে মিডিয়া প্লেয়ারে ক্রম অনুযায়ী খোলে।'
       }
     },
     confirm: {
@@ -451,8 +477,22 @@ const bn = {
       hold: 'মুলতুবি',
       resume: 'চালিয়ে যান',
       cancel: 'বাতিল',
-      remove: 'সরান'
-    }
+      remove: 'সরান',
+      pullNow: 'এখন ডাউনলোড — কিউ এড়িয়ে যান',
+      priorityBadge: 'অগ্রাধিকার',
+      statusPending: 'অপেক্ষায়',
+      statusRunning: 'ডাউনলোড হচ্ছে',
+      statusHeld: 'ধরে রাখা',
+      statusPaused: 'বিরত',
+      statusDone: 'সম্পন্ন',
+      statusError: 'ত্রুটি',
+      statusCancelled: 'বাতিল'
+    },
+    resumeAll: 'কিউ পুনরায় শুরু করুন',
+    resumeAllTitle: 'বিরত ডাউনলোড চালু করে কিউ চলতে দিন',
+    limitRate: 'গতি: {{value}}',
+    limitRateOff: 'গতি: বন্ধ',
+    limitRateTitle: 'ডাউনলোডের ব্যান্ডউইথ সীমা'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -540,24 +580,24 @@ const bn = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'প্রতি আইটেমে সর্বোচ্চ উপলব্ধ কোডেক',
+      mp4: 'H.264 + AAC পছন্দ, MP4 কনটেইনার · সর্বোত্তম চেষ্টা'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': '৪K পর্যন্ত',
+      '1440': '১৪৪০p পর্যন্ত',
+      '1080': '১০৮০p পর্যন্ত',
+      '720': '৭২০p পর্যন্ত',
+      '480': '৪৮০p পর্যন্ত',
+      '360': '৩৬০p পর্যন্ত'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'প্রতি আইটেমে সেরা ভিডিও + অডিও',
+      '2160': '২১৬০p-তে সীমিত, প্রতি আইটেমে প্রয়োজনে কমে',
+      '1440': '২K-তে সীমিত, প্রতি আইটেমে প্রয়োজনে কমে',
+      '1080': '১০৮০p-তে সীমিত, প্রতি আইটেমে প্রয়োজনে কমে',
+      '720': 'ছোট ফাইল, বিস্তৃত সামঞ্জস্য',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -568,13 +608,13 @@ const bn = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'সেরা নেটিভ অডিও, পুনরায় encode নয়',
+      mp3: 'MP3-তে রূপান্তর',
+      m4a: 'M4A (AAC)-তে রূপান্তর',
+      opus: 'Opus-এ রূপান্তর'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'YouTube-এ ১০৮০p-এর ওপরে H.264 নেই — স্বয়ংক্রিয়ভাবে ১০৮০p-তে সীমিত'
   },
   formatLabel: {
     audioFallback: 'অডিও',
@@ -597,7 +637,8 @@ const bn = {
       message_other: '{{count}}টি ডাউনলোড চলছে',
       detail: 'বন্ধ করলে সমস্ত সক্রিয় ডাউনলোড বাতিল হয়ে যাবে।',
       confirm: 'ডাউনলোড বাতিল করুন ও বন্ধ করুন',
-      keep: 'ডাউনলোড চালিয়ে যান'
+      keep: 'ডাউনলোড চালিয়ে যান',
+      pause: 'ডাউনলোড বিরতি দিয়ে বের হন'
     },
     closeToTray: {
       message: 'বন্ধ করার সময় Arroxy সিস্টেম ট্রেতে লুকাবে?',

--- a/src/shared/i18n/locales/de.ts
+++ b/src/shared/i18n/locales/de.ts
@@ -122,13 +122,26 @@ const de = {
       title: 'Dieser Link enthält eine Playlist',
       body: 'Nur das angeklickte Video oder aus der Playlist auswählen? Im nächsten Schritt kannst du einzelne Videos oder einen Bereich festlegen.',
       singleVideo: 'Nur dieses eine',
-      pickFromPlaylist: 'Aus Playlist auswählen'
+      pickFromPlaylist: 'Aus Playlist auswählen',
+      playlistLimit: 'Playlist-Prüflimit: {{count}} Einträge',
+      advancedSettings: 'Erweiterte Einstellungen',
+      singleTooltip: 'Verwendet den Einzelvideo-Modus von yt-dlp, sodass die an diese URL angehängte Playlist ignoriert wird.',
+      playlistTooltip: 'Verwendet den Playlist-Modus von yt-dlp und lädt bis zu deinem Playlist-Prüflimit, bevor die Auswahl angezeigt wird.'
     },
 
     url: {
       heading: 'YouTube-URL',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'Formate abrufen',
+      fetchFormatsTooltip: 'Formate, Untertitel, Ordner und Playlist-Elemente Schritt für Schritt auswählen, bevor sie zur Warteschlange hinzugefügt werden.',
+      quickDownload: 'Schnelldownload',
+      quickDownloadTooltip: 'Verwendet deine gespeicherten oder Standard-Einstellungen und fügt dieses einzelne Video zur Warteschlange hinzu, ohne die Einrichtungsschritte zu öffnen.',
+      quickPreparing: 'Wird vorbereitet',
+      quickQueued: 'Zur Warteschlange hinzugefügt',
+      quickSingleOnly: 'Schnelldownload ist nur für einzelne Videos gedacht. Nutze Formate abrufen für Playlists und Kanäle.',
+      quickProbeFailed: 'Prüfung fehlgeschlagen',
+      quickPrepareFailed: 'Warteschlangeneintrag konnte nicht vorbereitet werden',
+      quickFailed: 'Konnte dieses Element nicht hinzufügen: {{error}}',
       features: {
         heading: 'Was Arroxy laden kann',
         youtube: {
@@ -250,6 +263,15 @@ const de = {
       analytics: {
         toggle: 'Anonyme Nutzungsstatistiken senden',
         toggleDescription: 'Zählt nur App-Starts. Keine URLs, Dateinamen oder persönliche Daten.'
+      },
+      limitRate: {
+        label: 'Download-Geschwindigkeitslimit',
+        description: 'Begrenzt die Bandbreite für Mediendownloads. Die Anfrage-Pausen darunter sind meist der stärkere Hebel gegen Limits.',
+        off: 'Aus',
+        custom: 'Benutzerdefiniert…',
+        customPlaceholder: 'z. B. 750K oder 1.5M',
+        invalid: 'Nutze eine Zahl mit K oder M (z. B. 500K, 1.5M)',
+        activeWarning: 'Aktive Downloads behalten ihr aktuelles Limit. Pausieren + Fortsetzen wendet Änderungen an.'
       }
     },
     subtitles: {
@@ -397,6 +419,10 @@ const de = {
       writeThumbnail: {
         label: 'Thumbnail speichern',
         description: 'Speichert das Thumbnail als .jpg-Bilddatei neben dem Download.'
+      },
+      writeM3u: {
+        label: '.m3u-Playlistdatei erstellen',
+        description: 'Speichert eine .m3u-Playlist neben den Videos, damit sie in Reihenfolge im Mediaplayer geöffnet werden.'
       }
     },
     confirm: {
@@ -451,8 +477,22 @@ const de = {
       hold: 'Zurückhalten',
       resume: 'Fortsetzen',
       cancel: 'Abbrechen',
-      remove: 'Entfernen'
-    }
+      remove: 'Entfernen',
+      pullNow: 'Jetzt starten — Warteschlange überspringen',
+      priorityBadge: 'Priorität',
+      statusPending: 'Wartet',
+      statusRunning: 'Lädt herunter',
+      statusHeld: 'Zurückgehalten',
+      statusPaused: 'Pausiert',
+      statusDone: 'Fertig',
+      statusError: 'Fehler',
+      statusCancelled: 'Abgebrochen'
+    },
+    resumeAll: 'Warteschlange fortsetzen',
+    resumeAllTitle: 'Pausierte Downloads fortsetzen und die Warteschlange weiterlaufen lassen',
+    limitRate: 'Tempo: {{value}}',
+    limitRateOff: 'Tempo: Aus',
+    limitRateTitle: 'Bandbreitenlimit für Downloads'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -540,24 +580,24 @@ const de = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'Höchster verfügbarer Codec pro Eintrag',
+      mp4: 'H.264 + AAC bevorzugt, MP4-Container · bestmöglich'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': 'Bis 4K',
+      '1440': 'Bis 1440p',
+      '1080': 'Bis 1080p',
+      '720': 'Bis 720p',
+      '480': 'Bis 480p',
+      '360': 'Bis 360p'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'Höchstes verfügbares Video + Audio pro Eintrag',
+      '2160': 'Auf 2160p begrenzt, fällt pro Eintrag niedriger aus',
+      '1440': 'Auf 2K begrenzt, fällt pro Eintrag niedriger aus',
+      '1080': 'Auf 1080p begrenzt, fällt pro Eintrag niedriger aus',
+      '720': 'Kleinere Dateien, breite Kompatibilität',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -568,13 +608,13 @@ const de = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'Bestes natives Audio, keine Neukodierung',
+      mp3: 'In MP3 umwandeln',
+      m4a: 'In M4A (AAC) umwandeln',
+      opus: 'In Opus umwandeln'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'H.264 über 1080p ist auf YouTube nicht verfügbar — automatisch auf 1080p begrenzt'
   },
   formatLabel: {
     audioFallback: 'Audio',
@@ -597,7 +637,8 @@ const de = {
       message_other: '{{count}} Downloads laufen',
       detail: 'Beim Schließen werden alle aktiven Downloads abgebrochen.',
       confirm: 'Downloads abbrechen & beenden',
-      keep: 'Weiter herunterladen'
+      keep: 'Weiter herunterladen',
+      pause: 'Downloads pausieren & beenden'
     },
     closeToTray: {
       message: 'Arroxy beim Schließen in den Infobereich minimieren?',

--- a/src/shared/i18n/locales/el.ts
+++ b/src/shared/i18n/locales/el.ts
@@ -122,13 +122,26 @@ const el = {
       title: 'Αυτός ο σύνδεσμος έχει playlist',
       body: 'Θέλεις μόνο το βίντεο που έκανες κλικ, ή να επιλέξεις από την playlist; Θα διαλέξεις συγκεκριμένα βίντεο ή εύρος στη συνέχεια.',
       singleVideo: 'Μόνο αυτό',
-      pickFromPlaylist: 'Επιλογή από την playlist'
+      pickFromPlaylist: 'Επιλογή από την playlist',
+      playlistLimit: 'Όριο ελέγχου playlist: {{count}} στοιχεία',
+      advancedSettings: 'Σύνθετες ρυθμίσεις',
+      singleTooltip: 'Χρησιμοποιεί τη λειτουργία μεμονωμένου βίντεο του yt-dlp ώστε να αγνοηθεί η playlist που είναι συνδεδεμένη με αυτό το URL.',
+      playlistTooltip: 'Χρησιμοποιεί τη λειτουργία playlist του yt-dlp και ανακτά μέχρι το όριό σου πριν εμφανίσει τον επιλογέα.'
     },
 
     url: {
       heading: 'YouTube URL',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'Φόρτωση μορφών',
+      fetchFormatsTooltip: 'Επίλεξε μορφές, υπότιτλους, φάκελο και στοιχεία playlist βήμα προς βήμα πριν μπουν στην ουρά.',
+      quickDownload: 'Γρήγορη λήψη',
+      quickDownloadTooltip: 'Χρησιμοποιεί τις αποθηκευμένες ή προεπιλεγμένες προτιμήσεις σου και προσθέτει αυτό το μεμονωμένο βίντεο στην ουρά χωρίς τα βήματα ρύθμισης.',
+      quickPreparing: 'Προετοιμασία',
+      quickQueued: 'Προστέθηκε στην ουρά',
+      quickSingleOnly: 'Η γρήγορη λήψη είναι μόνο για μεμονωμένα βίντεο. Χρησιμοποίησε την ανάκτηση μορφών για playlist και κανάλια.',
+      quickProbeFailed: 'Ο έλεγχος απέτυχε',
+      quickPrepareFailed: 'Δεν ήταν δυνατή η προετοιμασία του στοιχείου ουράς',
+      quickFailed: 'Δεν ήταν δυνατή η προσθήκη: {{error}}',
       features: {
         heading: 'Τι μπορεί να κατεβάσει το Arroxy',
         youtube: {
@@ -250,6 +263,15 @@ const el = {
       analytics: {
         toggle: 'Αποστολή ανώνυμων στατιστικών χρήσης',
         toggleDescription: 'Μετράει μόνο εκκινήσεις εφαρμογής. Χωρίς URL, ονόματα αρχείων ή προσωπικά δεδομένα.'
+      },
+      limitRate: {
+        label: 'Όριο ταχύτητας λήψης',
+        description: 'Περιόρισε το bandwidth για λήψεις πολυμέσων. Ο ρυθμός αιτημάτων παρακάτω είναι συνήθως ισχυρότερος μοχλός ορίων.',
+        off: 'Ανενεργό',
+        custom: 'Προσαρμογή…',
+        customPlaceholder: 'π.χ. 750K ή 1.5M',
+        invalid: 'Χρησιμοποίησε αριθμό με K ή M (π.χ. 500K, 1.5M)',
+        activeWarning: 'Οι ενεργές λήψεις κρατούν το τρέχον όριο. Παύση + Συνέχεια για εφαρμογή αλλαγών.'
       }
     },
     subtitles: {
@@ -397,6 +419,10 @@ const el = {
       writeThumbnail: {
         label: 'Αποθήκευση μικρογραφίας',
         description: 'Αποθηκεύει τη μικρογραφία ως αρχείο εικόνας .jpg δίπλα στη λήψη.'
+      },
+      writeM3u: {
+        label: 'Δημιουργία αρχείου playlist .m3u',
+        description: 'Αποθηκεύει μια playlist .m3u δίπλα στα βίντεο ώστε να ανοίγουν με σειρά στο media player.'
       }
     },
     confirm: {
@@ -451,8 +477,22 @@ const el = {
       hold: 'Αναμονή',
       resume: 'Συνέχεια',
       cancel: 'Ακύρωση',
-      remove: 'Κατάργηση'
-    }
+      remove: 'Κατάργηση',
+      pullNow: 'Λήψη τώρα — παράκαμψη ουράς',
+      priorityBadge: 'Προτεραιότητα',
+      statusPending: 'Αναμονή',
+      statusRunning: 'Λήψη',
+      statusHeld: 'Σε κράτηση',
+      statusPaused: 'Σε παύση',
+      statusDone: 'Ολοκληρώθηκε',
+      statusError: 'Σφάλμα',
+      statusCancelled: 'Ακυρώθηκε'
+    },
+    resumeAll: 'Συνέχιση ουράς',
+    resumeAllTitle: 'Συνέχισε τις λήψεις σε παύση και άφησε την ουρά να προχωρήσει',
+    limitRate: 'Ταχύτητα: {{value}}',
+    limitRateOff: 'Ταχύτητα: Ανενεργή',
+    limitRateTitle: 'Όριο bandwidth για λήψεις'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -540,24 +580,24 @@ const el = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'Υψηλότερος διαθέσιμος codec ανά στοιχείο',
+      mp4: 'Προτιμάται H.264 + AAC, κοντέινερ MP4 · βέλτιστη προσπάθεια'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': 'Έως 4K',
+      '1440': 'Έως 1440p',
+      '1080': 'Έως 1080p',
+      '720': 'Έως 720p',
+      '480': 'Έως 480p',
+      '360': 'Έως 360p'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'Καλύτερο διαθέσιμο βίντεο + ήχος ανά στοιχείο',
+      '2160': 'Περιορισμός στα 2160p, πέφτει ανά στοιχείο αν χρειαστεί',
+      '1440': 'Περιορισμός στα 2K, πέφτει ανά στοιχείο αν χρειαστεί',
+      '1080': 'Περιορισμός στα 1080p, πέφτει ανά στοιχείο αν χρειαστεί',
+      '720': 'Μικρότερα αρχεία, ευρεία συμβατότητα',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -568,13 +608,13 @@ const el = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'Καλύτερος εγγενής ήχος, χωρίς επανακωδικοποίηση',
+      mp3: 'Μετατροπή σε MP3',
+      m4a: 'Μετατροπή σε M4A (AAC)',
+      opus: 'Μετατροπή σε Opus'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'Το H.264 πάνω από 1080p δεν είναι διαθέσιμο στο YouTube — περιορίζεται αυτόματα στα 1080p'
   },
   formatLabel: {
     audioFallback: 'Ήχος',
@@ -597,7 +637,8 @@ const el = {
       message_other: '{{count}} λήψεις σε εξέλιξη',
       detail: 'Το κλείσιμο θα ακυρώσει όλες τις ενεργές λήψεις.',
       confirm: 'Ακύρωση λήψεων & Έξοδος',
-      keep: 'Συνέχεια λήψεων'
+      keep: 'Συνέχεια λήψεων',
+      pause: 'Παύση λήψεων και έξοδος'
     },
     closeToTray: {
       message: 'Απόκρυψη Arroxy στο δίσκο συστήματος κατά το κλείσιμο;',

--- a/src/shared/i18n/locales/en.ts
+++ b/src/shared/i18n/locales/en.ts
@@ -132,6 +132,15 @@ const en = {
       heading: 'Video URL',
       placeholder: 'https://...',
       fetchFormats: 'Fetch formats',
+      fetchFormatsTooltip: 'Choose formats, subtitles, folder, and playlist items step by step before queueing.',
+      quickDownload: 'Quick download',
+      quickDownloadTooltip: 'Uses your saved or default preferences and adds this single video to the queue without opening the setup steps.',
+      quickPreparing: 'Preparing',
+      quickQueued: 'Added to queue',
+      quickSingleOnly: 'Quick download is for single videos. Use Fetch formats for playlists and channels.',
+      quickProbeFailed: 'Probe failed',
+      quickPrepareFailed: 'Queue item could not be prepared',
+      quickFailed: "Couldn't add this one: {{error}}",
       features: {
         heading: 'What Arroxy can pull',
         youtube: {

--- a/src/shared/i18n/locales/es.ts
+++ b/src/shared/i18n/locales/es.ts
@@ -122,12 +122,25 @@ const es = {
       title: 'Este enlace tiene una Playlist',
       body: '¿Solo el video en el que hiciste clic o prefieres elegir de la Playlist? En el siguiente paso podrás seleccionar videos concretos o un rango.',
       singleVideo: 'Solo este',
-      pickFromPlaylist: 'Elegir de la Playlist'
+      pickFromPlaylist: 'Elegir de la Playlist',
+      playlistLimit: 'Límite de análisis de playlist: {{count}} elementos',
+      advancedSettings: 'Ajustes avanzados',
+      singleTooltip: 'Usa el modo de vídeo único de yt-dlp para ignorar la playlist adjunta a esta URL.',
+      playlistTooltip: 'Usa el modo playlist de yt-dlp y carga hasta tu límite de análisis antes de mostrar el selector.'
     },
     url: {
       heading: 'URL de YouTube',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'Obtener formatos',
+      fetchFormatsTooltip: 'Elige formatos, subtítulos, carpeta y elementos de playlist paso a paso antes de enviar a la cola.',
+      quickDownload: 'Descarga rápida',
+      quickDownloadTooltip: 'Usa tus preferencias guardadas o predeterminadas y añade este video individual a la cola sin abrir los pasos de configuración.',
+      quickPreparing: 'Preparando',
+      quickQueued: 'Añadido a la cola',
+      quickSingleOnly: 'La descarga rápida es solo para videos individuales. Usa Obtener formatos para playlists y canales.',
+      quickProbeFailed: 'Falló el análisis',
+      quickPrepareFailed: 'No se pudo preparar el elemento de la cola',
+      quickFailed: 'No se pudo añadir: {{error}}',
       features: {
         heading: 'Qué puede bajar Arroxy',
         youtube: {
@@ -249,6 +262,15 @@ const es = {
       analytics: {
         toggle: 'Enviar estadísticas de uso anónimas',
         toggleDescription: 'Solo cuenta los inicios de la app. Sin URLs, nombres de archivo ni datos personales.'
+      },
+      limitRate: {
+        label: 'Límite de velocidad de descarga',
+        description: 'Limita el ancho de banda de las descargas multimedia. El ritmo de solicitudes de abajo suele ser el control más fuerte.',
+        off: 'Desactivado',
+        custom: 'Personalizado…',
+        customPlaceholder: 'p. ej. 750K o 1.5M',
+        invalid: 'Usa un número seguido de K o M (p. ej. 500K, 1.5M)',
+        activeWarning: 'Las descargas activas conservan su límite actual. Pausa + Reanuda para aplicar cambios.'
       }
     },
     subtitles: {
@@ -396,6 +418,10 @@ const es = {
       writeThumbnail: {
         label: 'Guardar miniatura',
         description: 'Guarda la miniatura como archivo .jpg junto a la descarga.'
+      },
+      writeM3u: {
+        label: 'Generar archivo de playlist .m3u',
+        description: 'Guarda una playlist .m3u junto a los vídeos para abrirlos en orden en tu reproductor.'
       }
     },
     confirm: {
@@ -450,8 +476,22 @@ const es = {
       hold: 'Retener',
       resume: 'Reanudar',
       cancel: 'Cancelar',
-      remove: 'Quitar'
-    }
+      remove: 'Quitar',
+      pullNow: 'Descargar ahora — saltar la cola',
+      priorityBadge: 'Prioridad',
+      statusPending: 'Esperando',
+      statusRunning: 'Descargando',
+      statusHeld: 'Retenido',
+      statusPaused: 'Pausado',
+      statusDone: 'Listo',
+      statusError: 'Error',
+      statusCancelled: 'Cancelado'
+    },
+    resumeAll: 'Reanudar cola',
+    resumeAllTitle: 'Reanudar descargas pausadas y dejar que la cola continúe',
+    limitRate: 'Velocidad: {{value}}',
+    limitRateOff: 'Velocidad: desactivada',
+    limitRateTitle: 'Límite de ancho de banda para descargas'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -539,24 +579,24 @@ const es = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'Códec más alto disponible por elemento',
+      mp4: 'H.264 + AAC preferido, contenedor MP4 · mejor esfuerzo'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': 'Hasta 4K',
+      '1440': 'Hasta 1440p',
+      '1080': 'Hasta 1080p',
+      '720': 'Hasta 720p',
+      '480': 'Hasta 480p',
+      '360': 'Hasta 360p'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'Mejor vídeo + audio disponible por elemento',
+      '2160': 'Limitado a 2160p, baja por elemento si hace falta',
+      '1440': 'Limitado a 2K, baja por elemento si hace falta',
+      '1080': 'Limitado a 1080p, baja por elemento si hace falta',
+      '720': 'Archivos más pequeños, amplia compatibilidad',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -567,13 +607,13 @@ const es = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'Mejor audio nativo, sin recodificar',
+      mp3: 'Convertir a MP3',
+      m4a: 'Convertir a M4A (AAC)',
+      opus: 'Convertir a Opus'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'H.264 por encima de 1080p no está disponible en YouTube — se limita automáticamente a 1080p'
   },
   formatLabel: {
     audioFallback: 'Audio',
@@ -596,7 +636,8 @@ const es = {
       message_other: '{{count}} descargas en curso',
       detail: 'Cerrar cancelará todas las descargas activas.',
       confirm: 'Cancelar descargas y salir',
-      keep: 'Seguir descargando'
+      keep: 'Seguir descargando',
+      pause: 'Pausar descargas y salir'
     },
     closeToTray: {
       message: '¿Ocultar Arroxy en la bandeja del sistema al cerrar?',

--- a/src/shared/i18n/locales/fr.ts
+++ b/src/shared/i18n/locales/fr.ts
@@ -122,13 +122,26 @@ const fr = {
       title: 'Ce lien contient une Playlist',
       body: "Seulement la vidéo sur laquelle tu as cliqué, ou tu préfères choisir dans la Playlist ? Tu pourras sélectionner des vidéos précises ou une plage à l'étape suivante.",
       singleVideo: 'Juste celle-ci',
-      pickFromPlaylist: 'Choisir dans la Playlist'
+      pickFromPlaylist: 'Choisir dans la Playlist',
+      playlistLimit: 'Limite d’analyse de playlist : {{count}} éléments',
+      advancedSettings: 'Paramètres avancés',
+      singleTooltip: 'Utilise le mode vidéo seule de yt-dlp afin d’ignorer la playlist attachée à cette URL.',
+      playlistTooltip: 'Utilise le mode playlist de yt-dlp et récupère jusqu’à votre limite avant d’afficher le sélecteur.'
     },
 
     url: {
       heading: 'URL YouTube',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'Récupérer les formats',
+      fetchFormatsTooltip: 'Choisissez les formats, sous-titres, dossier et éléments de playlist étape par étape avant l’ajout à la file.',
+      quickDownload: 'Téléchargement rapide',
+      quickDownloadTooltip: 'Utilise vos préférences enregistrées ou par défaut et ajoute cette vidéo seule à la file sans ouvrir les étapes de configuration.',
+      quickPreparing: 'Préparation',
+      quickQueued: 'Ajouté à la file',
+      quickSingleOnly: 'Le téléchargement rapide est réservé aux vidéos seules. Utilisez Récupérer les formats pour les playlists et les chaînes.',
+      quickProbeFailed: 'Analyse échouée',
+      quickPrepareFailed: 'Impossible de préparer l’élément de file',
+      quickFailed: 'Impossible d’ajouter cet élément : {{error}}',
       features: {
         heading: "Ce qu'Arroxy peut récupérer",
         youtube: {
@@ -250,6 +263,15 @@ const fr = {
       analytics: {
         toggle: "Envoyer des statistiques d'utilisation anonymes",
         toggleDescription: "Compte uniquement les lancements de l'application. Aucune URL, nom de fichier ou donnée personnelle."
+      },
+      limitRate: {
+        label: 'Limite de vitesse de téléchargement',
+        description: 'Limite la bande passante des téléchargements média. Le rythme des requêtes ci-dessous est souvent le levier le plus fort.',
+        off: 'Désactivé',
+        custom: 'Personnalisé…',
+        customPlaceholder: 'ex. 750K ou 1.5M',
+        invalid: 'Utilisez un nombre suivi de K ou M (ex. 500K, 1.5M)',
+        activeWarning: 'Les téléchargements actifs gardent leur limite actuelle. Pause + Reprendre pour appliquer.'
       }
     },
     subtitles: {
@@ -397,6 +419,10 @@ const fr = {
       writeThumbnail: {
         label: 'Enregistrer la miniature',
         description: 'Enregistre la miniature en fichier .jpg à côté du téléchargement.'
+      },
+      writeM3u: {
+        label: 'Générer un fichier playlist .m3u',
+        description: 'Enregistre une playlist .m3u à côté des vidéos pour les ouvrir dans l’ordre dans votre lecteur.'
       }
     },
     confirm: {
@@ -451,8 +477,22 @@ const fr = {
       hold: 'En attente',
       resume: 'Reprendre',
       cancel: 'Annuler',
-      remove: 'Supprimer'
-    }
+      remove: 'Supprimer',
+      pullNow: 'Télécharger maintenant — ignorer la file',
+      priorityBadge: 'Priorité',
+      statusPending: 'En attente',
+      statusRunning: 'Téléchargement',
+      statusHeld: 'Retenu',
+      statusPaused: 'En pause',
+      statusDone: 'Terminé',
+      statusError: 'Erreur',
+      statusCancelled: 'Annulé'
+    },
+    resumeAll: 'Reprendre la file',
+    resumeAllTitle: 'Reprendre les téléchargements en pause et laisser la file continuer',
+    limitRate: 'Vitesse : {{value}}',
+    limitRateOff: 'Vitesse : désactivée',
+    limitRateTitle: 'Limite de bande passante des téléchargements'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -540,24 +580,24 @@ const fr = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'Codec le plus élevé disponible par élément',
+      mp4: 'H.264 + AAC privilégiés, conteneur MP4 · au mieux'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': 'Jusqu’à 4K',
+      '1440': 'Jusqu’à 1440p',
+      '1080': 'Jusqu’à 1080p',
+      '720': 'Jusqu’à 720p',
+      '480': 'Jusqu’à 480p',
+      '360': 'Jusqu’à 360p'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'Meilleurs vidéo + audio disponibles par élément',
+      '2160': 'Limité à 2160p, baisse par élément si nécessaire',
+      '1440': 'Limité à 2K, baisse par élément si nécessaire',
+      '1080': 'Limité à 1080p, baisse par élément si nécessaire',
+      '720': 'Fichiers plus petits, large compatibilité',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -568,13 +608,13 @@ const fr = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'Meilleur audio natif, sans réencodage',
+      mp3: 'Convertir en MP3',
+      m4a: 'Convertir en M4A (AAC)',
+      opus: 'Convertir en Opus'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'H.264 au-dessus de 1080p n’est pas disponible sur YouTube — limité automatiquement à 1080p'
   },
   formatLabel: {
     audioFallback: 'Audio',
@@ -597,7 +637,8 @@ const fr = {
       message_other: '{{count}} téléchargements en cours',
       detail: 'La fermeture annulera tous les téléchargements actifs.',
       confirm: 'Annuler et quitter',
-      keep: 'Continuer le téléchargement'
+      keep: 'Continuer le téléchargement',
+      pause: 'Mettre en pause et quitter'
     },
     closeToTray: {
       message: 'Masquer Arroxy dans la barre des tâches lors de la fermeture ?',

--- a/src/shared/i18n/locales/hi.ts
+++ b/src/shared/i18n/locales/hi.ts
@@ -122,13 +122,26 @@ const hi = {
       title: 'इस लिंक में एक Playlist है',
       body: 'सिर्फ़ वही वीडियो चाहिए जिस पर क्लिक किया था, या Playlist में से चुनना है? आगे आप विशेष वीडियो या रेंज चुन सकते हैं।',
       singleVideo: 'बस यही एक',
-      pickFromPlaylist: 'Playlist में से चुनें'
+      pickFromPlaylist: 'Playlist में से चुनें',
+      playlistLimit: 'प्लेलिस्ट जाँच सीमा: {{count}} आइटम',
+      advancedSettings: 'उन्नत सेटिंग्स',
+      singleTooltip: 'yt-dlp का एकल-वीडियो मोड उपयोग करता है ताकि इस URL से जुड़ी प्लेलिस्ट अनदेखी हो।',
+      playlistTooltip: 'yt-dlp का प्लेलिस्ट मोड उपयोग करता है और पिकर दिखाने से पहले आपकी सीमा तक आइटम लाता है।'
     },
 
     url: {
       heading: 'YouTube URL',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'फ़ॉर्मेट लाएँ',
+      fetchFormatsTooltip: 'क्यू में जोड़ने से पहले फॉर्मैट, सबटाइटल, फ़ोल्डर और प्लेलिस्ट आइटम चरण-दर-चरण चुनें।',
+      quickDownload: 'त्वरित डाउनलोड',
+      quickDownloadTooltip: 'आपकी सेव की गई या डिफ़ॉल्ट पसंदों का उपयोग करके सेटअप चरण खोले बिना इस एकल वीडियो को क्यू में जोड़ता है।',
+      quickPreparing: 'तैयार हो रहा है',
+      quickQueued: 'क्यू में जोड़ दिया गया',
+      quickSingleOnly: 'त्वरित डाउनलोड केवल एकल वीडियो के लिए है। प्लेलिस्ट और चैनलों के लिए फॉर्मैट लाएँ का उपयोग करें।',
+      quickProbeFailed: 'जाँच विफल रही',
+      quickPrepareFailed: 'क्यू आइटम तैयार नहीं किया जा सका',
+      quickFailed: 'इसे जोड़ा नहीं जा सका: {{error}}',
       features: {
         heading: 'Arroxy क्या डाउनलोड कर सकता है',
         youtube: {
@@ -250,6 +263,15 @@ const hi = {
       analytics: {
         toggle: 'अनाम उपयोग आँकड़े भेजें',
         toggleDescription: 'केवल ऐप लॉन्च गिनता है। कोई URL, फ़ाइलनाम या व्यक्तिगत डेटा नहीं।'
+      },
+      limitRate: {
+        label: 'डाउनलोड गति सीमा',
+        description: 'मीडिया डाउनलोड के लिए बैंडविड्थ सीमित करें। नीचे की अनुरोध गति अक्सर अधिक मजबूत सीमा नियंत्रण है।',
+        off: 'बंद',
+        custom: 'कस्टम…',
+        customPlaceholder: 'जैसे 750K या 1.5M',
+        invalid: 'K या M के बाद वाली संख्या दें (जैसे 500K, 1.5M)',
+        activeWarning: 'चल रहे डाउनलोड अपनी मौजूदा सीमा रखते हैं। लागू करने के लिए विराम + फिर शुरू करें।'
       }
     },
     subtitles: {
@@ -397,6 +419,10 @@ const hi = {
       writeThumbnail: {
         label: 'थंबनेल सहेजें',
         description: 'थंबनेल को डाउनलोड के पास .jpg छवि फ़ाइल के रूप में सहेजता है।'
+      },
+      writeM3u: {
+        label: '.m3u प्लेलिस्ट फ़ाइल बनाएँ',
+        description: 'वीडियो के साथ .m3u प्लेलिस्ट सेव करता है ताकि वे मीडिया प्लेयर में क्रम से खुलें।'
       }
     },
     confirm: {
@@ -451,8 +477,22 @@ const hi = {
       hold: 'होल्ड',
       resume: 'फिर से शुरू',
       cancel: 'रद्द करें',
-      remove: 'हटाएँ'
-    }
+      remove: 'हटाएँ',
+      pullNow: 'अभी डाउनलोड — क्यू छोड़ें',
+      priorityBadge: 'प्राथमिकता',
+      statusPending: 'प्रतीक्षा में',
+      statusRunning: 'डाउनलोड हो रहा है',
+      statusHeld: 'रोका गया',
+      statusPaused: 'रुका हुआ',
+      statusDone: 'पूरा',
+      statusError: 'त्रुटि',
+      statusCancelled: 'रद्द'
+    },
+    resumeAll: 'क्यू फिर शुरू करें',
+    resumeAllTitle: 'रुके हुए डाउनलोड फिर शुरू करें और क्यू को चलने दें',
+    limitRate: 'गति: {{value}}',
+    limitRateOff: 'गति: बंद',
+    limitRateTitle: 'डाउनलोड के लिए बैंडविड्थ सीमा'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -540,24 +580,24 @@ const hi = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'हर आइटम के लिए उपलब्ध उच्चतम कोडेक',
+      mp4: 'H.264 + AAC प्राथमिक, MP4 कंटेनर · सर्वोत्तम प्रयास'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': '4K तक',
+      '1440': '1440p तक',
+      '1080': '1080p तक',
+      '720': '720p तक',
+      '480': '480p तक',
+      '360': '360p तक'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'हर आइटम के लिए सर्वश्रेष्ठ वीडियो + ऑडियो',
+      '2160': '2160p तक सीमित, हर आइटम पर ज़रूरत हो तो कम',
+      '1440': '2K तक सीमित, हर आइटम पर ज़रूरत हो तो कम',
+      '1080': '1080p तक सीमित, हर आइटम पर ज़रूरत हो तो कम',
+      '720': 'छोटी फ़ाइलें, व्यापक संगतता',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -568,13 +608,13 @@ const hi = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'सर्वश्रेष्ठ मूल ऑडियो, फिर से encode नहीं',
+      mp3: 'MP3 में बदलें',
+      m4a: 'M4A (AAC) में बदलें',
+      opus: 'Opus में बदलें'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'YouTube पर 1080p से ऊपर H.264 उपलब्ध नहीं है — अपने-आप 1080p तक सीमित'
   },
   formatLabel: {
     audioFallback: 'ऑडियो',
@@ -597,7 +637,8 @@ const hi = {
       message_other: '{{count}} डाउनलोड चल रही हैं',
       detail: 'बंद करने पर सभी सक्रिय डाउनलोड रद्द हो जाएँगी।',
       confirm: 'डाउनलोड रद्द करके बंद करें',
-      keep: 'डाउनलोड जारी रखें'
+      keep: 'डाउनलोड जारी रखें',
+      pause: 'डाउनलोड रोकें और बाहर निकलें'
     },
     closeToTray: {
       message: 'बंद करने पर Arroxy को सिस्टम ट्रे में छिपाएं?',

--- a/src/shared/i18n/locales/ja.ts
+++ b/src/shared/i18n/locales/ja.ts
@@ -122,13 +122,26 @@ const ja = {
       title: 'このリンクは Playlist に含まれています',
       body: 'クリックした動画だけをダウンロードしますか？それとも Playlist から選びますか？次のステップで特定の動画や範囲を選択できます。',
       singleVideo: 'この1本だけ',
-      pickFromPlaylist: 'Playlist から選ぶ'
+      pickFromPlaylist: 'Playlist から選ぶ',
+      playlistLimit: 'プレイリスト取得上限: {{count}} 件',
+      advancedSettings: '詳細設定',
+      singleTooltip: 'yt-dlp の単一動画モードを使い、この URL に付いたプレイリストを無視します。',
+      playlistTooltip: 'yt-dlp のプレイリストモードを使い、選択画面を出す前に上限まで取得します。'
     },
 
     url: {
       heading: 'YouTube URL',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: '形式を取得',
+      fetchFormatsTooltip: 'キューに追加する前に、形式、字幕、フォルダー、プレイリスト項目を手順ごとに選びます。',
+      quickDownload: 'クイックダウンロード',
+      quickDownloadTooltip: '保存済みまたは既定の設定を使い、設定手順を開かずにこの単一動画をキューへ追加します。',
+      quickPreparing: '準備中',
+      quickQueued: 'キューに追加しました',
+      quickSingleOnly: 'クイックダウンロードは単一動画専用です。プレイリストやチャンネルには形式を取得を使ってください。',
+      quickProbeFailed: '解析に失敗しました',
+      quickPrepareFailed: 'キュー項目を準備できませんでした',
+      quickFailed: '追加できませんでした: {{error}}',
       features: {
         heading: 'Arroxyで取得できるもの',
         youtube: {
@@ -240,7 +253,8 @@ const ja = {
         units: {
           seconds: '秒',
           threads: 'スレッド'
-        }
+        },
+        presetLabel: 'Arroxy はどのくらい慎重にしますか？'
       },
       closeToTray: {
         toggle: '閉じるときにトレイに格納',
@@ -249,6 +263,15 @@ const ja = {
       analytics: {
         toggle: '匿名の使用統計を送信',
         toggleDescription: 'アプリの起動回数のみを記録します。URL、ファイル名、個人情報は含まれません。'
+      },
+      limitRate: {
+        label: 'ダウンロード速度制限',
+        description: 'メディアダウンロードの帯域を制限します。下のリクエスト間隔のほうが強い制限になることが多いです。',
+        off: 'オフ',
+        custom: 'カスタム…',
+        customPlaceholder: '例: 750K または 1.5M',
+        invalid: 'K または M を付けた数値を使ってください（例: 500K、1.5M）',
+        activeWarning: '進行中のダウンロードは現在の制限を保持します。適用するには一時停止して再開してください。'
       }
     },
     subtitles: {
@@ -396,6 +419,10 @@ const ja = {
       writeThumbnail: {
         label: 'サムネイルを保存',
         description: 'サムネイルを .jpg 画像ファイルとしてダウンロードの隣に保存します。'
+      },
+      writeM3u: {
+        label: '.m3u プレイリストファイルを生成',
+        description: '動画の横に .m3u プレイリストを保存し、メディアプレーヤーで順番に開けるようにします。'
       }
     },
     confirm: {
@@ -450,8 +477,22 @@ const ja = {
       hold: '保留',
       resume: '再開',
       cancel: 'キャンセル',
-      remove: '削除'
-    }
+      remove: '削除',
+      pullNow: '今すぐ開始 — キューをスキップ',
+      priorityBadge: '優先',
+      statusPending: '待機中',
+      statusRunning: 'ダウンロード中',
+      statusHeld: '保留中',
+      statusPaused: '一時停止',
+      statusDone: '完了',
+      statusError: 'エラー',
+      statusCancelled: 'キャンセル済み'
+    },
+    resumeAll: 'キューを再開',
+    resumeAllTitle: '一時停止中のダウンロードを再開し、キューを続行します',
+    limitRate: '速度: {{value}}',
+    limitRateOff: '速度: オフ',
+    limitRateTitle: 'ダウンロードの帯域制限'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -539,24 +580,24 @@ const ja = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: '各項目で利用可能な最高のコーデック',
+      mp4: 'H.264 + AAC を優先、MP4 コンテナ · 可能な範囲で'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': '最大 4K',
+      '1440': '最大 1440p',
+      '1080': '最大 1080p',
+      '720': '最大 720p',
+      '480': '最大 480p',
+      '360': '最大 360p'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: '各項目で利用可能な最高の動画 + 音声',
+      '2160': '2160p までに制限し、項目ごとに下位へフォールバック',
+      '1440': '2K までに制限し、項目ごとに下位へフォールバック',
+      '1080': '1080p までに制限し、項目ごとに下位へフォールバック',
+      '720': '小さめのファイル、広い互換性',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -567,13 +608,13 @@ const ja = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: '最高のネイティブ音声、再エンコードなし',
+      mp3: 'MP3 に変換',
+      m4a: 'M4A (AAC) に変換',
+      opus: 'Opus に変換'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'YouTube では 1080p 超の H.264 は利用できません — 自動的に 1080p に制限されます'
   },
   formatLabel: {
     audioFallback: '音声',
@@ -596,7 +637,8 @@ const ja = {
       message_other: 'ダウンロード{{count}}件を実行中',
       detail: '閉じるとアクティブなダウンロードはすべてキャンセルされます。',
       confirm: 'ダウンロードをキャンセルして終了',
-      keep: 'ダウンロードを続ける'
+      keep: 'ダウンロードを続ける',
+      pause: 'ダウンロードを一時停止して終了'
     },
     closeToTray: {
       message: '閉じるときにArroxyをシステムトレイに格納しますか？',

--- a/src/shared/i18n/locales/my.ts
+++ b/src/shared/i18n/locales/my.ts
@@ -122,13 +122,26 @@ const my = {
       title: 'ဤလင့်ခ်တွင် Playlist ပါဝင်သည်',
       body: 'သင်နှိပ်ခဲ့သော ဗီဒီယိုကိုသာ လိုချင်သလော၊ Playlist မှ ရွေးချင်သလော? နောက်တွင် သီးခြားဗီဒီယိုများ သို့မဟုတ် အပိုင်းအခြား ရွေးနိုင်မည်။',
       singleVideo: 'ဤတစ်ခုသာ',
-      pickFromPlaylist: 'Playlist မှ ရွေးမည်'
+      pickFromPlaylist: 'Playlist မှ ရွေးမည်',
+      playlistLimit: 'Playlist စစ်ဆေးမှု ကန့်သတ်ချက်: {{count}} ခု',
+      advancedSettings: 'အဆင့်မြင့် ဆက်တင်များ',
+      singleTooltip: 'ဤ URL နှင့်တွဲနေသော playlist ကို လျစ်လျူရှုရန် yt-dlp ၏ ဗီဒီယိုတစ်ခုချင်း မုဒ်ကို သုံးသည်။',
+      playlistTooltip: 'yt-dlp ၏ playlist မုဒ်ကို သုံးပြီး ရွေးချယ်ကိရိယာ မပြမီ သင့်ကန့်သတ်ချက်အထိ ယူသည်။'
     },
 
     url: {
       heading: 'YouTube URL',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'ဖော်မတ်များရယူမည်',
+      fetchFormatsTooltip: 'တန်းစီစာရင်းထဲ မထည့်မီ ဖော်မတ်များ၊ စာတန်းထိုးများ၊ ဖိုင်တွဲနှင့် playlist အရာများကို အဆင့်လိုက် ရွေးပါ။',
+      quickDownload: 'အမြန်ဒေါင်းလုဒ်',
+      quickDownloadTooltip: 'သိမ်းထားသော သို့မဟုတ် မူရင်းရွေးချယ်မှုများကို အသုံးပြုပြီး ပြင်ဆင်မှုအဆင့်များ မဖွင့်ဘဲ ဤဗီဒီယိုတစ်ခုကို တန်းစီစာရင်းထဲ ထည့်သည်။',
+      quickPreparing: 'ပြင်ဆင်နေသည်',
+      quickQueued: 'တန်းစီစာရင်းထဲ ထည့်ပြီး',
+      quickSingleOnly: 'အမြန်ဒေါင်းလုဒ်သည် ဗီဒီယိုတစ်ခုချင်းအတွက်သာ ဖြစ်သည်။ Playlists နှင့် channels အတွက် ဖော်မတ်များ ရယူရန်ကို သုံးပါ။',
+      quickProbeFailed: 'စစ်ဆေးမှု မအောင်မြင်ပါ',
+      quickPrepareFailed: 'တန်းစီအရာကို မပြင်ဆင်နိုင်ပါ',
+      quickFailed: 'ဤအရာကို ထည့်မရပါ: {{error}}',
       features: {
         heading: 'Arroxy ဆွဲထုတ်နိုင်သည်',
         youtube: {
@@ -250,6 +263,15 @@ const my = {
       analytics: {
         toggle: 'အမည်မသိ သုံးစွဲမှုစာရင်းအင်းများ ပေးပို့ပါ',
         toggleDescription: 'အက်ပ် ဖွင့်သည့်အကြိမ်ရေကိုသာ ရေတွက်သည်။ URL၊ ဖိုင်အမည် သို့မဟုတ် ကိုယ်ရေးကိုယ်တာ ဒေတာ မပါဝင်ပါ။'
+      },
+      limitRate: {
+        label: 'ဒေါင်းလုဒ် အမြန်နှုန်း ကန့်သတ်ချက်',
+        description: 'မီဒီယာ ဒေါင်းလုဒ်များအတွက် bandwidth ကို ကန့်သတ်ပါ။ အောက်ပါ request pacing သည် အများအားဖြင့် ပိုအားကောင်းသော ကန့်သတ်ကိရိယာ ဖြစ်သည်။',
+        off: 'ပိတ်',
+        custom: 'စိတ်ကြိုက်…',
+        customPlaceholder: 'ဥပမာ 750K သို့ 1.5M',
+        invalid: 'K သို့ M ဖြင့်လိုက်သော နံပါတ်ကို သုံးပါ (ဥပမာ 500K, 1.5M)',
+        activeWarning: 'လုပ်ဆောင်နေသော ဒေါင်းလုဒ်များသည် လက်ရှိကန့်သတ်ချက်ကို ထိန်းထားသည်။ အသုံးပြုရန် ရပ်နား + ဆက်လုပ်ပါ။'
       }
     },
     subtitles: {
@@ -397,6 +419,10 @@ const my = {
       writeThumbnail: {
         label: 'Thumbnail သိမ်းမည်',
         description: 'Thumbnail ကို ဒေါင်းလုဒ်နဘေးတွင် .jpg ဓာတ်ပုံဖိုင်အဖြစ် သိမ်းမည်။'
+      },
+      writeM3u: {
+        label: '.m3u playlist ဖိုင် ဖန်တီးပါ',
+        description: 'ဗီဒီယိုများကို media player တွင် အစဉ်လိုက် ဖွင့်ရန် .m3u playlist ကို အတူသိမ်းသည်။'
       }
     },
     confirm: {
@@ -451,8 +477,22 @@ const my = {
       hold: 'ဆိုင်းငံ့မည်',
       resume: 'ဆက်လုပ်မည်',
       cancel: 'ပယ်ဖျက်မည်',
-      remove: 'ဖျက်မည်'
-    }
+      remove: 'ဖျက်မည်',
+      pullNow: 'ယခု ဒေါင်းလုဒ် — တန်းစီစာရင်း ကျော်',
+      priorityBadge: 'ဦးစားပေး',
+      statusPending: 'စောင့်နေသည်',
+      statusRunning: 'ဒေါင်းလုဒ်လုပ်နေသည်',
+      statusHeld: 'ထိန်းထားသည်',
+      statusPaused: 'ရပ်နားထားသည်',
+      statusDone: 'ပြီးပြီ',
+      statusError: 'အမှား',
+      statusCancelled: 'ပယ်ဖျက်ပြီး'
+    },
+    resumeAll: 'တန်းစီစာရင်း ဆက်လုပ်',
+    resumeAllTitle: 'ရပ်နားထားသော ဒေါင်းလုဒ်များကို ဆက်လုပ်ပြီး တန်းစီစာရင်းကို ဆက်လက်လည်ပတ်စေသည်',
+    limitRate: 'အမြန်နှုန်း: {{value}}',
+    limitRateOff: 'အမြန်နှုန်း: ပိတ်',
+    limitRateTitle: 'ဒေါင်းလုဒ်များအတွက် bandwidth ကန့်သတ်ချက်'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -540,24 +580,24 @@ const my = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'အရာတစ်ခုချင်းစီအတွက် ရနိုင်သော အမြင့်ဆုံး codec',
+      mp4: 'H.264 + AAC ကို ဦးစားပေး၊ MP4 container · အကောင်းဆုံးကြိုးစားမှု'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': '4K အထိ',
+      '1440': '1440p အထိ',
+      '1080': '1080p အထိ',
+      '720': '720p အထိ',
+      '480': '480p အထိ',
+      '360': '360p အထိ'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'အရာတစ်ခုချင်းစီအတွက် အကောင်းဆုံး ဗီဒီယို + အသံ',
+      '2160': '2160p တွင် ကန့်သတ်ပြီး အရာအလိုက် လိုအပ်လျှင် လျော့သည်',
+      '1440': '2K တွင် ကန့်သတ်ပြီး အရာအလိုက် လိုအပ်လျှင် လျော့သည်',
+      '1080': '1080p တွင် ကန့်သတ်ပြီး အရာအလိုက် လိုအပ်လျှင် လျော့သည်',
+      '720': 'ဖိုင်သေး၊ ကိုက်ညီမှု ကျယ်ပြန့်',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -568,13 +608,13 @@ const my = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'အကောင်းဆုံး မူရင်းအသံ၊ ပြန် encode မလုပ်',
+      mp3: 'MP3 သို့ ပြောင်း',
+      m4a: 'M4A (AAC) သို့ ပြောင်း',
+      opus: 'Opus သို့ ပြောင်း'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'YouTube တွင် 1080p အထက် H.264 မရှိပါ — 1080p သို့ အလိုအလျောက် ကန့်သတ်သည်'
   },
   formatLabel: {
     audioFallback: 'အသံ',
@@ -597,7 +637,8 @@ const my = {
       message_other: '{{count}} ဒေါင်းလုဒ်များ လုပ်ဆောင်နေဆဲ',
       detail: 'ပိတ်လျှင် လက်ရှိဒေါင်းလုဒ်အားလုံးကို ပယ်ဖျက်မည်။',
       confirm: 'ဒေါင်းလုဒ်ပယ်ဖျက်ပြီး ထွက်မည်',
-      keep: 'ဒေါင်းလုဒ်ဆက်လုပ်မည်'
+      keep: 'ဒေါင်းလုဒ်ဆက်လုပ်မည်',
+      pause: 'ဒေါင်းလုဒ်များ ရပ်နားပြီး ထွက်'
     },
     closeToTray: {
       message: 'ပိတ်သောအခါ Arroxy ကို system tray သို့ ဝှက်မည်လား?',

--- a/src/shared/i18n/locales/om.ts
+++ b/src/shared/i18n/locales/om.ts
@@ -122,12 +122,25 @@ const om = {
       title: 'Liinkin kun Playlist qaba',
       body: 'Viidiyoo tokko kana filadda, moo Playlist keessaa barbaadda? Viidiyoowwan addaddaa yookaan kutaa filattu itti aanu.',
       singleVideo: 'Kana qofa',
-      pickFromPlaylist: 'Playlist keessaa filadhu'
+      pickFromPlaylist: 'Playlist keessaa filadhu',
+      playlistLimit: 'Daangaa sakatta’iinsa playlist: wantoota {{count}}',
+      advancedSettings: 'Qindaa’inoota sadarkaa olaanaa',
+      singleTooltip: 'Haala viidiyoo tokkoo yt-dlp fayyadama; playlist URL kanaan hidhame ni tuffatama.',
+      playlistTooltip: 'Haala playlist yt-dlp fayyadamee hanga daangaa sakatta’iinsa playlist kee dura filannoo agarsiisa.'
     },
     url: {
       heading: 'YouTube URL',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'Foormaatii fidi',
+      fetchFormatsTooltip: 'Osoo tarree buusuu hin dabaliin dura formatoota, subtaitiloota, galmee fi wantoota playlist tarkaanfiin fili.',
+      quickDownload: 'Buusuu ariifachiisaa',
+      quickDownloadTooltip: 'Filannoowwan kee kuufaman yookiin durtii fayyadamee viidiyoo tokko kana tarree buusutti dabala, tarkaanfii qindaa’inaa osoo hin banu.',
+      quickPreparing: 'Qopheessaa jira',
+      quickQueued: 'Tarreetti dabalame',
+      quickSingleOnly: 'Buusuu ariifachiisaa viidiyoo tokko qofaf. Playlist fi channelootaaf Formatoota fidi fayyadami.',
+      quickProbeFailed: 'Sakatta’iinsi hin milkoofne',
+      quickPrepareFailed: 'Wantoota tarree qopheessuu hin dandeenye',
+      quickFailed: 'Kana dabaluun hin danda’amne: {{error}}',
       features: {
         heading: "Arroxy maal buufachuu danda'a",
         youtube: {
@@ -249,6 +262,15 @@ const om = {
       analytics: {
         toggle: 'Tilastoo faayidaa maqaa-malee ergaa',
         toggleDescription: 'Jalqabbii app qofa lakkaawa. URL, maqaa faayilii, ykn daataa dhuunfaa hin qabatu.'
+      },
+      limitRate: {
+        label: 'Daangaa saffisa buusuu',
+        description: 'Baandwiidtii buusuu miidiyaa daangeessi. Pacing gaaffii armaan gadii yeroo baay’ee caalaa jabaa dha.',
+        off: 'Dhaamsame',
+        custom: 'Kan mataa keetii…',
+        customPlaceholder: 'fkn. 750K yookiin 1.5M',
+        invalid: 'Lakkoofsa K yookiin M itti aanu fayyadami (fkn. 500K, 1.5M)',
+        activeWarning: 'Buusuuwwan hojiirra jiran daangaa isaanii ammaa qabu. Jijjiiruuf Dhaabi + Itti fufi.'
       }
     },
     subtitles: {
@@ -396,6 +418,10 @@ const om = {
       writeThumbnail: {
         label: 'Thumbnail kuusi',
         description: "Thumbnail .jpg faayilii suuraa ta'ee daawniloodii cinaa ni kuusa."
+      },
+      writeM3u: {
+        label: 'Faayilii playlist .m3u uumi',
+        description: 'Viidiyoowwan tarreen media player keessatti banamaniif .m3u isaan cinatti kuusi.'
       }
     },
     confirm: {
@@ -450,8 +476,22 @@ const om = {
       hold: 'Eegi',
       resume: 'Itti fufi',
       cancel: 'Haqi',
-      remove: 'Balleessi'
-    }
+      remove: 'Balleessi',
+      pullNow: 'Amma buusi — tarree darbii',
+      priorityBadge: 'Dursa',
+      statusPending: 'Eegaa jira',
+      statusRunning: 'Buusaa jira',
+      statusHeld: 'Qabame',
+      statusPaused: 'Dhaabbate',
+      statusDone: 'Xumurame',
+      statusError: 'Dogoggora',
+      statusCancelled: 'Haqame'
+    },
+    resumeAll: 'Tarree itti fufi',
+    resumeAllTitle: 'Buusuu dhaabbate itti fufi; tarreenis haa deemuu',
+    limitRate: 'Saffisa: {{value}}',
+    limitRateOff: 'Saffisa: Dhaamsame',
+    limitRateTitle: 'Daangaa baandwiidtii buusuuwwanii'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -539,24 +579,24 @@ const om = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'Codec ol’aanaa argamu tokkoon tokkoon wantaaf',
+      mp4: 'H.264 + AAC filatama, konteenera MP4 · carraa gaarii'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': 'Hanga 4K',
+      '1440': 'Hanga 1440p',
+      '1080': 'Hanga 1080p',
+      '720': 'Hanga 720p',
+      '480': 'Hanga 480p',
+      '360': 'Hanga 360p'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'Viidiyoo + sagalee ol’aanaa tokkoon tokkoon wantaaf',
+      '2160': 'Hanga 2160p daangeffama, tokkoon tokkoon wantaaf gara gadi deebi’a',
+      '1440': 'Hanga 2K daangeffama, tokkoon tokkoon wantaaf gara gadi deebi’a',
+      '1080': 'Hanga 1080p daangeffama, tokkoon tokkoon wantaaf gara gadi deebi’a',
+      '720': 'Faayiloota xiqqaa, walsimsiisa bal’aa',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -567,13 +607,13 @@ const om = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'Sagalee native ol’aanaa, irra deebi’ee hin encode’u',
+      mp3: 'Gara MP3 jijjiiri',
+      m4a: 'Gara M4A (AAC) jijjiiri',
+      opus: 'Gara Opus jijjiiri'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'H.264 1080p olii YouTube irratti hin jiru — ofumaan 1080p irratti daangeffama'
   },
   formatLabel: {
     audioFallback: 'Sagalee',
@@ -596,7 +636,8 @@ const om = {
       message_other: 'Daawniloodoonni {{count}} adeemaa jiru',
       detail: 'Cufuun daawniloodoonni hundi haqama.',
       confirm: 'Daawniloodii Haqi fi Cufii',
-      keep: 'Daawniloodii itti fufi'
+      keep: 'Daawniloodii itti fufi',
+      pause: 'Buusuu dhaabiitii ba’i'
     },
     closeToTray: {
       message: 'Cufuun Arroxy tiiree irratti dhoksi?',

--- a/src/shared/i18n/locales/ps.ts
+++ b/src/shared/i18n/locales/ps.ts
@@ -122,13 +122,26 @@ const ps = {
       title: 'دا لینک یو Playlist لري',
       body: 'یوازې هغه ویډیو چې کلیک مو کاوه، که د Playlist نه غوره کول غواړئ؟ بعد به ځانګړي ویډیوګانې یا سلسله غوره کړئ.',
       singleVideo: 'یوازې دا یو',
-      pickFromPlaylist: 'له Playlist نه غوره کړئ'
+      pickFromPlaylist: 'له Playlist نه غوره کړئ',
+      playlistLimit: 'د پلی‌لېسټ کتنې حد: {{count}} توکي',
+      advancedSettings: 'پرمختللې امستنې',
+      singleTooltip: 'د yt-dlp د یوه ویډیو حالت کاروي، نو له دې URL سره تړلی پلی‌لېسټ له پامه غورځول کېږي.',
+      playlistTooltip: 'د yt-dlp د پلی‌لېسټ حالت کاروي او د انتخابګر تر ښودلو مخکې ستاسې تر ټاکلي حد پورې توکي راولي.'
     },
 
     url: {
       heading: 'YouTube URL',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'بڼې ترلاسه کړه',
+      fetchFormatsTooltip: 'له قطار ته تر زیاتولو مخکې بڼې، فرعي لیکنې، پوښۍ او د پلی‌لېسټ توکي ګام په ګام وټاکئ.',
+      quickDownload: 'چټک ډاونلوډ',
+      quickDownloadTooltip: 'ستاسې خوندي شوې یا تلواله خوښې کاروي او دا یو ویډیو د چمتو کولو پړاوونو له پرانیستو پرته قطار ته زیاتوي.',
+      quickPreparing: 'چمتو کېږي',
+      quickQueued: 'قطار ته زیات شو',
+      quickSingleOnly: 'چټک ډاونلوډ یوازې د یوه ویډیو لپاره دی. د پلی‌لېسټونو او چینلونو لپاره بڼې راوړئ وکاروئ.',
+      quickProbeFailed: 'کتنه ناکامه شوه',
+      quickPrepareFailed: 'د قطار توکی چمتو نه شو',
+      quickFailed: 'دا ونه زیاتېدل: {{error}}',
       features: {
         heading: 'Arroxy څه ډاونلوډ کولی شي',
         youtube: {
@@ -250,6 +263,15 @@ const ps = {
       analytics: {
         toggle: 'د ناپیژندل شوي کارونې احصائیې واستوئ',
         toggleDescription: 'یوازې د اپلیکیشن پیلونه شمیري. هیڅ URL، د فایل نومونه، یا شخصي معلومات نه شته.'
+      },
+      limitRate: {
+        label: 'د ډاونلوډ سرعت حد',
+        description: 'د رسنیو د ډاونلوډونو بینډوېډت محدودوي. لاندې د غوښتنو تمپو عموماً پیاوړی محدودوونکی دی.',
+        off: 'بند',
+        custom: 'ځانګړی…',
+        customPlaceholder: 'لکه 750K یا 1.5M',
+        invalid: 'له K یا M سره عدد وکاروئ (لکه 500K، 1.5M)',
+        activeWarning: 'فعال ډاونلوډونه خپل اوسنی حد ساتي. د پلي کولو لپاره ودرول + دوام وکاروئ.'
       }
     },
     subtitles: {
@@ -397,6 +419,10 @@ const ps = {
       writeThumbnail: {
         label: 'تھمبنیل خوندي کړه',
         description: 'تھمبنیل د ډاونلوډ سره یوځای د .jpg انځور فایل بڼه کې خوندي کوي.'
+      },
+      writeM3u: {
+        label: 'د .m3u پلی‌لېسټ فایل جوړول',
+        description: 'د ویډیوګانو ترڅنګ .m3u پلی‌لېسټ ساتي چې په میډیا پلیر کې په ترتیب خلاص شي.'
       }
     },
     confirm: {
@@ -451,8 +477,22 @@ const ps = {
       hold: 'ودرول',
       resume: 'دوام',
       cancel: 'لغوه کول',
-      remove: 'لیرې کول'
-    }
+      remove: 'لیرې کول',
+      pullNow: 'اوس ډاونلوډ — قطار پرېږدئ',
+      priorityBadge: 'لومړیتوب',
+      statusPending: 'په تمه',
+      statusRunning: 'ډاونلوډ کېږي',
+      statusHeld: 'ساتل شوی',
+      statusPaused: 'درول شوی',
+      statusDone: 'بشپړ',
+      statusError: 'تېروتنه',
+      statusCancelled: 'لغوه شوی'
+    },
+    resumeAll: 'قطار ته دوام ورکړئ',
+    resumeAllTitle: 'درول شوي ډاونلوډونه دوام کړئ او قطار روان پرېږدئ',
+    limitRate: 'سرعت: {{value}}',
+    limitRateOff: 'سرعت: بند',
+    limitRateTitle: 'د ډاونلوډونو بینډوېډت حد'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -540,24 +580,24 @@ const ps = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'د هر توکي لپاره تر ټولو لوړ موجود codec',
+      mp4: 'H.264 + AAC غوره، MP4 کانتینر · تر وسه ښه'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': 'تر 4K پورې',
+      '1440': 'تر 1440p پورې',
+      '1080': 'تر 1080p پورې',
+      '720': 'تر 720p پورې',
+      '480': 'تر 480p پورې',
+      '360': 'تر 360p پورې'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'د هر توکي لپاره غوره ویډیو + غږ',
+      '2160': 'تر 2160p محدود، د هر توکي لپاره ښکته راځي',
+      '1440': 'تر 2K محدود، د هر توکي لپاره ښکته راځي',
+      '1080': 'تر 1080p محدود، د هر توکي لپاره ښکته راځي',
+      '720': 'کوچني فایلونه، پراخه سازګاري',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -568,13 +608,13 @@ const ps = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'غوره اصلي غږ، بیا کوډ نه کېږي',
+      mp3: 'MP3 ته بدلول',
+      m4a: 'M4A (AAC) ته بدلول',
+      opus: 'Opus ته بدلول'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'په YouTube کې له 1080p پورته H.264 نشته — په اتومات ډول 1080p ته محدودېږي'
   },
   formatLabel: {
     audioFallback: 'غږ',
@@ -597,7 +637,8 @@ const ps = {
       message_other: '{{count}} ډاونلوډونه روان دي',
       detail: 'تړول به ټول فعال ډاونلوډونه لغوه کړي.',
       confirm: 'ډاونلوډونه لغوه کړه او وتلو',
-      keep: 'ډاونلوډ دوام کړه'
+      keep: 'ډاونلوډ دوام کړه',
+      pause: 'ډاونلوډونه ودرول او وتل'
     },
     closeToTray: {
       message: 'ایا د تړولو پر وخت Arroxy سیسټم ټرې ته پټ کړو؟',

--- a/src/shared/i18n/locales/ru.ts
+++ b/src/shared/i18n/locales/ru.ts
@@ -122,13 +122,26 @@ const ru = {
       title: 'Эта ссылка — часть Playlist',
       body: 'Хочешь скачать только то видео, на которое нажал, или выбрать из Playlist? Дальше сможешь указать конкретные видео или диапазон.',
       singleVideo: 'Только это одно',
-      pickFromPlaylist: 'Выбрать из Playlist'
+      pickFromPlaylist: 'Выбрать из Playlist',
+      playlistLimit: 'Лимит проверки плейлиста: {{count}} элементов',
+      advancedSettings: 'Дополнительные настройки',
+      singleTooltip: 'Использует режим одиночного видео yt-dlp, поэтому плейлист в этой ссылке игнорируется.',
+      playlistTooltip: 'Использует режим плейлиста yt-dlp и загружает элементы до выбранного лимита перед показом выбора.'
     },
 
     url: {
       heading: 'Ссылка YouTube',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'Получить форматы',
+      fetchFormatsTooltip: 'Выберите форматы, субтитры, папку и элементы плейлиста по шагам перед добавлением в очередь.',
+      quickDownload: 'Быстрая загрузка',
+      quickDownloadTooltip: 'Использует сохранённые или стандартные настройки и добавляет это одиночное видео в очередь без шагов настройки.',
+      quickPreparing: 'Подготовка',
+      quickQueued: 'Добавлено в очередь',
+      quickSingleOnly: 'Быстрая загрузка работает только для одиночных видео. Для плейлистов и каналов используйте Получить форматы.',
+      quickProbeFailed: 'Проверка не удалась',
+      quickPrepareFailed: 'Не удалось подготовить элемент очереди',
+      quickFailed: 'Не удалось добавить: {{error}}',
       features: {
         heading: 'Что умеет скачивать Arroxy',
         youtube: {
@@ -226,7 +239,8 @@ const ru = {
         units: {
           seconds: 'сек',
           threads: 'потоков'
-        }
+        },
+        presetLabel: 'Насколько осторожным должен быть Arroxy?'
       },
       playlistProbeLimit: {
         label: 'Элементов плейлиста для сканирования',
@@ -249,6 +263,15 @@ const ru = {
       analytics: {
         toggle: 'Отправлять анонимную статистику',
         toggleDescription: 'Только подсчёт запусков приложения. Без URL, имён файлов или личных данных.'
+      },
+      limitRate: {
+        label: 'Ограничение скорости загрузки',
+        description: 'Ограничивает пропускную способность для загрузки медиа. Интервалы запросов ниже обычно сильнее влияют на лимиты.',
+        off: 'Выкл.',
+        custom: 'Своя…',
+        customPlaceholder: 'например 750K или 1.5M',
+        invalid: 'Введите число с K или M (например 500K, 1.5M)',
+        activeWarning: 'Активные загрузки сохранят текущий лимит. Пауза + Возобновить применит изменения.'
       }
     },
     subtitles: {
@@ -396,6 +419,10 @@ const ru = {
       writeThumbnail: {
         label: 'Сохранить превью',
         description: 'Сохраняет превью как файл .jpg рядом с загрузкой.'
+      },
+      writeM3u: {
+        label: 'Создать файл плейлиста .m3u',
+        description: 'Сохраняет .m3u рядом с видео, чтобы медиаплеер открывал их по порядку.'
       }
     },
     confirm: {
@@ -450,8 +477,22 @@ const ru = {
       hold: 'Отложить',
       resume: 'Продолжить',
       cancel: 'Отменить',
-      remove: 'Удалить'
-    }
+      remove: 'Удалить',
+      pullNow: 'Загрузить сейчас — пропустить очередь',
+      priorityBadge: 'Приоритет',
+      statusPending: 'Ожидание',
+      statusRunning: 'Загрузка',
+      statusHeld: 'Удержано',
+      statusPaused: 'Пауза',
+      statusDone: 'Готово',
+      statusError: 'Ошибка',
+      statusCancelled: 'Отменено'
+    },
+    resumeAll: 'Возобновить очередь',
+    resumeAllTitle: 'Возобновить приостановленные загрузки и продолжить очередь',
+    limitRate: 'Скорость: {{value}}',
+    limitRateOff: 'Скорость: выкл.',
+    limitRateTitle: 'Ограничение пропускной способности для загрузок'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -539,24 +580,24 @@ const ru = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'Самый высокий доступный кодек для каждого элемента',
+      mp4: 'Предпочтительно H.264 + AAC, контейнер MP4 · по возможности'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': 'До 4K',
+      '1440': 'До 1440p',
+      '1080': 'До 1080p',
+      '720': 'До 720p',
+      '480': 'До 480p',
+      '360': 'До 360p'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'Лучшее доступное видео + аудио для каждого элемента',
+      '2160': 'Ограничено 2160p, понижается отдельно для каждого элемента',
+      '1440': 'Ограничено 2K, понижается отдельно для каждого элемента',
+      '1080': 'Ограничено 1080p, понижается отдельно для каждого элемента',
+      '720': 'Меньшие файлы, широкая совместимость',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -567,13 +608,13 @@ const ru = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'Лучшее исходное аудио, без перекодирования',
+      mp3: 'Преобразовать в MP3',
+      m4a: 'Преобразовать в M4A (AAC)',
+      opus: 'Преобразовать в Opus'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'H.264 выше 1080p недоступен на YouTube — автоматически ограничивается 1080p'
   },
   formatLabel: {
     audioFallback: 'Аудио',
@@ -596,7 +637,8 @@ const ru = {
       message_other: '{{count}} загрузок идёт',
       detail: 'При закрытии все активные загрузки будут отменены.',
       confirm: 'Отменить загрузки и выйти',
-      keep: 'Продолжить загрузку'
+      keep: 'Продолжить загрузку',
+      pause: 'Поставить загрузки на паузу и выйти'
     },
     closeToTray: {
       message: 'Скрывать Arroxy в системный трей при закрытии?',

--- a/src/shared/i18n/locales/sr.ts
+++ b/src/shared/i18n/locales/sr.ts
@@ -122,13 +122,26 @@ const sr = {
       title: 'Овај линк је из плејлисте',
       body: 'Желиш само видео на који си кликнуо, или да бираш из плејлисте? Следећи корак ти омогућава да одабереш одређене видеосе или распон.',
       singleVideo: 'Само овај',
-      pickFromPlaylist: 'Бирај из плејлисте'
+      pickFromPlaylist: 'Бирај из плејлисте',
+      playlistLimit: 'Limit provere plejliste: {{count}} stavki',
+      advancedSettings: 'Napredna podešavanja',
+      singleTooltip: 'Koristi yt-dlp režim za pojedinačni video, pa se plejlista vezana za ovaj URL ignoriše.',
+      playlistTooltip: 'Koristi yt-dlp režim plejliste i učitava do vašeg limita pre prikaza birača.'
     },
 
     url: {
       heading: 'YouTube URL',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'Учитај формате',
+      fetchFormatsTooltip: 'Izaberite formate, titlove, fasciklu i stavke plejliste korak po korak pre dodavanja u red.',
+      quickDownload: 'Brzo preuzimanje',
+      quickDownloadTooltip: 'Koristi sačuvana ili podrazumevana podešavanja i dodaje ovaj pojedinačni video u red bez otvaranja koraka podešavanja.',
+      quickPreparing: 'Priprema',
+      quickQueued: 'Dodato u red',
+      quickSingleOnly: 'Brzo preuzimanje je samo za pojedinačne video snimke. Za plejliste i kanale koristite Preuzmi formate.',
+      quickProbeFailed: 'Provera nije uspela',
+      quickPrepareFailed: 'Stavka reda nije mogla da se pripremi',
+      quickFailed: 'Nije moguće dodati: {{error}}',
       features: {
         heading: 'Шта Arroxy може да преузме',
         youtube: {
@@ -240,7 +253,8 @@ const sr = {
         units: {
           seconds: 'сек',
           threads: 'нити'
-        }
+        },
+        presetLabel: 'Насколько осторожным должен быть Arroxy?'
       },
       closeToTray: {
         toggle: 'Сакриј у системски трај при затварању',
@@ -249,6 +263,15 @@ const sr = {
       analytics: {
         toggle: 'Пошаљи анонимне статистике коришћења',
         toggleDescription: 'Броји само покретања апликације. Без URL-ова, имена датотека или личних података.'
+      },
+      limitRate: {
+        label: 'Ограничение скорости загрузки',
+        description: 'Ограничивает пропускную способность для загрузки медиа. Интервалы запросов ниже обычно сильнее влияют на лимиты.',
+        off: 'Выкл.',
+        custom: 'Своя…',
+        customPlaceholder: 'например 750K или 1.5M',
+        invalid: 'Введите число с K или M (например 500K, 1.5M)',
+        activeWarning: 'Активные загрузки сохранят текущий лимит. Пауза + Возобновить применит изменения.'
       }
     },
     subtitles: {
@@ -396,6 +419,10 @@ const sr = {
       writeThumbnail: {
         label: 'Сачувај сличицу',
         description: 'Чува сличицу као .jpg датотеку слике поред преузимања.'
+      },
+      writeM3u: {
+        label: 'Создать файл плейлиста .m3u',
+        description: 'Сохраняет .m3u рядом с видео, чтобы медиаплеер открывал их по порядку.'
       }
     },
     confirm: {
@@ -450,8 +477,22 @@ const sr = {
       hold: 'Задржи',
       resume: 'Настави',
       cancel: 'Откажи',
-      remove: 'Уклони'
-    }
+      remove: 'Уклони',
+      pullNow: 'Загрузить сейчас — пропустить очередь',
+      priorityBadge: 'Приоритет',
+      statusPending: 'Ожидание',
+      statusRunning: 'Загрузка',
+      statusHeld: 'Удержано',
+      statusPaused: 'Пауза',
+      statusDone: 'Готово',
+      statusError: 'Ошибка',
+      statusCancelled: 'Отменено'
+    },
+    resumeAll: 'Возобновить очередь',
+    resumeAllTitle: 'Возобновить приостановленные загрузки и продолжить очередь',
+    limitRate: 'Скорость: {{value}}',
+    limitRateOff: 'Скорость: выкл.',
+    limitRateTitle: 'Ограничение пропускной способности для загрузок'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -539,24 +580,24 @@ const sr = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'Najviši dostupan kodek po stavci',
+      mp4: 'Prednost H.264 + AAC, MP4 kontejner · najbolji pokušaj'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': 'Do 4K',
+      '1440': 'Do 1440p',
+      '1080': 'Do 1080p',
+      '720': 'Do 720p',
+      '480': 'Do 480p',
+      '360': 'Do 360p'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'Najbolji dostupan video + audio po stavci',
+      '2160': 'Ograničeno na 2160p, pada niže po stavci',
+      '1440': 'Ograničeno na 2K, pada niže po stavci',
+      '1080': 'Ograničeno na 1080p, pada niže po stavci',
+      '720': 'Manji fajlovi, široka kompatibilnost',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -567,13 +608,13 @@ const sr = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'Najbolji izvorni audio, bez ponovnog kodiranja',
+      mp3: 'Konvertuj u MP3',
+      m4a: 'Konvertuj u M4A (AAC)',
+      opus: 'Konvertuj u Opus'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'H.264 iznad 1080p nije dostupan na YouTube-u — automatski se ograničava na 1080p'
   },
   formatLabel: {
     audioFallback: 'Звук',
@@ -596,7 +637,8 @@ const sr = {
       message_other: '{{count}} преузимања у току',
       detail: 'Затварање ће отказати сва активна преузимања.',
       confirm: 'Откажи преузимања и Затвори',
-      keep: 'Настави преузимање'
+      keep: 'Настави преузимање',
+      pause: 'Поставить загрузки на паузу и выйти'
     },
     closeToTray: {
       message: 'Сакрити Arroxy у системски трај при затварању?',

--- a/src/shared/i18n/locales/sw.ts
+++ b/src/shared/i18n/locales/sw.ts
@@ -122,12 +122,25 @@ const sw = {
       title: 'Kiungo hiki kina Playlist',
       body: 'Unataka video uliyobofya tu, au uchague kutoka Playlist? Hatua inayofuata utachagua video maalum au anuwai.',
       singleVideo: 'Hii tu',
-      pickFromPlaylist: 'Chagua kutoka Playlist'
+      pickFromPlaylist: 'Chagua kutoka Playlist',
+      playlistLimit: 'Kikomo cha kuchunguza playlist: vipengee {{count}}',
+      advancedSettings: 'Mipangilio ya kina',
+      singleTooltip: 'Hutumia modi ya video moja ya yt-dlp ili kupuuza playlist iliyounganishwa na URL hii.',
+      playlistTooltip: 'Hutumia modi ya playlist ya yt-dlp na kuchukua hadi kikomo chako kabla ya kuonyesha kichaguaji.'
     },
     url: {
       heading: 'YouTube URL',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'Pata maumbo',
+      fetchFormatsTooltip: 'Chagua fomati, manukuu, folda na vipengee vya orodha ya kucheza hatua kwa hatua kabla ya kuongeza kwenye foleni.',
+      quickDownload: 'Pakua haraka',
+      quickDownloadTooltip: 'Hutumia mapendeleo yako yaliyohifadhiwa au chaguomsingi na kuongeza video hii moja kwenye foleni bila kufungua hatua za usanidi.',
+      quickPreparing: 'Inaandaa',
+      quickQueued: 'Imeongezwa kwenye foleni',
+      quickSingleOnly: 'Pakua haraka ni kwa video moja tu. Tumia Leta fomati kwa orodha za kucheza na vituo.',
+      quickProbeFailed: 'Uchunguzi umeshindikana',
+      quickPrepareFailed: 'Kipengee cha foleni hakikuweza kuandaliwa',
+      quickFailed: 'Haikuweza kuongeza hii: {{error}}',
       features: {
         heading: 'Arroxy inaweza kupakua nini',
         youtube: {
@@ -249,6 +262,15 @@ const sw = {
       analytics: {
         toggle: 'Tuma takwimu za matumizi zisizo na jina',
         toggleDescription: 'Huhesabu tu uzinduzi wa programu. Hakuna URL, majina ya faili, au data za kibinafsi.'
+      },
+      limitRate: {
+        label: 'Kikomo cha kasi ya kupakua',
+        description: 'Dhibiti bandwidth ya vipakuliwa vya media. Udhibiti wa maombi hapa chini mara nyingi una nguvu zaidi.',
+        off: 'Imezimwa',
+        custom: 'Maalum…',
+        customPlaceholder: 'mf. 750K au 1.5M',
+        invalid: 'Tumia nambari ikifuatiwa na K au M (mf. 500K, 1.5M)',
+        activeWarning: 'Vipakuliwa vinavyoendelea huhifadhi kikomo cha sasa. Sitisha + Endelea ili kutumia mabadiliko.'
       }
     },
     subtitles: {
@@ -396,6 +418,10 @@ const sw = {
       writeThumbnail: {
         label: 'Hifadhi picha ndogo',
         description: 'Inahifadhi picha ndogo kama faili ya picha ya .jpg karibu na kipakuliwa.'
+      },
+      writeM3u: {
+        label: 'Tengeneza faili ya playlist .m3u',
+        description: 'Hifadhi playlist ya .m3u pamoja na video ili zifunguke kwa mpangilio kwenye kicheza media.'
       }
     },
     confirm: {
@@ -450,8 +476,22 @@ const sw = {
       hold: 'Simama',
       resume: 'Endelea',
       cancel: 'Ghairi',
-      remove: 'Ondoa'
-    }
+      remove: 'Ondoa',
+      pullNow: 'Pakua sasa — ruka foleni',
+      priorityBadge: 'Kipaumbele',
+      statusPending: 'Inasubiri',
+      statusRunning: 'Inapakua',
+      statusHeld: 'Imeshikiliwa',
+      statusPaused: 'Imesitishwa',
+      statusDone: 'Imekamilika',
+      statusError: 'Hitilafu',
+      statusCancelled: 'Imeghairiwa'
+    },
+    resumeAll: 'Endeleza foleni',
+    resumeAllTitle: 'Endeleza vipakuliwa vilivyosimamishwa na ruhusu foleni iendelee',
+    limitRate: 'Kasi: {{value}}',
+    limitRateOff: 'Kasi: Imezimwa',
+    limitRateTitle: 'Kikomo cha bandwidth kwa vipakuliwa'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -539,24 +579,24 @@ const sw = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'Kodeki bora inayopatikana kwa kila kipengee',
+      mp4: 'H.264 + AAC inapendelewa, kontena MP4 · juhudi bora'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': 'Hadi 4K',
+      '1440': 'Hadi 1440p',
+      '1080': 'Hadi 1080p',
+      '720': 'Hadi 720p',
+      '480': 'Hadi 480p',
+      '360': 'Hadi 360p'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'Video + sauti bora inayopatikana kwa kila kipengee',
+      '2160': 'Imepunguzwa hadi 2160p, hushuka kwa kila kipengee ikihitajika',
+      '1440': 'Imepunguzwa hadi 2K, hushuka kwa kila kipengee ikihitajika',
+      '1080': 'Imepunguzwa hadi 1080p, hushuka kwa kila kipengee ikihitajika',
+      '720': 'Faili ndogo, upatanifu mpana',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -567,13 +607,13 @@ const sw = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'Sauti bora asilia, bila kusimba upya',
+      mp3: 'Geuza kuwa MP3',
+      m4a: 'Geuza kuwa M4A (AAC)',
+      opus: 'Geuza kuwa Opus'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'H.264 zaidi ya 1080p haipatikani YouTube — hupunguzwa kiotomatiki hadi 1080p'
   },
   formatLabel: {
     audioFallback: 'Sauti',
@@ -596,7 +636,8 @@ const sw = {
       message_other: 'Vipakuzi {{count}} vinavyoendelea',
       detail: 'Kufunga kutafuta vipakuzi vyote vinavyofanya kazi.',
       confirm: 'Ghairi Vipakuzi na Toka',
-      keep: 'Endelea Kupakua'
+      keep: 'Endelea Kupakua',
+      pause: 'Sitisha vipakuliwa na uondoke'
     },
     closeToTray: {
       message: 'Ficha Arroxy kwenye tray ya mfumo ukifunga?',

--- a/src/shared/i18n/locales/uk.ts
+++ b/src/shared/i18n/locales/uk.ts
@@ -122,13 +122,26 @@ const uk = {
       title: 'Це посилання з Playlist',
       body: 'Хочеш завантажити лише те відео, на яке натиснув, чи вибрати з Playlist? Далі зможеш вказати конкретні відео або діапазон.',
       singleVideo: 'Лише це одне',
-      pickFromPlaylist: 'Вибрати з Playlist'
+      pickFromPlaylist: 'Вибрати з Playlist',
+      playlistLimit: 'Ліміт перевірки плейлиста: {{count}} елементів',
+      advancedSettings: 'Додаткові налаштування',
+      singleTooltip: 'Використовує режим одного відео yt-dlp, тому плейлист у цьому URL ігнорується.',
+      playlistTooltip: 'Використовує режим плейлиста yt-dlp і завантажує елементи до твого ліміту перед показом вибору.'
     },
 
     url: {
       heading: 'Посилання YouTube',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'Отримати формати',
+      fetchFormatsTooltip: 'Вибери формати, субтитри, папку й елементи плейлиста крок за кроком перед додаванням у чергу.',
+      quickDownload: 'Швидке завантаження',
+      quickDownloadTooltip: 'Використовує збережені або стандартні налаштування й додає це окреме відео в чергу без кроків налаштування.',
+      quickPreparing: 'Підготовка',
+      quickQueued: 'Додано в чергу',
+      quickSingleOnly: 'Швидке завантаження працює лише для окремих відео. Для плейлистів і каналів використовуй Отримати формати.',
+      quickProbeFailed: 'Перевірка не вдалася',
+      quickPrepareFailed: 'Не вдалося підготувати елемент черги',
+      quickFailed: 'Не вдалося додати: {{error}}',
       features: {
         heading: 'Що Arroxy вміє завантажувати',
         youtube: {
@@ -240,7 +253,8 @@ const uk = {
         units: {
           seconds: 'сек',
           threads: 'потоків'
-        }
+        },
+        presetLabel: 'Наскільки обережним має бути Arroxy?'
       },
       closeToTray: {
         toggle: 'Приховувати в трей при закритті',
@@ -249,6 +263,15 @@ const uk = {
       analytics: {
         toggle: 'Надсилати анонімну статистику',
         toggleDescription: 'Лише підрахунок запусків додатку. Без URL, імен файлів чи особистих даних.'
+      },
+      limitRate: {
+        label: 'Обмеження швидкості завантаження',
+        description: 'Обмежує пропускну здатність для медіазавантажень. Інтервали запитів нижче зазвичай сильніше впливають на ліміти.',
+        off: 'Вимкнено',
+        custom: 'Власне…',
+        customPlaceholder: 'наприклад 750K або 1.5M',
+        invalid: 'Введи число з K або M (наприклад 500K, 1.5M)',
+        activeWarning: 'Активні завантаження зберігають поточний ліміт. Пауза + Продовжити застосує зміни.'
       }
     },
     subtitles: {
@@ -396,6 +419,10 @@ const uk = {
       writeThumbnail: {
         label: 'Зберегти мініатюру',
         description: 'Зберігає мініатюру як файл .jpg поруч із завантаженням.'
+      },
+      writeM3u: {
+        label: 'Створити файл плейлиста .m3u',
+        description: 'Зберігає .m3u поруч із відео, щоб вони відкривалися в медіаплеєрі по порядку.'
       }
     },
     confirm: {
@@ -450,8 +477,22 @@ const uk = {
       hold: 'Утримати',
       resume: 'Продовжити',
       cancel: 'Скасувати',
-      remove: 'Видалити'
-    }
+      remove: 'Видалити',
+      pullNow: 'Завантажити зараз — пропустити чергу',
+      priorityBadge: 'Пріоритет',
+      statusPending: 'Очікує',
+      statusRunning: 'Завантажується',
+      statusHeld: 'Утримано',
+      statusPaused: 'На паузі',
+      statusDone: 'Готово',
+      statusError: 'Помилка',
+      statusCancelled: 'Скасовано'
+    },
+    resumeAll: 'Продовжити чергу',
+    resumeAllTitle: 'Продовжити призупинені завантаження й дати черзі рухатися далі',
+    limitRate: 'Швидкість: {{value}}',
+    limitRateOff: 'Швидкість: вимкнено',
+    limitRateTitle: 'Обмеження пропускної здатності для завантажень'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -539,24 +580,24 @@ const uk = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'Найвищий доступний кодек для кожного елемента',
+      mp4: 'Перевага H.264 + AAC, контейнер MP4 · наскільки можливо'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': 'До 4K',
+      '1440': 'До 1440p',
+      '1080': 'До 1080p',
+      '720': 'До 720p',
+      '480': 'До 480p',
+      '360': 'До 360p'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'Найкраще доступне відео + аудіо для кожного елемента',
+      '2160': 'Обмежено 2160p, знижується окремо для кожного елемента',
+      '1440': 'Обмежено 2K, знижується окремо для кожного елемента',
+      '1080': 'Обмежено 1080p, знижується окремо для кожного елемента',
+      '720': 'Менші файли, широка сумісність',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -567,13 +608,13 @@ const uk = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'Найкраще оригінальне аудіо, без перекодування',
+      mp3: 'Перетворити на MP3',
+      m4a: 'Перетворити на M4A (AAC)',
+      opus: 'Перетворити на Opus'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'H.264 вище 1080p недоступний на YouTube — автоматично обмежується 1080p'
   },
   formatLabel: {
     audioFallback: 'Аудіо',
@@ -596,7 +637,8 @@ const uk = {
       message_other: 'Триває завантажень: {{count}}',
       detail: 'Закриття скасує всі активні завантаження.',
       confirm: 'Скасувати завантаження й вийти',
-      keep: 'Продовжити завантаження'
+      keep: 'Продовжити завантаження',
+      pause: 'Призупинити завантаження й вийти'
     },
     closeToTray: {
       message: 'Приховувати Arroxy в системний трей при закритті?',

--- a/src/shared/i18n/locales/ur.ts
+++ b/src/shared/i18n/locales/ur.ts
@@ -122,13 +122,26 @@ const ur = {
       title: 'اس لنک میں Playlist ہے',
       body: 'کیا آپ صرف وہی ویڈیو چاہتے ہیں جس پر کلک کیا، یا Playlist سے انتخاب کرنا چاہتے ہیں؟ اگلے مرحلے میں آپ مخصوص ویڈیوز یا رینج منتخب کریں گے۔',
       singleVideo: 'صرف یہ ایک',
-      pickFromPlaylist: 'Playlist سے انتخاب'
+      pickFromPlaylist: 'Playlist سے انتخاب',
+      playlistLimit: 'پلے لسٹ جانچ حد: {{count}} آئٹمز',
+      advancedSettings: 'اعلیٰ ترتیبات',
+      singleTooltip: 'yt-dlp کا واحد ویڈیو موڈ استعمال کرتا ہے تاکہ اس URL سے منسلک پلے لسٹ نظر انداز ہو۔',
+      playlistTooltip: 'yt-dlp کا پلے لسٹ موڈ استعمال کرتا ہے اور انتخاب دکھانے سے پہلے آپ کی حد تک آئٹمز لاتا ہے۔'
     },
 
     url: {
       heading: 'YouTube URL',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'فارمیٹس لائیں',
+      fetchFormatsTooltip: 'قطار میں شامل کرنے سے پہلے فارمیٹس، سب ٹائٹلز، فولڈر اور پلے لسٹ آئٹمز مرحلہ وار منتخب کریں۔',
+      quickDownload: 'فوری ڈاؤن لوڈ',
+      quickDownloadTooltip: 'آپ کی محفوظ یا ڈیفالٹ ترجیحات استعمال کرکے سیٹ اپ مراحل کھولے بغیر اس واحد ویڈیو کو قطار میں شامل کرتا ہے۔',
+      quickPreparing: 'تیاری ہو رہی ہے',
+      quickQueued: 'قطار میں شامل ہو گیا',
+      quickSingleOnly: 'فوری ڈاؤن لوڈ صرف ایک ویڈیو کے لیے ہے۔ پلے لسٹس اور چینلز کے لیے فارمیٹس حاصل کریں استعمال کریں۔',
+      quickProbeFailed: 'جانچ ناکام ہوگئی',
+      quickPrepareFailed: 'قطار آئٹم تیار نہیں کیا جا سکا',
+      quickFailed: 'یہ شامل نہیں ہو سکا: {{error}}',
       features: {
         heading: 'Arroxy کیا لا سکتا ہے',
         youtube: {
@@ -234,7 +247,13 @@ const ur = {
           sleepRequests: 'میٹا ڈیٹا چیکس کے درمیان انتظار',
           sleepInterval: 'میڈیا شروع ہونے سے پہلے وقفہ: کم از کم',
           maxSleepInterval: 'میڈیا شروع ہونے سے پہلے وقفہ: زیادہ سے زیادہ',
-          concurrentFragments: 'ڈاؤن لوڈ کنکشنز'
+          concurrentFragments: 'ڈاؤن لوڈ کنکشنز',
+          sleepSubtitles: 'سب ٹائٹل فائلوں سے پہلے انتظار'
+        },
+        presetLabel: 'Arroxy کتنی احتیاط کرے؟',
+        units: {
+          seconds: 'سیکنڈ',
+          threads: 'تھریڈز'
         }
       },
       closeToTray: {
@@ -244,6 +263,15 @@ const ur = {
       analytics: {
         toggle: 'گمنام استعمال کے اعداد و شمار بھیجیں',
         toggleDescription: 'صرف ایپ لانچز گنتا ہے۔ کوئی URL، فائل نام، یا ذاتی ڈیٹا نہیں۔'
+      },
+      limitRate: {
+        label: 'ڈاؤن لوڈ رفتار حد',
+        description: 'میڈیا ڈاؤن لوڈز کے لیے بینڈوڈتھ محدود کریں۔ نیچے درخواستوں کی رفتار عام طور پر زیادہ مضبوط حد ہے۔',
+        off: 'بند',
+        custom: 'حسب ضرورت…',
+        customPlaceholder: 'مثلاً 750K یا 1.5M',
+        invalid: 'K یا M کے ساتھ ایک نمبر استعمال کریں (مثلاً 500K، 1.5M)',
+        activeWarning: 'فعال ڈاؤن لوڈز اپنی موجودہ حد رکھتے ہیں۔ لاگو کرنے کے لیے توقف + جاری رکھیں۔'
       }
     },
     subtitles: {
@@ -391,6 +419,10 @@ const ur = {
       writeThumbnail: {
         label: 'تھمب نیل محفوظ کریں',
         description: 'تھمب نیل کو ڈاؤن لوڈ کے ساتھ .jpg امیج فائل کے طور پر محفوظ کرتا ہے۔'
+      },
+      writeM3u: {
+        label: '.m3u پلے لسٹ فائل بنائیں',
+        description: 'ویڈیوز کے ساتھ .m3u پلے لسٹ محفوظ کرتا ہے تاکہ وہ میڈیا پلیئر میں ترتیب سے کھلیں۔'
       }
     },
     confirm: {
@@ -445,8 +477,22 @@ const ur = {
       hold: 'روکیں',
       resume: 'دوبارہ شروع کریں',
       cancel: 'منسوخ کریں',
-      remove: 'ہٹائیں'
-    }
+      remove: 'ہٹائیں',
+      pullNow: 'اب ڈاؤن لوڈ — قطار چھوڑیں',
+      priorityBadge: 'ترجیح',
+      statusPending: 'منتظر',
+      statusRunning: 'ڈاؤن لوڈ ہو رہا ہے',
+      statusHeld: 'روکا گیا',
+      statusPaused: 'توقف شدہ',
+      statusDone: 'مکمل',
+      statusError: 'خرابی',
+      statusCancelled: 'منسوخ'
+    },
+    resumeAll: 'قطار جاری رکھیں',
+    resumeAllTitle: 'رکے ہوئے ڈاؤن لوڈز جاری رکھیں اور قطار چلنے دیں',
+    limitRate: 'رفتار: {{value}}',
+    limitRateOff: 'رفتار: بند',
+    limitRateTitle: 'ڈاؤن لوڈز کے لیے بینڈوڈتھ حد'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -534,24 +580,24 @@ const ur = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'ہر آئٹم کے لیے سب سے اعلیٰ دستیاب کوڈیک',
+      mp4: 'H.264 + AAC ترجیحی، MP4 کنٹینر · بہترین کوشش'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': '4K تک',
+      '1440': '1440p تک',
+      '1080': '1080p تک',
+      '720': '720p تک',
+      '480': '480p تک',
+      '360': '360p تک'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'ہر آئٹم کے لیے بہترین ویڈیو + آڈیو',
+      '2160': '2160p تک محدود، ہر آئٹم پر ضرورت ہو تو کم',
+      '1440': '2K تک محدود، ہر آئٹم پر ضرورت ہو تو کم',
+      '1080': '1080p تک محدود، ہر آئٹم پر ضرورت ہو تو کم',
+      '720': 'چھوٹی فائلیں، وسیع مطابقت',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -562,13 +608,13 @@ const ur = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'بہترین اصل آڈیو، دوبارہ encode نہیں',
+      mp3: 'MP3 میں تبدیل کریں',
+      m4a: 'M4A (AAC) میں تبدیل کریں',
+      opus: 'Opus میں تبدیل کریں'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'YouTube پر 1080p سے اوپر H.264 دستیاب نہیں — خودکار طور پر 1080p تک محدود'
   },
   formatLabel: {
     audioFallback: 'آڈیو',
@@ -591,7 +637,8 @@ const ur = {
       message_other: '{{count}} ڈاؤن لوڈز جاری ہیں',
       detail: 'بند کرنے سے تمام ایکٹو ڈاؤن لوڈز منسوخ ہو جائیں گے۔',
       confirm: 'ڈاؤن لوڈز منسوخ کریں اور بند کریں',
-      keep: 'ڈاؤن لوڈ جاری رکھیں'
+      keep: 'ڈاؤن لوڈ جاری رکھیں',
+      pause: 'ڈاؤن لوڈز روک کر بند کریں'
     },
     closeToTray: {
       message: 'بند کرتے وقت Arroxy کو سسٹم ٹرے میں چھپائیں؟',

--- a/src/shared/i18n/locales/uz.ts
+++ b/src/shared/i18n/locales/uz.ts
@@ -122,13 +122,26 @@ const uz = {
       title: 'Bu havola Playlist ga tegishli',
       body: 'Faqat bosilgan videoni olasizmi yoki Playlist dan tanlaysizmi? Keyingi qadamda aniq videolar yoki diapazon tanlanadi.',
       singleVideo: 'Faqat shu birini',
-      pickFromPlaylist: 'Playlist dan tanlash'
+      pickFromPlaylist: 'Playlist dan tanlash',
+      playlistLimit: 'Pleylist tekshiruv chegarasi: {{count}} ta element',
+      advancedSettings: 'Kengaytirilgan sozlamalar',
+      singleTooltip: 'Bu URLga ulangan pleylist e’tiborsiz qolishi uchun yt-dlp bitta video rejimidan foydalanadi.',
+      playlistTooltip: 'Tanlagichni ko‘rsatishdan oldin yt-dlp pleylist rejimida belgilangan chegaragacha yuklaydi.'
     },
 
     url: {
       heading: 'YouTube URL',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'Formatlarni olish',
+      fetchFormatsTooltip: 'Navbatga qo‘shishdan oldin formatlar, subtitrlar, jild va pleylist elementlarini bosqichma-bosqich tanlang.',
+      quickDownload: 'Tez yuklab olish',
+      quickDownloadTooltip: 'Saqlangan yoki standart sozlamalaringizdan foydalanib, sozlash bosqichlarini ochmasdan bu bitta videoni navbatga qo‘shadi.',
+      quickPreparing: 'Tayyorlanmoqda',
+      quickQueued: 'Navbatga qo‘shildi',
+      quickSingleOnly: 'Tez yuklab olish faqat bitta video uchun. Pleylistlar va kanallar uchun Formatlarni olishdan foydalaning.',
+      quickProbeFailed: 'Tekshiruv muvaffaqiyatsiz',
+      quickPrepareFailed: 'Navbat elementi tayyorlanmadi',
+      quickFailed: 'Buni qo‘shib bo‘lmadi: {{error}}',
       features: {
         heading: 'Arroxy nima yuklab olishi mumkin',
         youtube: {
@@ -234,7 +247,13 @@ const uz = {
           sleepRequests: 'Metadata tekshiruvlari orasidagi kutish',
           sleepInterval: 'Media boshlanishidan oldingi pauza: min',
           maxSleepInterval: 'Media boshlanishidan oldingi pauza: maks',
-          concurrentFragments: 'Yuklab olish ulanishlari'
+          concurrentFragments: 'Yuklab olish ulanishlari',
+          sleepSubtitles: 'Subtitr fayllaridan oldin kutish'
+        },
+        presetLabel: 'Arroxy qanchalik ehtiyotkor bo‘lsin?',
+        units: {
+          seconds: 'soniya',
+          threads: 'oqim'
         }
       },
       closeToTray: {
@@ -244,6 +263,15 @@ const uz = {
       analytics: {
         toggle: 'Anonim foydalanish statistikasini yuborish',
         toggleDescription: 'Faqat ilovani ishga tushirish sonini hisoblaydi. URL, fayl nomlari yoki shaxsiy maʼlumotlar yoʼq.'
+      },
+      limitRate: {
+        label: 'Yuklab olish tezligi chegarasi',
+        description: 'Media yuklab olishlar uchun tarmoq sarfini cheklang. Quyidagi so‘rov oralig‘i odatda kuchliroq vosita.',
+        off: 'O‘chiq',
+        custom: 'Maxsus…',
+        customPlaceholder: 'mas. 750K yoki 1.5M',
+        invalid: 'K yoki M bilan tugaydigan son kiriting (mas. 500K, 1.5M)',
+        activeWarning: 'Faol yuklab olishlar joriy chegarasini saqlaydi. Qo‘llash uchun Pauza + Davom ettiring.'
       }
     },
     subtitles: {
@@ -391,6 +419,10 @@ const uz = {
       writeThumbnail: {
         label: 'Muqovani saqlash',
         description: 'Muqovani yuklamaning yoniga .jpg rasm fayli sifatida saqlaydi.'
+      },
+      writeM3u: {
+        label: '.m3u pleylist faylini yaratish',
+        description: 'Videolar media pleerda tartib bilan ochilishi uchun yoniga .m3u pleylistini saqlaydi.'
       }
     },
     confirm: {
@@ -445,8 +477,22 @@ const uz = {
       hold: 'Ushlab tur',
       resume: 'Davom ettirish',
       cancel: 'Bekor qilish',
-      remove: "O'chirish"
-    }
+      remove: "O'chirish",
+      pullNow: 'Hozir yuklab olish — navbatni o‘tkazish',
+      priorityBadge: 'Ustuvor',
+      statusPending: 'Kutilmoqda',
+      statusRunning: 'Yuklanmoqda',
+      statusHeld: 'Ushlab turilgan',
+      statusPaused: 'Pauzada',
+      statusDone: 'Tayyor',
+      statusError: 'Xato',
+      statusCancelled: 'Bekor qilingan'
+    },
+    resumeAll: 'Navbatni davom ettirish',
+    resumeAllTitle: 'Pauzadagi yuklab olishlarni davom ettirib, navbatni yurgizish',
+    limitRate: 'Tezlik: {{value}}',
+    limitRateOff: 'Tezlik: o‘chiq',
+    limitRateTitle: 'Yuklab olishlar uchun tarmoq chegarasi'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -534,24 +580,24 @@ const uz = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'Har bir element uchun mavjud eng yuqori kodek',
+      mp4: 'H.264 + AAC afzal, MP4 konteyner · imkon qadar'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': '4K gacha',
+      '1440': '1440p gacha',
+      '1080': '1080p gacha',
+      '720': '720p gacha',
+      '480': '480p gacha',
+      '360': '360p gacha'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'Har bir element uchun eng yaxshi video + audio',
+      '2160': '2160p bilan cheklanadi, har elementda pastroqqa tushadi',
+      '1440': '2K bilan cheklanadi, har elementda pastroqqa tushadi',
+      '1080': '1080p bilan cheklanadi, har elementda pastroqqa tushadi',
+      '720': 'Kichikroq fayllar, keng moslik',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -562,13 +608,13 @@ const uz = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'Eng yaxshi asl audio, qayta kodlanmaydi',
+      mp3: 'MP3 ga aylantirish',
+      m4a: 'M4A (AAC) ga aylantirish',
+      opus: 'Opus ga aylantirish'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'YouTube’da 1080p dan yuqori H.264 mavjud emas — avtomatik 1080p bilan cheklanadi'
   },
   formatLabel: {
     audioFallback: 'Audio',
@@ -591,7 +637,8 @@ const uz = {
       message_other: '{{count}} ta yuklama jarayonda',
       detail: 'Yopilsa barcha faol yuklamalar bekor qilinadi.',
       confirm: 'Yuklamalarni bekor qilish va chiqish',
-      keep: 'Yuklab olishni davom ettirish'
+      keep: 'Yuklab olishni davom ettirish',
+      pause: 'Yuklab olishlarni pauzalab chiqish'
     },
     closeToTray: {
       message: 'Yopilganda Arroxy ni tizim soatiga yashirasizmi?',

--- a/src/shared/i18n/locales/vi.ts
+++ b/src/shared/i18n/locales/vi.ts
@@ -122,13 +122,26 @@ const vi = {
       title: 'Liên kết này có Playlist',
       body: 'Bạn chỉ muốn video đã chọn, hay muốn chọn từ Playlist? Bạn sẽ chọn các video cụ thể hoặc một đoạn ở bước tiếp theo.',
       singleVideo: 'Chỉ cái này thôi',
-      pickFromPlaylist: 'Chọn từ Playlist'
+      pickFromPlaylist: 'Chọn từ Playlist',
+      playlistLimit: 'Giới hạn dò playlist: {{count}} mục',
+      advancedSettings: 'Cài đặt nâng cao',
+      singleTooltip: 'Dùng chế độ video đơn của yt-dlp để bỏ qua playlist gắn với URL này.',
+      playlistTooltip: 'Dùng chế độ playlist của yt-dlp và lấy đến giới hạn dò playlist trước khi hiện bộ chọn.'
     },
 
     url: {
       heading: 'YouTube URL',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: 'Tải định dạng',
+      fetchFormatsTooltip: 'Chọn định dạng, phụ đề, thư mục và mục playlist từng bước trước khi thêm vào hàng đợi.',
+      quickDownload: 'Tải nhanh',
+      quickDownloadTooltip: 'Dùng tùy chọn đã lưu hoặc mặc định của bạn và thêm video đơn này vào hàng đợi mà không mở các bước thiết lập.',
+      quickPreparing: 'Đang chuẩn bị',
+      quickQueued: 'Đã thêm vào hàng đợi',
+      quickSingleOnly: 'Tải nhanh chỉ dành cho video đơn. Dùng Lấy định dạng cho playlist và kênh.',
+      quickProbeFailed: 'Thăm dò thất bại',
+      quickPrepareFailed: 'Không thể chuẩn bị mục hàng đợi',
+      quickFailed: 'Không thể thêm mục này: {{error}}',
       features: {
         heading: 'Arroxy có thể tải gì',
         youtube: {
@@ -234,7 +247,13 @@ const vi = {
           sleepRequests: 'Chờ giữa các lần kiểm tra metadata',
           sleepInterval: 'Dừng trước khi media bắt đầu: tối thiểu',
           maxSleepInterval: 'Dừng trước khi media bắt đầu: tối đa',
-          concurrentFragments: 'Kết nối tải xuống'
+          concurrentFragments: 'Kết nối tải xuống',
+          sleepSubtitles: 'Chờ trước tệp phụ đề'
+        },
+        presetLabel: 'Arroxy nên thận trọng mức nào?',
+        units: {
+          seconds: 'giây',
+          threads: 'luồng'
         }
       },
       closeToTray: {
@@ -244,6 +263,15 @@ const vi = {
       analytics: {
         toggle: 'Gửi thống kê sử dụng ẩn danh',
         toggleDescription: 'Chỉ đếm số lần khởi động ứng dụng. Không có URL, tên tệp hay dữ liệu cá nhân.'
+      },
+      limitRate: {
+        label: 'Giới hạn tốc độ tải',
+        description: 'Giới hạn băng thông cho tải media. Nhịp yêu cầu bên dưới thường là đòn bẩy giới hạn mạnh hơn.',
+        off: 'Tắt',
+        custom: 'Tùy chỉnh…',
+        customPlaceholder: 'vd. 750K hoặc 1.5M',
+        invalid: 'Dùng một số theo sau bởi K hoặc M (vd. 500K, 1.5M)',
+        activeWarning: 'Tải xuống đang chạy giữ giới hạn hiện tại. Tạm dừng + Tiếp tục để áp dụng.'
       }
     },
     subtitles: {
@@ -391,6 +419,10 @@ const vi = {
       writeThumbnail: {
         label: 'Lưu hình thu nhỏ',
         description: 'Lưu hình thu nhỏ dưới dạng tệp ảnh .jpg cạnh tệp tải xuống.'
+      },
+      writeM3u: {
+        label: 'Tạo tệp playlist .m3u',
+        description: 'Lưu playlist .m3u cạnh các video để mở đúng thứ tự trong trình phát.'
       }
     },
     confirm: {
@@ -445,8 +477,22 @@ const vi = {
       hold: 'Giữ',
       resume: 'Tiếp tục',
       cancel: 'Hủy',
-      remove: 'Xóa'
-    }
+      remove: 'Xóa',
+      pullNow: 'Tải ngay — bỏ qua hàng đợi',
+      priorityBadge: 'Ưu tiên',
+      statusPending: 'Đang chờ',
+      statusRunning: 'Đang tải',
+      statusHeld: 'Đang giữ',
+      statusPaused: 'Tạm dừng',
+      statusDone: 'Xong',
+      statusError: 'Lỗi',
+      statusCancelled: 'Đã hủy'
+    },
+    resumeAll: 'Tiếp tục hàng đợi',
+    resumeAllTitle: 'Tiếp tục các tải xuống đã tạm dừng và cho hàng đợi chạy tiếp',
+    limitRate: 'Tốc độ: {{value}}',
+    limitRateOff: 'Tốc độ: Tắt',
+    limitRateTitle: 'Giới hạn băng thông cho tải xuống'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -534,24 +580,24 @@ const vi = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'Codec cao nhất có sẵn cho từng mục',
+      mp4: 'Ưu tiên H.264 + AAC, vùng chứa MP4 · cố gắng tốt nhất'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': 'Tối đa 4K',
+      '1440': 'Tối đa 1440p',
+      '1080': 'Tối đa 1080p',
+      '720': 'Tối đa 720p',
+      '480': 'Tối đa 480p',
+      '360': 'Tối đa 360p'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: 'Video + âm thanh tốt nhất có sẵn cho từng mục',
+      '2160': 'Giới hạn 2160p, hạ xuống theo từng mục nếu cần',
+      '1440': 'Giới hạn 2K, hạ xuống theo từng mục nếu cần',
+      '1080': 'Giới hạn 1080p, hạ xuống theo từng mục nếu cần',
+      '720': 'Tệp nhỏ hơn, tương thích rộng',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -562,13 +608,13 @@ const vi = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: 'Âm thanh gốc tốt nhất, không mã hóa lại',
+      mp3: 'Chuyển sang MP3',
+      m4a: 'Chuyển sang M4A (AAC)',
+      opus: 'Chuyển sang Opus'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'H.264 trên 1080p không có trên YouTube — tự động giới hạn ở 1080p'
   },
   formatLabel: {
     audioFallback: 'Âm thanh',
@@ -591,7 +637,8 @@ const vi = {
       message_other: '{{count}} tải xuống đang tiến hành',
       detail: 'Đóng ứng dụng sẽ hủy tất cả các tải xuống đang hoạt động.',
       confirm: 'Hủy tải xuống & Thoát',
-      keep: 'Tiếp tục tải xuống'
+      keep: 'Tiếp tục tải xuống',
+      pause: 'Tạm dừng tải và thoát'
     },
     closeToTray: {
       message: 'Ẩn Arroxy xuống khay hệ thống khi đóng?',

--- a/src/shared/i18n/locales/zh.ts
+++ b/src/shared/i18n/locales/zh.ts
@@ -122,13 +122,26 @@ const zh = {
       title: '此链接包含 Playlist',
       body: '只想下载你点击的那个视频，还是从 Playlist 中挑选？下一步可以选择特定视频或指定范围。',
       singleVideo: '就这一个',
-      pickFromPlaylist: '从 Playlist 中挑选'
+      pickFromPlaylist: '从 Playlist 中挑选',
+      playlistLimit: '播放列表探测限制：{{count}} 个项目',
+      advancedSettings: '高级设置',
+      singleTooltip: '使用 yt-dlp 单视频模式，因此会忽略此 URL 附带的播放列表。',
+      playlistTooltip: '使用 yt-dlp 播放列表模式，并在显示选择器前获取到你的探测限制。'
     },
 
     url: {
       heading: 'YouTube 链接',
       placeholder: 'https://www.youtube.com/watch?v=...',
       fetchFormats: '获取格式',
+      fetchFormatsTooltip: '加入队列前，逐步选择格式、字幕、文件夹和播放列表项目。',
+      quickDownload: '快速下载',
+      quickDownloadTooltip: '使用已保存或默认偏好设置，将此单个视频加入队列，而不打开设置步骤。',
+      quickPreparing: '正在准备',
+      quickQueued: '已加入队列',
+      quickSingleOnly: '快速下载仅适用于单个视频。播放列表和频道请使用获取格式。',
+      quickProbeFailed: '探测失败',
+      quickPrepareFailed: '无法准备队列项目',
+      quickFailed: '无法添加此项：{{error}}',
       features: {
         heading: 'Arroxy 能下载什么',
         youtube: {
@@ -240,7 +253,8 @@ const zh = {
         units: {
           seconds: '秒',
           threads: '线程'
-        }
+        },
+        presetLabel: 'Arroxy 应该多谨慎？'
       },
       closeToTray: {
         toggle: '关闭时最小化到托盘',
@@ -249,6 +263,15 @@ const zh = {
       analytics: {
         toggle: '发送匿名使用统计',
         toggleDescription: '仅统计应用启动次数，不包含任何URL、文件名或个人数据。'
+      },
+      limitRate: {
+        label: '下载速度限制',
+        description: '限制媒体下载的带宽。下面的请求节奏通常是更强的限速手段。',
+        off: '关闭',
+        custom: '自定义…',
+        customPlaceholder: '例如 750K 或 1.5M',
+        invalid: '使用数字并加上 K 或 M（例如 500K、1.5M）',
+        activeWarning: '正在进行的下载会保留当前限制。暂停再继续即可应用更改。'
       }
     },
     subtitles: {
@@ -396,6 +419,10 @@ const zh = {
       writeThumbnail: {
         label: '保存缩略图',
         description: '将缩略图保存为 .jpg 图片文件，放在下载文件旁边。'
+      },
+      writeM3u: {
+        label: '生成 .m3u 播放列表文件',
+        description: '在视频旁保存 .m3u 播放列表，以便播放器按顺序打开。'
       }
     },
     confirm: {
@@ -450,8 +477,22 @@ const zh = {
       hold: '搁置',
       resume: '继续',
       cancel: '取消',
-      remove: '移除'
-    }
+      remove: '移除',
+      pullNow: '立即下载 — 跳过队列',
+      priorityBadge: '优先',
+      statusPending: '等待中',
+      statusRunning: '下载中',
+      statusHeld: '已挂起',
+      statusPaused: '已暂停',
+      statusDone: '完成',
+      statusError: '错误',
+      statusCancelled: '已取消'
+    },
+    resumeAll: '继续队列',
+    resumeAllTitle: '继续已暂停的下载并让队列继续运行',
+    limitRate: '速度：{{value}}',
+    limitRateOff: '速度：关闭',
+    limitRateTitle: '下载带宽限制'
   },
   update: {
     appVersion: 'Arroxy {{version}}',
@@ -539,24 +580,24 @@ const zh = {
       mp4: 'MP4 (H.264)'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: '每个项目可用的最高编解码器',
+      mp4: '优先 H.264 + AAC，MP4 容器 · 尽力匹配'
     },
     tier: {
       best: 'Best quality',
-      '2160': 'Up to 4K',
-      '1440': 'Up to 1440p',
-      '1080': 'Up to 1080p',
-      '720': 'Up to 720p',
-      '480': 'Up to 480p',
-      '360': 'Up to 360p'
+      '2160': '最高 4K',
+      '1440': '最高 1440p',
+      '1080': '最高 1080p',
+      '720': '最高 720p',
+      '480': '最高 480p',
+      '360': '最高 360p'
     },
     tierDesc: {
-      best: 'Highest available video + audio per item',
-      '2160': 'Capped at 2160p, falls back to lower per item',
-      '1440': 'Capped at 2K, falls back to lower per item',
-      '1080': 'Capped at 1080p, falls back to lower per item',
-      '720': 'Smaller files, broad compatibility',
+      best: '每个项目可用的最佳视频 + 音频',
+      '2160': '限制为 2160p，每项必要时降级',
+      '1440': '限制为 2K，每项必要时降级',
+      '1080': '限制为 1080p，每项必要时降级',
+      '720': '文件更小，兼容性广',
       '480': 'Low bandwidth',
       '360': 'Smallest video'
     },
@@ -567,13 +608,13 @@ const zh = {
       opus: 'Opus'
     },
     audioFormatDesc: {
-      best: 'Native best audio, no re-encode',
-      mp3: 'Convert to MP3',
-      m4a: 'Convert to M4A (AAC)',
-      opus: 'Convert to Opus'
+      best: '最佳原生音频，不重新编码',
+      mp3: '转换为 MP3',
+      m4a: '转换为 M4A (AAC)',
+      opus: '转换为 Opus'
     },
     audioFormatBitrate: 'Audio ({{format}} {{kbps}}K)',
-    mp4Cap: 'H.264 above 1080p is not available on YouTube — capped to 1080p automatically'
+    mp4Cap: 'YouTube 不提供 1080p 以上的 H.264 — 自动限制为 1080p'
   },
   formatLabel: {
     audioFallback: '音频',
@@ -596,7 +637,8 @@ const zh = {
       message_other: '正在进行 {{count}} 个下载',
       detail: '关闭将取消所有正在进行的下载。',
       confirm: '取消下载并退出',
-      keep: '继续下载'
+      keep: '继续下载',
+      pause: '暂停下载并退出'
     },
     closeToTray: {
       message: '关闭时将 Arroxy 最小化到系统托盘？',

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -84,6 +84,9 @@ export const SUPPORTED_LANGS = supportedLangSchema.options;
 export const uiThemeSchema = z.enum(['light', 'dark', 'system']);
 export type UiTheme = z.infer<typeof uiThemeSchema>;
 
+export const quickDownloadStatusSchema = z.enum(['idle', 'preparing', 'queued', 'error']);
+export type QuickDownloadStatus = z.infer<typeof quickDownloadStatusSchema>;
+
 export const cookiesModeSchema = z.enum(['off', 'file', 'browser']);
 export type CookiesMode = z.infer<typeof cookiesModeSchema>;
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6,7 +6,7 @@ export type { PreparedJob } from './preparedJob.js';
 // Re-export the enum types whose canonical definition lives in `schemas.ts`
 // (where they're z.enum schemas). Importing from `@shared/types` continues to
 // work for callers that don't care about the schema vs type distinction.
-export type { Preset, PlaylistSelection, PlaylistVideoTier, PlaylistAudioFormat, SubtitleMode, SubtitleFormat, SponsorBlockMode, SponsorBlockCategory, SupportedLang, UiTheme, QueueItemStatus, QueueLane, AudioConvertTarget, AudioBitrate, AudioConvert, AudioSelection, CookiesMode, CookiesBrowser, NetworkPacingPreset } from './schemas.js';
+export type { Preset, PlaylistSelection, PlaylistVideoTier, PlaylistAudioFormat, SubtitleMode, SubtitleFormat, SponsorBlockMode, SponsorBlockCategory, SupportedLang, UiTheme, QueueItemStatus, QueueLane, AudioConvertTarget, AudioBitrate, AudioConvert, AudioSelection, CookiesMode, CookiesBrowser, NetworkPacingPreset, QuickDownloadStatus } from './schemas.js';
 
 export type { StatusKey } from './schemas.js';
 export type { LocalizedError, YtDlpErrorKind } from './i18n/types.js';

--- a/tests/renderer/app.test.tsx
+++ b/tests/renderer/app.test.tsx
@@ -51,6 +51,53 @@ describe('App renderer', () => {
     });
   });
 
+  it('renders quick download and disables URL actions while preparing', async () => {
+    let resolveProbe!: (value: Awaited<ReturnType<typeof mockAppApi.downloads.probe>>) => void;
+    vi.mocked(mockAppApi.downloads.probe).mockReturnValue(
+      new Promise((resolve) => {
+        resolveProbe = resolve;
+      })
+    );
+    render(<App />);
+
+    const quick = await screen.findByTestId('btn-quick-download');
+    const fetch = screen.getByTestId('btn-find-formats');
+    expect(quick).toHaveTextContent('Quick download');
+    expect(quick).toBeDisabled();
+
+    const input = await screen.findByPlaceholderText(/^https/i);
+    fireEvent.change(input, { target: { value: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' } });
+    fireEvent.click(quick);
+
+    await waitFor(() => {
+      expect(quick).toBeDisabled();
+      expect(fetch).toBeDisabled();
+      expect(quick).toHaveTextContent('Preparing');
+    });
+
+    resolveProbe({
+      ok: true,
+      data: {
+        kind: 'video',
+        extractor: 'youtube',
+        extractorKey: 'Youtube',
+        webpageUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        isAudioOnlySource: false,
+        formats: [{ formatId: '22', label: '720p | mp4', ext: 'mp4', resolution: '720p', fps: 30, isVideoOnly: false, isAudioOnly: false }],
+        title: 'Test Video',
+        thumbnail: '',
+        subtitles: {},
+        automaticCaptions: {},
+        isLive: false,
+        hasDrm: false
+      }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('quick-download-feedback')).toHaveTextContent('Added to queue');
+    });
+  });
+
   it('shows queue panel below wizard', async () => {
     render(<App />);
     expect(await screen.findByLabelText('Download Queue')).toBeInTheDocument();

--- a/tests/renderer/probe-orchestrator.test.tsx
+++ b/tests/renderer/probe-orchestrator.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAppStore } from '@renderer/store/useAppStore.js';
 import type { ProbeError, ProbeResult } from '@shared/types.js';
 import { ok, fail, type Result } from '@shared/result.js';
+import { defaultAppSettings } from '@shared/constants.js';
 import { RESET_WIZARD_STATE } from '@renderer/store/wizard/commands.js';
 import { buildMockAppApi } from '../shared/mockAppApi.js';
 
@@ -131,6 +132,170 @@ describe('submitUrl — video probe', () => {
     await probePromise;
 
     expect(useAppStore.getState().formatsLoading).toBe(false);
+  });
+});
+
+describe('quickDownload', () => {
+  it('probes in forced single-video mode and queues a prepared item from saved prefs', async () => {
+    const api = buildMockAppApi();
+    vi.mocked(api.downloads.probe).mockResolvedValue(ok(VIDEO_PROBE));
+    window.appApi = api;
+
+    useAppStore.setState({
+      wizardUrl: `${YOUTUBE_URL}&list=PLtest`,
+      wizardOutputDir: '/tmp/downloads',
+      settings: {
+        common: { defaultOutputDir: '/tmp/downloads', rememberLastOutputDir: false, clipboardWatchEnabled: false, includeIdInSingleFilenames: true },
+        single: { lastPreset: 'balanced' },
+        playlist: {}
+      }
+    });
+
+    await useAppStore.getState().quickDownload();
+
+    expect(api.downloads.probe).toHaveBeenCalledWith({
+      url: `${YOUTUBE_URL}&list=PLtest`,
+      playlistMode: 'video'
+    });
+    const queued = vi.mocked(api.queue.cmd.add).mock.calls[0]?.[0]?.[0];
+    expect(queued).toMatchObject({
+      url: `${YOUTUBE_URL}&list=PLtest`,
+      title: 'Test Video',
+      outputDir: '/tmp/downloads',
+      status: 'pending',
+      lane: 'normal',
+      job: expect.objectContaining({
+        kind: 'single-format',
+        extractor: 'youtube',
+        extractorKey: 'Youtube',
+        outputTemplate: '%(title).200B [%(id)s].%(ext)s'
+      })
+    });
+    expect(useAppStore.getState().wizardUrl).toBe('');
+    expect(useAppStore.getState().wizardStep).toBe('url');
+    expect(useAppStore.getState().quickDownloadStatus).toBe('queued');
+  });
+
+  it('works on first launch with default settings and no saved single prefs', async () => {
+    const api = buildMockAppApi();
+    vi.mocked(api.downloads.probe).mockResolvedValue(ok(VIDEO_PROBE));
+    window.appApi = api;
+
+    useAppStore.setState({
+      wizardUrl: YOUTUBE_URL,
+      wizardOutputDir: '/tmp/first-launch-downloads',
+      settings: defaultAppSettings('/tmp/first-launch-downloads')
+    });
+
+    await useAppStore.getState().quickDownload();
+
+    const queued = vi.mocked(api.queue.cmd.add).mock.calls[0]?.[0]?.[0];
+    expect(queued).toMatchObject({
+      outputDir: '/tmp/first-launch-downloads',
+      formatLabel: 'Best quality',
+      job: expect.objectContaining({
+        kind: 'single-format',
+        preset: 'best-quality'
+      })
+    });
+    expect(useAppStore.getState().quickDownloadStatus).toBe('queued');
+    expect(useAppStore.getState().wizardUrl).toBe('');
+    expect(useAppStore.getState().wizardStep).toBe('url');
+  });
+
+  it('resets quick-download feedback when the URL changes', () => {
+    useAppStore.setState({
+      quickDownloadStatus: 'error',
+      quickDownloadError: 'Previous failure'
+    });
+
+    useAppStore.getState().setWizardUrl(YOUTUBE_URL);
+
+    expect(useAppStore.getState().quickDownloadStatus).toBe('idle');
+    expect(useAppStore.getState().quickDownloadError).toBeNull();
+  });
+
+  it('sets preparing while the probe is in flight', async () => {
+    const api = buildMockAppApi();
+    let resolveProbe!: (v: Result<ProbeResult, ProbeError>) => void;
+    vi.mocked(api.downloads.probe).mockReturnValue(
+      new Promise<Result<ProbeResult, ProbeError>>((res) => {
+        resolveProbe = res;
+      })
+    );
+    window.appApi = api;
+
+    useAppStore.setState({ wizardUrl: YOUTUBE_URL, wizardOutputDir: '/tmp' });
+    const promise = useAppStore.getState().quickDownload();
+
+    expect(useAppStore.getState().quickDownloadStatus).toBe('preparing');
+
+    resolveProbe(ok(VIDEO_PROBE));
+    await promise;
+    expect(useAppStore.getState().quickDownloadStatus).toBe('queued');
+  });
+
+  it('rejects playlist probe results without enqueueing', async () => {
+    const api = buildMockAppApi();
+    vi.mocked(api.downloads.probe).mockResolvedValue(ok(PLAYLIST_PROBE));
+    window.appApi = api;
+
+    useAppStore.setState({ wizardUrl: 'https://www.youtube.com/playlist?list=PLtest', wizardOutputDir: '/tmp' });
+    await useAppStore.getState().quickDownload();
+
+    expect(api.queue.cmd.add).not.toHaveBeenCalled();
+    expect(useAppStore.getState().wizardUrl).toBe('https://www.youtube.com/playlist?list=PLtest');
+    expect(useAppStore.getState().quickDownloadStatus).toBe('error');
+    expect(useAppStore.getState().quickDownloadError).toBe('wizard.url.quickSingleOnly');
+  });
+
+  it('keeps the URL and shows an error when probing fails', async () => {
+    const api = buildMockAppApi();
+    vi.mocked(api.downloads.probe).mockResolvedValue(fail({ kind: 'other', message: 'Probe failed' }));
+    window.appApi = api;
+
+    useAppStore.setState({ wizardUrl: YOUTUBE_URL, wizardOutputDir: '/tmp' });
+    await useAppStore.getState().quickDownload();
+
+    expect(api.queue.cmd.add).not.toHaveBeenCalled();
+    expect(useAppStore.getState().wizardUrl).toBe(YOUTUBE_URL);
+    expect(useAppStore.getState().quickDownloadStatus).toBe('error');
+    expect(useAppStore.getState().quickDownloadError).toBe('Probe failed');
+  });
+
+  it('keeps the URL and shows an error when queue add fails', async () => {
+    const api = buildMockAppApi();
+    vi.mocked(api.downloads.probe).mockResolvedValue(ok(VIDEO_PROBE));
+    vi.mocked(api.queue.cmd.add).mockResolvedValue(fail({ code: 'validation', message: 'Queue failed' }));
+    window.appApi = api;
+
+    useAppStore.setState({ wizardUrl: YOUTUBE_URL, wizardOutputDir: '/tmp' });
+    await useAppStore.getState().quickDownload();
+
+    expect(useAppStore.getState().wizardUrl).toBe(YOUTUBE_URL);
+    expect(useAppStore.getState().quickDownloadStatus).toBe('error');
+    expect(useAppStore.getState().quickDownloadError).toBe('Queue failed');
+  });
+
+  it('opens the cookies config dialog without probing when cookies settings are incomplete', async () => {
+    const api = buildMockAppApi();
+    window.appApi = api;
+
+    useAppStore.setState({
+      wizardUrl: YOUTUBE_URL,
+      wizardOutputDir: '/tmp',
+      settings: {
+        common: { defaultOutputDir: '/tmp', rememberLastOutputDir: false, clipboardWatchEnabled: false, cookiesMode: 'file', cookiesPath: '' },
+        single: {},
+        playlist: {}
+      }
+    });
+
+    await useAppStore.getState().quickDownload();
+
+    expect(api.downloads.probe).not.toHaveBeenCalled();
+    expect(useAppStore.getState().cookiesConfigDialogIssue).toBe('file-missing-path');
+    expect(useAppStore.getState().quickDownloadStatus).toBe('idle');
   });
 });
 

--- a/tests/renderer/splash-screen.test.tsx
+++ b/tests/renderer/splash-screen.test.tsx
@@ -1,0 +1,12 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { SplashScreen } from '@renderer/components/system/SplashScreen.js';
+
+describe('SplashScreen', () => {
+  it('blocks pointer events while warmup overlay is visible', () => {
+    render(<SplashScreen initialized={false} warmupBlocking={[]} warmupDiagnostics={null} warmupProgress={null} />);
+
+    expect(screen.getByTestId('splash-overlay')).toHaveStyle({ pointerEvents: 'auto' });
+  });
+});


### PR DESCRIPTION
## Summary
- add a Quick download button on the URL step that probes in single-video mode and queues using saved/default prefs
- reuse the existing single queue-item builder so quick and confirm queue paths produce the same job shape
- add inline preparing/success/error feedback and playlist/channel single-only handling

## Tests
- bunx vitest run --project jsdom tests/renderer/probe-orchestrator.test.tsx tests/renderer/app.test.tsx
- bun run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## User-facing changes
- Adds a "Quick download" button on the URL input step that probes the entered URL in forced single-video mode and immediately enqueues a download using saved or default single-video preferences (skips the full wizard).
- Inline UX for quick-download: "Preparing" spinner/disabled state, success feedback ("Added to queue"), and explicit error messages including a single-only restriction for playlists/channels.
- While quick-download is preparing the clipboard URL listener and Enter-key submission are ignored and the main "Fetch formats" action is disabled.
- New i18n strings and tooltips for the quick-download flow and failures.

## Internal / refactor changes
- State + actions: introduces QuickDownloadStatus (schema/type) and adds quickDownloadStatus, quickDownloadError to the probe-orchestrator slice; implements quickDownload(): Promise<void> which probes in single mode, applies derived video probe state, persists format prefs, builds and enqueues a single QueueItem, optionally shows queue tips, resets wizard state, and sets status to queued or error.
- Wizard helpers: extracts videoProbeState(...) and refactors applyVideoProbeResult to apply a Partial<AppState>; setWizardUrl now clears quick-download state; RESET_WIZARD_STATE extended with quickDownload fields.
- Queue helpers: exports buildSingleQueueItemFromState(get, lane) (replaces internal buildQueueItem) and maybeShowQueueTip(set); submitWizardToQueue uses the shared single-item builder so quick and confirm flows produce identical job shapes.
- UI: StepUrlInput reads quickDownload state from store, renders the quick-download CTA with spinner/tooltip/feedback, and blocks conflicting actions during preparation.
- Shared schema/types: adds quickDownloadStatusSchema and re-exports QuickDownloadStatus.
- Tests: new/expanded Vitest renderer tests cover quickDownload success, first-launch default presets, in-flight probing transitions, playlist/channel rejection, probe failure, queue-add failure, and cookies-related bypass behavior. Minor change to SplashScreen pointer-events behavior.

## Risk areas
- IPC boundaries and main-process validation: quickDownload triggers downloads.probe, downloads.probeCancel and queue commands via the preload IPC API. Ensure main handlers validate/sanitize probe inputs and responses and cannot be tricked into creating malformed queue items.
- Renderer→main surface expansion: exposing quick enqueue flow increases frequency and paths of renderer-initiated queue operations. Confirm the preload/main handlers enforce authorization, input validation, and do not leak sensitive data (cookies, credentials, absolute paths) into renderer-visible payloads or logs.
- Race conditions / state transitions: although re-entry is guarded and in-flight probes can be cancelled, overlapping clipboard events or rapid URL edits might cause transient inconsistent UI state; review probe cancellation, store transitions, and the guard that blocks new clipboard/Enter events while preparing.
- Type/export changes: new exported helpers (buildSingleQueueItemFromState, maybeShowQueueTip), added slice fields and types alter the renderer's public exports — run full TypeScript build to catch consumers.
- Error messaging: quickDownloadError values are surfaced directly to the UI and sometimes map to i18n keys; verify messages are user-friendly and do not leak internal error traces.
- Release/build: no new runtime dependencies detected, but i18n and type changes require rebuild; ensure CI/type checks pass.

## Tests / checks to run
- Unit/renderer tests:
  - bunx vitest run --project jsdom tests/renderer/probe-orchestrator.test.tsx
  - bunx vitest run --project jsdom tests/renderer/app.test.tsx
- Static/CI:
  - bun run check (lint/type checks)
  - Full TypeScript build to verify new exports/types compile.
- Manual/integration:
  - Quick-download a single-video URL and verify the queued QueueItem shape matches the normal confirm flow.
  - Quick-download a playlist/channel URL and confirm the single-only error is shown and no queue item is created.
  - Simulate probe failures, queue-add failures and incomplete cookies settings to verify quickDownload transitions to error/idle states and errors are user-facing.
  - Inspect IPC traffic (devtools / main logs) to confirm no sensitive data is exposed and payload shapes match main-handler expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->