### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  BUN_VERSION: '1.2.23'
+
+permissions:
+  contents: read
 
 jobs:
   check:
@@ -26,7 +30,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/deps-vuln-gate.yml
+++ b/.github/workflows/deps-vuln-gate.yml
@@ -1,8 +1,7 @@
 name: Deps vuln gate
 
-# Runs `bun audit` against every Dependabot PR. Blocks merge if a bump pulls
-# in (or fails to fix) a high+ advisory. Non-bot PRs skip this — humans run
-# `bun run deps:vuln` locally pre-release instead.
+# Runs `bun audit` against every dependency PR. Blocks merge if a bump pulls
+# in (or fails to fix) a high+ advisory.
 
 on:
   pull_request:
@@ -16,16 +15,18 @@ on:
 permissions:
   contents: read
 
+env:
+  BUN_VERSION: '1.2.23'
+
 jobs:
   audit:
-    if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/deps-vuln-gate.yml
+++ b/.github/workflows/deps-vuln-gate.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@v2.2.0
         with:

--- a/.github/workflows/e2e-cold-start.yml
+++ b/.github/workflows/e2e-cold-start.yml
@@ -13,6 +13,10 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  BUN_VERSION: '1.2.23'
+
+permissions:
+  contents: read
 
 jobs:
   cold-start:
@@ -39,7 +43,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Cache bun dependencies
         uses: actions/cache@v5

--- a/.github/workflows/e2e-cold-start.yml
+++ b/.github/workflows/e2e-cold-start.yml
@@ -40,6 +40,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@v2.2.0
         with:

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -28,6 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           # render-flatpak-manifest.py reads v* tags to build the metainfo
           # <releases> block, matching the tagged release workflow.
           fetch-depth: 0

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -25,6 +25,10 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  BUN_VERSION: '1.2.23'
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -34,7 +38,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
       - run: bun install --frozen-lockfile
       # On tag push, build both NSIS Setup and Portable (both shipped on the
       # GitHub Release; portable feeds the scoop bucket). Otherwise, only

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -36,6 +36,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: ${{ env.BUN_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,10 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  BUN_VERSION: '1.2.23'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   verify-version:
@@ -43,6 +44,26 @@ jobs:
 
           echo "Releasing version $PACKAGE_VERSION"
 
+  quality-gate:
+    needs: verify-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - uses: oven-sh/setup-bun@v2.2.0
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check
+        run: bun run check
+
   prepare-release:
     # Pre-create a single draft release for this tag before any publisher runs.
     # Without this, the parallel mac/linux `build` matrix jobs each call
@@ -55,7 +76,7 @@ jobs:
     # By pre-creating a draft here, electron-publisher reuses it (it returns
     # the existing draft on the next list-releases call) and Windows
     # Installer's `view || create` shortcut also reuses it.
-    needs: verify-version
+    needs: quality-gate
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -78,6 +99,8 @@ jobs:
     # scripts/build/fetch-embedded.sh). yt-dlp + deno remain runtime-fetched
     # by BinaryManager.
     needs: prepare-release
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:
@@ -90,7 +113,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2.2.0
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
       - run: bun install --frozen-lockfile
       - run: bun run ${{ matrix.dist-cmd }}
         env:
@@ -101,6 +124,8 @@ jobs:
   finalize:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
       - name: Set release title and notes
@@ -244,6 +269,8 @@ jobs:
   upload-flatpak:
     needs: build-flatpak
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/release_to_winget.yml
+++ b/.github/workflows/release_to_winget.yml
@@ -8,6 +8,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: windows-latest
@@ -23,7 +26,7 @@ jobs:
             });
             core.setOutput("tag", latest.data.tag_name);
 
-      - uses: vedantmgoyal9/winget-releaser@main
+      - uses: vedantmgoyal9/winget-releaser@7bd472be23763def6e16bd06cc8b1cdfab0e2fd5
         with:
           identifier: AntonioOrionus.Arroxy
           installers-regex: '^Arroxy-Setup-.*\.exe$'


### PR DESCRIPTION
## Summary
- add a release quality gate before publishing
- scope workflow permissions to least privilege
- pin Bun and the Winget publisher action
- run the dependency vulnerability gate for all dependency PRs

## Verification
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -color=false
- bun run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## User-facing changes
- Release process now blocks publishing until a new pre-release quality gate passes (runs bun install --frozen-lockfile and bun run check), reducing the chance of releasing broken or unverified artifacts.
- Dependency vulnerability scanning (bun audit) is applied to all dependency PRs (not just Dependabot), so users should see broader blocking on high+ advisories.

## Internal / refactor changes
- Workflow permissions hardened: default workflows set minimum permissions (contents: read) and publish/release jobs explicitly request write where needed.
- Credentials persistence disabled in PR runs (checkout: persist-credentials: false) to avoid leaking tokens.
- Bun toolchain pinned via workflow-level BUN_VERSION (used across CI, deps-vuln-gate, e2e-cold-start, installer-smoke, release).
- Release workflow restructured: new quality-gate job added and prepare-release now depends on it.
- Winget publisher action pinned from tracking main to a fixed commit SHA.
- Minor CI workflow edits to use the pinned BUN_VERSION env variable.

## Risk areas
- Release/job ordering: the added quality-gate changes release job dependencies — verify artifact propagation, job concurrency, and that downstream jobs still run when expected.
- Build/tooling: pinning Bun (1.2.23) prevents automatic updates; failures may occur if the pinned version becomes incompatible with code or other actions.
- Publisher action pinning: winget-releaser pinned to a specific commit removes automatic upstream fixes/security patches — monitor upstream for updates.
- Permissions tightening: some jobs may fail due to insufficient permissions if any required scopes were omitted; ensure write scopes are granted only where necessary.
- IPC/Electron considerations: no source code changes here, but verify release artifacts used by Electron packaging (if applicable) are still produced and signed as expected under the new pipeline.
- Dependency gating: expanding bun audit to all dependency PRs may block merges more frequently; confirm expected thresholds and false positives.

## Tests / checks to run
- actionlint: go run github.com/rhysd/actionlint/cmd/actionlint@latest -color=false
- Local CI checks: bun run check (already added to quality gate)
- Verify workflows in a dry run or test branch:
  - Trigger dependency PRs from non-Dependabot sources to confirm deps-vuln-gate runs.
  - Run release workflow end-to-end (or simulated) to confirm quality-gate blocks or permits publish as intended and that artifacts propagate to publish jobs.
  - Run Windows installer smoke tests and e2e cold-start suites with pinned Bun.
- Confirm no jobs fail due to permission changes and that persist-credentials: false does not break required checkout/auth flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->