### PR TITLE
Add quick download to clipboard dialog

### DIFF
--- a/src/renderer/src/browserMock.ts
+++ b/src/renderer/src/browserMock.ts
@@ -66,6 +66,7 @@ export function installBrowserMock(): void {
   const progressListeners = new Set<(e: ProgressEvent) => void>();
   const updateListeners = new Set<(info: UpdateAvailablePayload) => void>();
   const warmupProgressListeners = new Set<(e: WarmupProgressEvent) => void>();
+  const clipboardUrlListeners = new Set<(url: string) => void>();
   const queueSnapshotListeners = new Set<(items: QueueItem[]) => void>();
   const queueAddedListeners = new Set<(event: { items: QueueItem[]; atIdx: number }) => void>();
   const queueUpdatedListeners = new Set<(event: { item: QueueItem }) => void>();
@@ -76,6 +77,10 @@ export function installBrowserMock(): void {
   const launchMode = readBrowserMockLaunchMode();
 
   let settings: AppSettings = scenarioState.settings;
+
+  (window as Window & { __arroxyMockEmitClipboardUrl?: (url: string) => void }).__arroxyMockEmitClipboardUrl = (url) => {
+    clipboardUrlListeners.forEach((listener) => listener(url));
+  };
 
   function emitScenarioUpdate(listener: (info: UpdateAvailablePayload) => void): void {
     const update = scenarioState.update ?? { version: '1.2.0', currentVersion: '0.0.1', installChannel: 'direct' as const };
@@ -447,7 +452,10 @@ export function installBrowserMock(): void {
         progressListeners.add(listener);
         return () => progressListeners.delete(listener);
       },
-      onClipboardUrl: () => () => undefined,
+      onClipboardUrl: (listener) => {
+        clipboardUrlListeners.add(listener);
+        return () => clipboardUrlListeners.delete(listener);
+      },
       onWarmupProgress: (listener) => {
         warmupProgressListeners.add(listener);
         return () => warmupProgressListeners.delete(listener);

--- a/src/renderer/src/components/shared/ClipboardConfirmDialog.tsx
+++ b/src/renderer/src/components/shared/ClipboardConfirmDialog.tsx
@@ -1,5 +1,5 @@
 import { type JSX, useRef } from 'react';
-import { ArrowRight } from 'lucide-react';
+import { ArrowRight, Download } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog.js';
 import { Button } from '../ui/button.js';
@@ -10,11 +10,13 @@ interface Props {
   url: string | null;
   onUse: () => void;
   onFetch: () => void;
+  onQuickDownload: () => void;
   onDisable: () => void;
   onCancel: () => void;
+  quickPreparing: boolean;
 }
 
-export function ClipboardConfirmDialog({ open, url, onUse, onFetch, onDisable, onCancel }: Props): JSX.Element {
+export function ClipboardConfirmDialog({ open, url, onUse, onFetch, onQuickDownload, onDisable, onCancel, quickPreparing }: Props): JSX.Element {
   const { t } = useTranslation();
   const fetchButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -25,7 +27,7 @@ export function ClipboardConfirmDialog({ open, url, onUse, onFetch, onDisable, o
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent showCloseButton={false} data-testid="clipboard-confirm-dialog" initialFocus={() => fetchButtonRef.current} className="sm:max-w-lg">
+      <DialogContent showCloseButton={false} data-testid="clipboard-confirm-dialog" initialFocus={() => fetchButtonRef.current} className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>{t('wizard.url.clipboard.dialog.title')}</DialogTitle>
           <DialogDescription>{t('wizard.url.clipboard.dialog.body')}</DialogDescription>
@@ -35,7 +37,7 @@ export function ClipboardConfirmDialog({ open, url, onUse, onFetch, onDisable, o
             {url}
           </div>
         ) : null}
-        <DialogFooter>
+        <DialogFooter className="sm:flex-wrap sm:items-center">
           <Tooltip>
             <TooltipTrigger
               render={(props) => (
@@ -54,7 +56,11 @@ export function ClipboardConfirmDialog({ open, url, onUse, onFetch, onDisable, o
           <Button type="button" variant="outline" onClick={onUse} data-testid="clipboard-confirm-use">
             {t('wizard.url.clipboard.dialog.useButton')}
           </Button>
-          <Button ref={fetchButtonRef} type="button" onClick={onFetch} data-testid="clipboard-confirm-fetch" className="shadow-[0_4px_14px_var(--brand-glow)] gap-2">
+          <Button type="button" variant="outline" onClick={onQuickDownload} disabled={quickPreparing} data-testid="clipboard-confirm-quick-download" className="gap-2">
+            {quickPreparing ? <span className="h-4 w-4 rounded-full border-2 border-current/20 border-t-current animate-spin" aria-hidden /> : <Download size={16} />}
+            {quickPreparing ? t('wizard.url.quickPreparing') : t('wizard.url.quickDownload')}
+          </Button>
+          <Button ref={fetchButtonRef} type="button" onClick={onFetch} disabled={quickPreparing} data-testid="clipboard-confirm-fetch" className="shadow-[0_4px_14px_var(--brand-glow)] disabled:shadow-none gap-2">
             {t('wizard.url.fetchFormats')} <ArrowRight size={16} className="rtl:rotate-180" />
           </Button>
         </DialogFooter>

--- a/src/renderer/src/components/wizard/StepUrlInput.tsx
+++ b/src/renderer/src/components/wizard/StepUrlInput.tsx
@@ -108,6 +108,12 @@ export function StepUrlInput(): JSX.Element {
     await submitUrl();
   }
 
+  async function handleQuickDownloadClipboard(): Promise<void> {
+    if (pendingClipboardUrl) setWizardUrl(pendingClipboardUrl);
+    setPendingClipboardUrl(null);
+    await quickDownload();
+  }
+
   function handleDisableClipboard(): void {
     void setClipboardWatchEnabled(false);
     setPendingClipboardUrl(null);
@@ -378,7 +384,7 @@ export function StepUrlInput(): JSX.Element {
         </div>
       </details>
 
-      <ClipboardConfirmDialog open={pendingClipboardUrl !== null && initialized} url={pendingClipboardUrl} onUse={handleConfirmClipboard} onFetch={() => void handleFetchClipboard()} onDisable={handleDisableClipboard} onCancel={handleCancelClipboard} />
+      <ClipboardConfirmDialog open={pendingClipboardUrl !== null && initialized} url={pendingClipboardUrl} onUse={handleConfirmClipboard} onFetch={() => void handleFetchClipboard()} onQuickDownload={() => void handleQuickDownloadClipboard()} onDisable={handleDisableClipboard} onCancel={handleCancelClipboard} quickPreparing={quickPreparing} />
       <IncompleteCookiesConfigDialog issue={cookiesConfigDialogIssue} onDismiss={dismissCookiesConfigDialog} onOpenSettings={openCookiesSettings} />
     </div>
   );

--- a/tests/renderer/wizard-clipboard-autofill.test.tsx
+++ b/tests/renderer/wizard-clipboard-autofill.test.tsx
@@ -126,6 +126,26 @@ describe('wizard clipboard confirm dialog', () => {
     expect(submitSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('"Quick download" appears before fetch, applies the URL, closes the dialog, and calls quickDownload', async () => {
+    const quickDownloadSpy = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ quickDownload: quickDownloadSpy } as Partial<ReturnType<typeof useAppStore.getState>>);
+
+    render(<StepUrlInput />);
+    act(() => {
+      clipboardListener!(FRESH_URL);
+    });
+
+    expect(screen.getByTestId('clipboard-confirm-dialog')).toHaveTextContent(/Quick download.*Fetch formats/s);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('clipboard-confirm-quick-download'));
+    });
+
+    expect(useAppStore.getState().wizardUrl).toBe(FRESH_URL);
+    expect(screen.queryByTestId('clipboard-confirm-dialog')).not.toBeInTheDocument();
+    expect(quickDownloadSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('"Cancel" closes without touching wizardUrl', () => {
     render(<StepUrlInput />);
     act(() => {


### PR DESCRIPTION
## Summary
- add Quick download to the clipboard URL confirmation dialog before Fetch formats
- widen and wrap the dialog footer so the new action fits cleanly
- expose a browser-mock clipboard emitter for deterministic visual testing

## Testing
- bun run check
- visual checked desktop and mobile browser-mock dialog layout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-facing changes

Added a "Quick download" action to the clipboard URL confirmation dialog that appears before the "Fetch formats" step. This allows users to initiate downloads directly from clipboard URLs without navigating through the fetch formats flow. The dialog footer layout was adjusted to accommodate the new button with responsive wrapping on smaller screens.

## Internal/refactor changes

**Component updates:**
- `ClipboardConfirmDialog` now accepts `onQuickDownload` callback and `quickPreparing` loading state, with conditional button disable logic
- `StepUrlInput` added `handleQuickDownloadClipboard` async handler to set the wizard URL from pending clipboard input and trigger download
- Dialog content width expanded (`sm:max-w-lg` → `sm:max-w-2xl`) with footer footer layout adjustments for flex wrapping

**Testing infrastructure:**
- `browserMock.ts` now exposes clipboard URL event mocking: `window.__arroxyMockEmitClipboardUrl(url)` emitter and `mock.events.onClipboardUrl(listener)` subscription handler for deterministic visual testing
- Added new test case verifying quick download action executes the expected flow

## Risk areas

- New global `window.__arroxyMockEmitClipboardUrl` is introduced by `installBrowserMock()`. This is intended for testing environments but should be verified as test-only code and not exposed in production builds.
- Clipboard event handling flow expanded with new state management; verify clipboard URL context propagates correctly through the dialog lifecycle.
- Button disable logic depends on `quickPreparing` state—ensure this state is properly initialized and cleared to prevent UI deadlock.

## Tests and checks

- `bun run check` was run during development
- Visual verification performed for desktop and mobile browser-mock dialog layouts
- New test added for quick download action in `wizard-clipboard-autofill.test.tsx`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->