### PR TITLE
Add playlist scope filters

### DIFF
--- a/src/main/ipc/downloadHandlers.ts
+++ b/src/main/ipc/downloadHandlers.ts
@@ -25,11 +25,11 @@ function getCookiesValidationFailure(settings: Awaited<ReturnType<SettingsStore[
 export function registerDownloadHandlers(deps: DownloadHandlerDeps): void {
   const { downloadService, probeService, settingsStore } = deps;
 
-  handle<z.infer<typeof probeSchema>, ProbeResult, ProbeError>(IPC_CHANNELS.downloadsProbe, probeSchema, async ({ url, playlistMode }) => {
+  handle<z.infer<typeof probeSchema>, ProbeResult, ProbeError>(IPC_CHANNELS.downloadsProbe, probeSchema, async ({ url, playlistMode, playlistScope }) => {
     const settings = await settingsStore.get();
     const issue = getIncompleteCookiesConfigIssue(settings.common);
     if (issue) return fail<ProbeResult, ProbeError>({ kind: 'other', message: cookiesConfigIssueMessage(issue) });
-    return probeService.probe(url, settings.common.cookiesMode ?? 'off', playlistMode ?? 'auto');
+    return probeService.probe(url, settings.common.cookiesMode ?? 'off', playlistMode ?? 'auto', playlistScope);
   });
 
   // Renderer fires this when the user changes URL or navigates away from a

--- a/src/main/services/ProbeService.ts
+++ b/src/main/services/ProbeService.ts
@@ -4,7 +4,7 @@ import { splitStderrLines } from '@main/utils/process.js';
 import { ok, fail, type Result } from '@shared/result.js';
 import { sortFormatsByQuality } from '@shared/qualitySorter.js';
 import { humanSize } from '@shared/format.js';
-import type { FormatOption, PlaylistEntry, ProbeError, ProbePlaylistMode, ProbeResult, ProbeDegradationReason, SubtitleMap } from '@shared/types.js';
+import type { FormatOption, PlaylistEntry, PlaylistScope, ProbeError, ProbePlaylistMode, ProbeResult, ProbeDegradationReason, SubtitleMap } from '@shared/types.js';
 import { LIVE_CHAT_LANG } from '@shared/constants.js';
 import { infoDictSchema, isPlaylistLike, isUrlRedirect, type InfoDict, type PlaylistInfo, type MultiVideoInfo, type VideoInfo, type YtDlpFormat, type YtDlpSubtitleTrack } from '@shared/ytdlp/infoDict.js';
 import { isAudioOnlySource } from '@shared/ytdlp/extractorPredicates.js';
@@ -38,6 +38,8 @@ interface ProbeSignal {
 }
 
 type ProbeAttemptName = 'initial' | 'retry';
+
+type PlaylistScopeRequestLog = PlaylistScope['items'];
 
 interface ProbeAttemptSuccess {
   info: InfoDict;
@@ -334,7 +336,7 @@ export class ProbeService {
     this.inFlight.clear();
   }
 
-  async probe(url: string, cookiesMode: 'off' | 'file' | 'browser' = 'off', playlistMode: ProbePlaylistMode = 'auto'): Promise<Result<ProbeResult, ProbeError>> {
+  async probe(url: string, cookiesMode: 'off' | 'file' | 'browser' = 'off', playlistMode: ProbePlaylistMode = 'auto', playlistScope?: PlaylistScope): Promise<Result<ProbeResult, ProbeError>> {
     const startMs = Date.now();
     const emitSuccess = (result: ProbeResult): void => {
       trackMain('format_probed', {
@@ -357,9 +359,9 @@ export class ProbeService {
     try {
       if (this.mockMode) return ok(buildMockProbeResult(url));
 
-      logger.info('Probe started', { url });
+      logger.info('Probe started', { url, playlistMode, playlistScope: playlistScopeRequestForLog(playlistScope) });
 
-      const probeResult = await this.probeWithRedirectFollow(url, playlistMode, controller.signal);
+      const probeResult = await this.probeWithRedirectFollow(url, playlistMode, playlistScope, controller.signal);
       if (controller.signal.aborted) {
         emitFailure('cancelled');
         return fail<ProbeResult, ProbeError>({ kind: 'other', message: 'Probe cancelled' });
@@ -380,6 +382,7 @@ export class ProbeService {
           // valid container with no entries (private playlist, members-only,
           // geo-blocked, exhausted page). Categorize accordingly so analytics
           // and any user-facing copy can distinguish the cause.
+          logger.warn('Playlist probe returned no entries', { url, playlistMode, playlistScope: playlistScopeRequestForLog(playlistScope) });
           emitFailure('content_unavailable');
           return fail<ProbeResult, ProbeError>({ kind: 'other', message: 'Playlist returned no entries' });
         }
@@ -401,11 +404,11 @@ export class ProbeService {
       }
 
       emitSuccess(mapped);
-      logger.info('Probe result', summarizeProbeResult(mapped));
+      logger.info('Probe result', { ...summarizeProbeResult(mapped), playlistMode, playlistScope: playlistScopeRequestForLog(playlistScope) });
       return ok(mapped);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown probing error';
-      logger.error('Probe failure', { message, url });
+      logger.error('Probe failure', { message, url, playlistMode, playlistScope: playlistScopeRequestForLog(playlistScope) });
       emitFailure(controller.signal.aborted ? 'cancelled' : classifyProbeFailure(message));
       return fail<ProbeResult, ProbeError>({ kind: 'other', message });
     } finally {
@@ -416,26 +419,26 @@ export class ProbeService {
   // Loop over `_type: 'url' / 'url_transparent'` redirects up to depth 1 to
   // follow extractor redirects (e.g. Bandcamp track → resolved video). Anything
   // deeper is a misbehaving extractor — bail rather than loop.
-  private async probeWithRedirectFollow(url: string, playlistMode: ProbePlaylistMode, signal: AbortSignal): Promise<ProbeAttemptResult> {
+  private async probeWithRedirectFollow(url: string, playlistMode: ProbePlaylistMode, playlistScope: PlaylistScope | undefined, signal: AbortSignal): Promise<ProbeAttemptResult> {
     let currentUrl = url;
     for (let depth = 0; depth <= 1; depth++) {
       if (signal.aborted) return { kind: 'failure', error: { kind: 'other', message: 'Probe cancelled' } satisfies ProbeError, errorCategory: 'cancelled' };
-      const attempt = await this.runProbeWithDegradationRetry(currentUrl, playlistMode, signal);
+      const attempt = await this.runProbeWithDegradationRetry(currentUrl, playlistMode, playlistScope, signal);
       if (attempt.kind === 'failure') return attempt;
       const info = attempt.data.info;
       if (!isUrlRedirect(info)) return attempt;
       const next = info.url;
       if (!next || next === currentUrl) return attempt;
-      logger.info('Probe redirect', { from: currentUrl, to: next, depth });
+      logger.info('Probe redirect', { from: currentUrl, to: next, depth, playlistMode, playlistScope: playlistScopeRequestForLog(playlistScope) });
       currentUrl = next;
     }
     // Fell through both attempts; return whatever we got — caller surfaces as
     // 'redirected too many times' if still a url_redirect.
-    return this.runProbeWithDegradationRetry(currentUrl, playlistMode, signal);
+    return this.runProbeWithDegradationRetry(currentUrl, playlistMode, playlistScope, signal);
   }
 
-  private async runProbeWithDegradationRetry(url: string, playlistMode: ProbePlaylistMode, signal: AbortSignal): Promise<ProbeAttemptResult> {
-    const initial = await this.runProbeAttempt(url, 'initial', playlistMode, signal);
+  private async runProbeWithDegradationRetry(url: string, playlistMode: ProbePlaylistMode, playlistScope: PlaylistScope | undefined, signal: AbortSignal): Promise<ProbeAttemptResult> {
+    const initial = await this.runProbeAttempt(url, 'initial', playlistMode, playlistScope, signal);
     if (initial.kind === 'failure') return initial;
     if (initial.data.degradationSignals.length === 0) return initial;
     if (signal.aborted) return initial;
@@ -445,9 +448,9 @@ export class ProbeService {
       degradationSignals: initial.data.degradationSignals
     });
 
-    const retry = await this.runProbeAttempt(url, 'retry', playlistMode, signal);
+    const retry = await this.runProbeAttempt(url, 'retry', playlistMode, playlistScope, signal);
     if (retry.kind === 'failure') {
-      logger.info('Probe retry failed; using initial degraded result', { url });
+      logger.info('Probe retry failed; using initial degraded result', { url, playlistMode, playlistScope: playlistScopeRequestForLog(playlistScope) });
       return initial;
     }
     if (retry.data.degradationSignals.length === 0) return retry;
@@ -458,10 +461,10 @@ export class ProbeService {
     return retryFormatCount > initialFormatCount ? retry : initial;
   }
 
-  private async runProbeAttempt(url: string, attempt: ProbeAttemptName, playlistMode: ProbePlaylistMode, signal: AbortSignal): Promise<ProbeAttemptResult> {
+  private async runProbeAttempt(url: string, attempt: ProbeAttemptName, playlistMode: ProbePlaylistMode, playlistScope: PlaylistScope | undefined, signal: AbortSignal): Promise<ProbeAttemptResult> {
     const source = attempt === 'retry' ? 'yt-dlp-probe-retry' : 'yt-dlp-probe';
     const result = await this.ytDlp.run(
-      { kind: 'probe', url, playlistMode },
+      { kind: 'probe', url, playlistMode, playlistScope },
       {
         abortSignal: signal,
         onStderr: (chunk) => {
@@ -488,7 +491,7 @@ export class ProbeService {
       // probe-time failures we additionally recognize 'unsupportedUrl' which
       // yt-dlp emits before extraction begins.
       const probeKind = classifyProbeFailure(rawError ?? '');
-      logger.error('yt-dlp probe failed', { attempt, code, url, kind: probeKind });
+      logger.error('yt-dlp probe failed', { attempt, code, url, kind: probeKind, playlistMode, playlistScope: playlistScopeRequestForLog(playlistScope) });
       return {
         kind: 'failure',
         error: { kind: 'ytdlp', error: { kind: probeKind, raw: rawError ?? 'Probing failed' } } satisfies ProbeError,
@@ -525,6 +528,8 @@ export class ProbeService {
     logger.info('Probe complete', {
       attempt,
       url,
+      playlistMode,
+      playlistScope: playlistScopeRequestForLog(playlistScope),
       type: info._type ?? 'video',
       title: (info as VideoInfo).title,
       extractor: (info as VideoInfo).extractor,
@@ -541,6 +546,10 @@ function formatCount(info: InfoDict): number {
   if (isPlaylistLike(info)) return info.entries.length;
   const v = info as VideoInfo;
   return v.formats?.length ?? 0;
+}
+
+function playlistScopeRequestForLog(scope: PlaylistScope | undefined): PlaylistScopeRequestLog {
+  return scope?.items ?? { kind: 'app-limit' };
 }
 
 // Compact, log-friendly summary of a ProbeResult. Intentionally drops large

--- a/src/main/services/YtDlp.ts
+++ b/src/main/services/YtDlp.ts
@@ -10,7 +10,7 @@ import { siteForUrl } from '@shared/sites/index.js';
 import type { PlaylistScope, SubtitleFormat, SubtitleMode, SponsorBlockMode, SponsorBlockCategory, StatusKey, AudioConvert } from '@shared/types.js';
 import { resolveEmbedPolicy } from '@shared/embedPolicy.js';
 import { resolveNetworkPacing, resolvePlaylistProbeLimit } from '@shared/networkPacing.js';
-import { describePlaylistScopeForLog } from '@shared/playlistScope.js';
+import { describePlaylistScopeForLog, playlistScopeSentinelFields } from '@shared/playlistScope.js';
 import { DEFAULT_PLAYLIST_PROBE_LIMIT, type NetworkPacingArgs } from '@shared/constants.js';
 import type { BinaryManager } from './BinaryManager.js';
 import type { TokenService } from './TokenService.js';
@@ -412,9 +412,8 @@ function buildSubtitleArgs(req: Extract<YtDlpRequest, { kind: 'subtitle' }>, pac
 }
 
 function playlistScopeArgs(scope: PlaylistScope | undefined, visibleLimit: number): string[] {
-  if (!scope || scope.items.kind === 'app-limit') return ['--playlist-end', String(visibleLimit + 1)];
-  if (scope.items.kind === 'first') return ['--playlist-items', `1:${scope.items.count + 1}`];
-  return ['--playlist-items', `${scope.items.from}:${scope.items.to + 1}`];
+  const fields = playlistScopeSentinelFields(scope, visibleLimit);
+  return [fields.ytDlpFlag, fields.ytDlpValue];
 }
 
 export function buildVideoArgs(req: Extract<YtDlpRequest, { kind: 'video' | 'video+embed' }>, pacing: NetworkPacingArgs | undefined): string[] {

--- a/src/main/services/YtDlp.ts
+++ b/src/main/services/YtDlp.ts
@@ -7,9 +7,10 @@ import { resolveCookies, type ResolvedCookies } from './cookiesResolver.js';
 import { nonEmpty } from '@shared/format.js';
 import { EMBED_CONTAINER_EXT } from '@shared/subtitlePath.js';
 import { siteForUrl } from '@shared/sites/index.js';
-import type { SubtitleFormat, SubtitleMode, SponsorBlockMode, SponsorBlockCategory, StatusKey, AudioConvert } from '@shared/types.js';
+import type { PlaylistScope, SubtitleFormat, SubtitleMode, SponsorBlockMode, SponsorBlockCategory, StatusKey, AudioConvert } from '@shared/types.js';
 import { resolveEmbedPolicy } from '@shared/embedPolicy.js';
 import { resolveNetworkPacing, resolvePlaylistProbeLimit } from '@shared/networkPacing.js';
+import { describePlaylistScopeForLog } from '@shared/playlistScope.js';
 import { DEFAULT_PLAYLIST_PROBE_LIMIT, type NetworkPacingArgs } from '@shared/constants.js';
 import type { BinaryManager } from './BinaryManager.js';
 import type { TokenService } from './TokenService.js';
@@ -38,7 +39,7 @@ function redactProxy(url: string | undefined): string | null {
 export type ProbePlaylistMode = 'auto' | 'video' | 'playlist';
 
 export type YtDlpRequest =
-  | { kind: 'probe'; url: string; playlistMode?: ProbePlaylistMode }
+  | { kind: 'probe'; url: string; playlistMode?: ProbePlaylistMode; playlistScope?: PlaylistScope }
   | {
       kind: 'subtitle';
       url: string;
@@ -410,6 +411,12 @@ function buildSubtitleArgs(req: Extract<YtDlpRequest, { kind: 'subtitle' }>, pac
   return ['--skip-download', '--no-playlist', '--write-subs', '--sub-langs', req.subtitleLanguages.join(','), ...(req.writeAutoSubs ? ['--write-auto-subs'] : []), ...sleepSubtitlesArgs(pacing), ...requestPacingArgs(pacing), '--sub-format', `${fmt}/best`, '--convert-subs', fmt, '-o', `${subOutputDir}/${template}`, req.url];
 }
 
+function playlistScopeArgs(scope: PlaylistScope | undefined, visibleLimit: number): string[] {
+  if (!scope || scope.items.kind === 'app-limit') return ['--playlist-end', String(visibleLimit + 1)];
+  if (scope.items.kind === 'first') return ['--playlist-items', `1:${scope.items.count + 1}`];
+  return ['--playlist-items', `${scope.items.from}:${scope.items.to + 1}`];
+}
+
 export function buildVideoArgs(req: Extract<YtDlpRequest, { kind: 'video' | 'video+embed' }>, pacing: NetworkPacingArgs | undefined): string[] {
   const skipDownload = req.kind === 'video' && req.skipDownload === true;
   const args: string[] = ['--progress', '--no-playlist'];
@@ -525,8 +532,8 @@ export function buildArgs(req: YtDlpRequest, opts: { pacing?: NetworkPacingArgs;
       //   default routes Radio/Mix to playlist, which is rarely user intent.
       const modeFlag = req.playlistMode === 'video' ? ['--no-playlist'] : req.playlistMode === 'playlist' ? ['--yes-playlist'] : [];
       const visibleLimit = opts.playlistProbeLimit ?? DEFAULT_PLAYLIST_PROBE_LIMIT;
-      const capFlag = req.playlistMode === 'video' ? [] : ['--playlist-end', String(visibleLimit + 1)];
-      const args = ['--dump-single-json', '--flat-playlist', ...modeFlag, ...capFlag, ...requestPacingArgs(opts.pacing), req.url];
+      const scopeArgs = req.playlistMode === 'video' ? [] : playlistScopeArgs(req.playlistScope, visibleLimit);
+      const args = ['--dump-single-json', '--flat-playlist', ...modeFlag, ...scopeArgs, ...requestPacingArgs(opts.pacing), req.url];
       return { args };
     }
     case 'subtitle': {
@@ -576,6 +583,13 @@ export class YtDlp {
     const playlistProbeLimit = resolvePlaylistProbeLimit(settings.common);
     const { args, subtitleFormat } = buildArgs(req, { pacing, playlistProbeLimit });
     const isProbe = req.kind === 'probe';
+    if (isProbe) {
+      ytDlpLog.info('probe request', {
+        url: req.url,
+        playlistMode: req.playlistMode ?? 'auto',
+        playlistScope: req.playlistMode === 'video' ? null : describePlaylistScopeForLog(req.playlistScope, playlistProbeLimit)
+      });
+    }
     // Bandwidth cap applies to media downloads only — probes need raw speed
     // for snappy "Fetch formats" UX, sidecar subs are tiny so throttling
     // wouldn't change YouTube's anti-bot signal.

--- a/src/renderer/src/browserMock.ts
+++ b/src/renderer/src/browserMock.ts
@@ -1,7 +1,7 @@
 import type { AppApi } from '@shared/api.js';
 import type { AppSettings, DependencyDiagnostic, DependencyId, ProgressEvent, QueueItem, StatusEvent, UpdateAvailablePayload, WarmUpOutput, WarmupProgressEvent } from '@shared/types.js';
 import { QUEUE_STATUS, STATUS_KEY } from '@shared/schemas.js';
-import { buildScenarioAppApiState, getScenario, normalVideoProbe, playlistProbe, readScenarioIdFromUrl, readUrlParams, type BrowserMockScenario } from './dev/browserMockScenarios.js';
+import { buildScenarioAppApiState, getScenario, normalVideoProbe, playlistProbe, readScenarioIdFromUrl, readUrlParams, shouldMockEmptyPlaylistScopeReload, type BrowserMockScenario } from './dev/browserMockScenarios.js';
 import { applyThemeLive, readKnobs, RTL_LANGS } from './dev/browserMockKnobs.js';
 
 const BROWSER_MOCK_LAUNCH_MODES = ['ready', 'cold-loading', 'cold-error'] as const;
@@ -301,6 +301,10 @@ export function installBrowserMock(): void {
 
         if (scenarioState.probeError) {
           return { ok: false, error: scenarioState.probeError };
+        }
+
+        if (shouldMockEmptyPlaylistScopeReload(scenarioState.scenario, input.playlistMode, input.playlistScope)) {
+          return { ok: false, error: { kind: 'other', message: 'Playlist returned no entries' } };
         }
 
         if (scenarioState.probeResult) {

--- a/src/renderer/src/components/wizard/NetworkPacingSettings.tsx
+++ b/src/renderer/src/components/wizard/NetworkPacingSettings.tsx
@@ -8,7 +8,6 @@ import { useAppStore } from '../../store/useAppStore.js';
 import { Input } from '../ui/input.js';
 import { RadioOption } from '../ui/radio-option.js';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js';
-import { PlaylistProbeLimitSelector } from './PlaylistProbeLimitSelector.js';
 
 const CUSTOM_FIELDS = [
   { key: 'pacingSleepRequests', labelKey: 'sleepRequests', unitKey: 'seconds', testId: 'pacing-sleep-requests' },
@@ -93,17 +92,6 @@ export function NetworkPacingSettings(): JSX.Element {
       <div className="flex flex-col gap-0.5">
         <span className="text-[13px] font-medium text-foreground">{t('wizard.url.networkPacing.heading')}</span>
         <span className="text-[11px] text-[var(--text-subtle)]">{t('wizard.url.networkPacing.description')}</span>
-      </div>
-
-      <div className="flex flex-col gap-1.5 rounded-md border border-[var(--border-strong)] bg-background/35 p-2.5" data-testid="playlist-probe-limit-section">
-        <div className="flex items-center gap-1">
-          <span className="text-[9px] font-bold uppercase tracking-[0.12em] text-[var(--text-subtle)]">{t('wizard.url.playlistProbeLimit.label')}</span>
-          <HelpTooltip testId="playlist-probe-limit-tooltip" label={t('wizard.url.playlistProbeLimit.label')}>
-            {t('wizard.url.playlistProbeLimit.tooltip')}
-          </HelpTooltip>
-        </div>
-        <p className="text-[11px] text-[var(--text-subtle)]">{t('wizard.url.playlistProbeLimit.description')}</p>
-        <PlaylistProbeLimitSelector testId="playlist-probe-limit" className="w-full" />
       </div>
 
       <div className="flex flex-col gap-1.5 rounded-md border border-[var(--border-strong)] bg-background/35 p-2.5">

--- a/src/renderer/src/components/wizard/PlaylistScopeControl.tsx
+++ b/src/renderer/src/components/wizard/PlaylistScopeControl.tsx
@@ -1,0 +1,149 @@
+import { useState, type JSX } from 'react';
+import { SlidersHorizontal } from 'lucide-react';
+import type { TFunction } from 'i18next';
+import { useTranslation } from 'react-i18next';
+import { playlistScopeSchema, PLAYLIST_PROBE_LIMIT_MAX, PLAYLIST_PROBE_LIMIT_MIN } from '@shared/schemas.js';
+import type { PlaylistScope } from '@shared/types.js';
+import { resolvePlaylistProbeLimit } from '@shared/networkPacing.js';
+import { useAppStore } from '../../store/useAppStore.js';
+import { Button } from '../ui/button.js';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog.js';
+import { Input } from '../ui/input.js';
+import { RadioOption } from '../ui/radio-option.js';
+
+type ItemMode = PlaylistScope['items']['kind'];
+
+interface PlaylistScopeControlProps {
+  onApplyScope?: (scope: PlaylistScope) => Promise<void> | void;
+  applyLabel?: string;
+  pendingLabel?: string;
+  disabled?: boolean;
+}
+
+function copy(t: TFunction, key: string, defaultValue: string, values: Record<string, string | number> = {}): string {
+  return t(key, { defaultValue, ...values });
+}
+
+function scopeSummary(scope: PlaylistScope, appLimit: number, t: TFunction): string {
+  return scope.items.kind === 'app-limit' ? copy(t, 'wizard.url.playlistScope.summaryAppLimit', 'Load first {{count}} items', { count: appLimit }) : scope.items.kind === 'first' ? copy(t, 'wizard.url.playlistScope.summaryFirst', 'Load first {{count}} items', { count: scope.items.count }) : copy(t, 'wizard.url.playlistScope.summaryRange', 'Load items {{from}}-{{to}}', { from: scope.items.from, to: scope.items.to });
+}
+
+export function PlaylistScopeControl({ onApplyScope, applyLabel, pendingLabel, disabled = false }: PlaylistScopeControlProps): JSX.Element {
+  const { t } = useTranslation();
+  const { playlistScope, setPlaylistScope, settings } = useAppStore();
+  const appLimit = resolvePlaylistProbeLimit(settings?.common);
+  const [open, setOpen] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [mode, setMode] = useState<ItemMode>(playlistScope.items.kind);
+  const [firstDraft, setFirstDraft] = useState(playlistScope.items.kind === 'first' ? String(playlistScope.items.count) : String(appLimit));
+  const [fromDraft, setFromDraft] = useState(playlistScope.items.kind === 'range' ? String(playlistScope.items.from) : '1');
+  const [toDraft, setToDraft] = useState(playlistScope.items.kind === 'range' ? String(playlistScope.items.to) : String(appLimit));
+
+  function syncDraftsFromScope(): void {
+    setMode(playlistScope.items.kind);
+    setFirstDraft(playlistScope.items.kind === 'first' ? String(playlistScope.items.count) : String(appLimit));
+    setFromDraft(playlistScope.items.kind === 'range' ? String(playlistScope.items.from) : '1');
+    setToDraft(playlistScope.items.kind === 'range' ? String(playlistScope.items.to) : String(appLimit));
+  }
+
+  function parseScope(): PlaylistScope | null {
+    const items = mode === 'app-limit' ? { kind: 'app-limit' as const } : mode === 'first' ? { kind: 'first' as const, count: Number(firstDraft) } : { kind: 'range' as const, from: Number(fromDraft), to: Number(toDraft) };
+    const candidate = { items };
+    const parsed = playlistScopeSchema.safeParse(candidate);
+    return parsed.success ? parsed.data : null;
+  }
+
+  const parsedScope = parseScope();
+
+  function resetDrafts(): void {
+    setMode('app-limit');
+    setFirstDraft(String(appLimit));
+    setFromDraft('1');
+    setToDraft(String(appLimit));
+  }
+
+  async function applyScope(): Promise<void> {
+    if (!parsedScope) return;
+    if (onApplyScope) {
+      setApplying(true);
+      try {
+        await onApplyScope(parsedScope);
+        setOpen(false);
+      } finally {
+        setApplying(false);
+      }
+      return;
+    }
+    setPlaylistScope(parsedScope);
+    setOpen(false);
+  }
+
+  return (
+    <section className="rounded-md border border-[var(--border-strong)] bg-card/40 px-3 py-2.5" data-testid="playlist-scope-control">
+      <div className="flex items-center gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="text-[9px] font-bold uppercase tracking-[0.12em] text-[var(--text-subtle)]">{copy(t, 'wizard.url.playlistScope.label', 'Playlist scope')}</p>
+          <p className="mt-1 truncate text-[12px] text-foreground" data-testid="playlist-scope-summary">
+            {scopeSummary(playlistScope, appLimit, t)}
+          </p>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="gap-1.5"
+          onClick={() => {
+            syncDraftsFromScope();
+            setOpen(true);
+          }}
+          data-testid="playlist-scope-change"
+          disabled={disabled || applying}
+        >
+          <SlidersHorizontal size={14} />
+          {copy(t, 'wizard.url.playlistScope.change', 'Change')}
+        </Button>
+      </div>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md" data-testid="playlist-scope-dialog">
+          <DialogHeader>
+            <DialogTitle>{copy(t, 'wizard.url.playlistScope.dialogTitle', 'Playlist scope')}</DialogTitle>
+            <DialogDescription>{copy(t, 'wizard.url.playlistScope.dialogDescription', 'Choose what Arroxy asks yt-dlp to load for this playlist.')}</DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1.5">
+              <span className="text-[11px] font-medium text-[var(--text-subtle)]">{copy(t, 'wizard.url.playlistScope.itemsLabel', 'Items to load')}</span>
+              <div className="grid gap-1" role="radiogroup" aria-label={copy(t, 'wizard.url.playlistScope.itemsLabel', 'Items to load')}>
+                <RadioOption label={copy(t, 'wizard.url.playlistScope.appLimit', 'Use app limit: {{count}}', { count: appLimit })} checked={mode === 'app-limit'} onClick={() => setMode('app-limit')} />
+                <RadioOption label={copy(t, 'wizard.url.playlistScope.first', 'First')} checked={mode === 'first'} onClick={() => setMode('first')} />
+                {mode === 'first' && <Input type="number" min={PLAYLIST_PROBE_LIMIT_MIN} max={PLAYLIST_PROBE_LIMIT_MAX} value={firstDraft} onChange={(event) => setFirstDraft(event.target.value)} className="h-8 font-mono" data-testid="playlist-scope-first-input" />}
+                <RadioOption label={copy(t, 'wizard.url.playlistScope.range', 'Range')} checked={mode === 'range'} onClick={() => setMode('range')} />
+                {mode === 'range' && (
+                  <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+                    <Input type="number" min={PLAYLIST_PROBE_LIMIT_MIN} max={PLAYLIST_PROBE_LIMIT_MAX} value={fromDraft} onChange={(event) => setFromDraft(event.target.value)} className="h-8 font-mono" data-testid="playlist-scope-range-from" />
+                    <span className="text-[11px] text-[var(--text-subtle)]">{copy(t, 'wizard.url.playlistScope.to', 'to')}</span>
+                    <Input type="number" min={PLAYLIST_PROBE_LIMIT_MIN} max={PLAYLIST_PROBE_LIMIT_MAX} value={toDraft} onChange={(event) => setToDraft(event.target.value)} className="h-8 font-mono" data-testid="playlist-scope-range-to" />
+                  </div>
+                )}
+              </div>
+            </div>
+            {!parsedScope && <p className="text-[11px] text-amber-500">{copy(t, 'wizard.url.playlistScope.invalid', 'Use whole item numbers from 1 to 5000, with the start no higher than the end.')}</p>}
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={resetDrafts} data-testid="playlist-scope-reset">
+              {copy(t, 'wizard.url.playlistScope.reset', 'Reset')}
+            </Button>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              {copy(t, 'wizard.url.playlistScope.cancel', 'Cancel')}
+            </Button>
+            <Button type="button" onClick={() => void applyScope()} disabled={!parsedScope || applying} data-testid="playlist-scope-apply">
+              {applying ? (pendingLabel ?? copy(t, 'wizard.url.playlistScope.reloading', 'Reloading...')) : (applyLabel ?? copy(t, 'wizard.url.playlistScope.apply', 'Apply'))}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}

--- a/src/renderer/src/components/wizard/PlaylistScopeControl.tsx
+++ b/src/renderer/src/components/wizard/PlaylistScopeControl.tsx
@@ -28,6 +28,12 @@ function scopeSummary(scope: PlaylistScope, appLimit: number, t: TFunction): str
   return scope.items.kind === 'app-limit' ? copy(t, 'wizard.url.playlistScope.summaryAppLimit', 'Load first {{count}} items', { count: appLimit }) : scope.items.kind === 'first' ? copy(t, 'wizard.url.playlistScope.summaryFirst', 'Load first {{count}} items', { count: scope.items.count }) : copy(t, 'wizard.url.playlistScope.summaryRange', 'Load items {{from}}-{{to}}', { from: scope.items.from, to: scope.items.to });
 }
 
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === 'string' && error.length > 0) return error;
+  return 'Unknown error';
+}
+
 export function PlaylistScopeControl({ onApplyScope, applyLabel, pendingLabel, disabled = false }: PlaylistScopeControlProps): JSX.Element {
   const { t } = useTranslation();
   const { playlistScope, setPlaylistScope, settings } = useAppStore();
@@ -38,12 +44,14 @@ export function PlaylistScopeControl({ onApplyScope, applyLabel, pendingLabel, d
   const [firstDraft, setFirstDraft] = useState(playlistScope.items.kind === 'first' ? String(playlistScope.items.count) : String(appLimit));
   const [fromDraft, setFromDraft] = useState(playlistScope.items.kind === 'range' ? String(playlistScope.items.from) : '1');
   const [toDraft, setToDraft] = useState(playlistScope.items.kind === 'range' ? String(playlistScope.items.to) : String(appLimit));
+  const [applyError, setApplyError] = useState<string | null>(null);
 
   function syncDraftsFromScope(): void {
     setMode(playlistScope.items.kind);
     setFirstDraft(playlistScope.items.kind === 'first' ? String(playlistScope.items.count) : String(appLimit));
     setFromDraft(playlistScope.items.kind === 'range' ? String(playlistScope.items.from) : '1');
     setToDraft(playlistScope.items.kind === 'range' ? String(playlistScope.items.to) : String(appLimit));
+    setApplyError(null);
   }
 
   function parseScope(): PlaylistScope | null {
@@ -60,15 +68,19 @@ export function PlaylistScopeControl({ onApplyScope, applyLabel, pendingLabel, d
     setFirstDraft(String(appLimit));
     setFromDraft('1');
     setToDraft(String(appLimit));
+    setApplyError(null);
   }
 
   async function applyScope(): Promise<void> {
     if (!parsedScope) return;
+    setApplyError(null);
     if (onApplyScope) {
       setApplying(true);
       try {
         await onApplyScope(parsedScope);
         setOpen(false);
+      } catch (error) {
+        setApplyError(copy(t, 'wizard.url.playlistScope.applyError', 'Could not apply that playlist scope: {{message}}', { message: errorMessage(error) }));
       } finally {
         setApplying(false);
       }
@@ -129,6 +141,11 @@ export function PlaylistScopeControl({ onApplyScope, applyLabel, pendingLabel, d
               </div>
             </div>
             {!parsedScope && <p className="text-[11px] text-amber-500">{copy(t, 'wizard.url.playlistScope.invalid', 'Use whole item numbers from 1 to 5000, with the start no higher than the end.')}</p>}
+            {applyError ? (
+              <p className="text-[11px] text-amber-500" data-testid="playlist-scope-apply-error">
+                {applyError}
+              </p>
+            ) : null}
           </div>
 
           <DialogFooter>

--- a/src/renderer/src/components/wizard/StepPlaylistItems.tsx
+++ b/src/renderer/src/components/wizard/StepPlaylistItems.tsx
@@ -14,6 +14,7 @@ import { resolvePlaylistDir } from '../../store/wizard/playlistDir.js';
 import { formatDuration } from '@renderer/lib/formatDuration.js';
 import { notify } from '@renderer/lib/notify.js';
 import { PlaylistProbeLimitSelector } from './PlaylistProbeLimitSelector.js';
+import { PlaylistScopeControl } from './PlaylistScopeControl.js';
 
 // undefined = no duration metadata (common for nested-playlist entries from
 // music search, channel root, etc.) — render an em-dash instead of falsely
@@ -26,7 +27,7 @@ function formatEntryDuration(seconds: number | undefined, liveLabel: string): st
 export function StepPlaylistItems(): JSX.Element {
   const { t } = useTranslation();
   const store = useAppStore();
-  const { playlistItems, selectedPlaylistItemIds, playlistTitle, playlistProbeLoading, playlistLikelyCapped, syncedDownloadedIds, syncScanState, setPlaylistItemSelected, selectAllPlaylistItems, selectNonePlaylistItems, selectPlaylistRange, confirmPlaylistSelection, back, wizardExtractor, scanDownloadedInFolder, applyFolderSync, setPlaylistFolder, settings, retryFormatProbe } = store;
+  const { playlistItems, selectedPlaylistItemIds, playlistTitle, playlistProbeLoading, playlistScopeReloading, playlistScopeError, playlistLikelyCapped, syncedDownloadedIds, syncScanState, setPlaylistItemSelected, selectAllPlaylistItems, selectNonePlaylistItems, selectPlaylistRange, confirmPlaylistSelection, back, wizardExtractor, scanDownloadedInFolder, applyFolderSync, setPlaylistFolder, settings, reloadPlaylistWithScope, retryFormatProbe } = store;
 
   // Effective folder the playlist's files land in (and where the scan looks) —
   // the same resolver the queue builder + scan use, so display == download == scan.
@@ -70,6 +71,7 @@ export function StepPlaylistItems(): JSX.Element {
   const selectedCount = selectedPlaylistItemIds.length;
   const playlistLimit = resolvePlaylistProbeLimit(settings?.common);
   const showProbeLimitAlert = !playlistProbeLoading && playlistLikelyCapped;
+  const probeLimitDescription = t('wizard.playlist.probeLimitAlertDesc', { count: playlistLimit });
   // yt-dlp's --flat-playlist returns thumbnails for some extractors
   // (YouTube tab) but not others (PornHub paged list, generic). When no
   // entry has one, hide the thumbnail slot entirely so the list renders
@@ -92,12 +94,24 @@ export function StepPlaylistItems(): JSX.Element {
         <span className="shrink-0 text-xs text-muted-foreground">{t(isAudioOnlySource(wizardExtractor) ? 'wizard.playlist.itemCountAudio' : 'wizard.playlist.itemCount', { count: playlistItems.length })}</span>
       </div>
 
+      <PlaylistScopeControl applyLabel={t('wizard.url.playlistScope.applyReload', { defaultValue: 'Apply and reload' })} pendingLabel={t('wizard.url.playlistScope.reloading', { defaultValue: 'Reloading...' })} disabled={playlistProbeLoading || playlistScopeReloading} onApplyScope={reloadPlaylistWithScope} />
+
+      {playlistScopeError ? (
+        <Alert variant="warning" className="flex items-start gap-3" data-testid="playlist-scope-error">
+          <Info className="mt-0.5 size-4 shrink-0 text-amber-500" />
+          <div className="min-w-0 flex-1">
+            <AlertTitle>{t('wizard.url.playlistScope.emptyTitle', { defaultValue: 'No videos in that scope' })}</AlertTitle>
+            <AlertDescription className="break-words">{playlistScopeError}</AlertDescription>
+          </div>
+        </Alert>
+      ) : null}
+
       {showProbeLimitAlert && (
         <Alert variant="warning" className="flex items-start gap-3" data-testid="playlist-probe-limit-alert">
           <Info className="mt-0.5 size-4 shrink-0 text-sky-500" />
           <div className="min-w-0 flex-1">
             <AlertTitle>{t('wizard.playlist.probeLimitAlertTitle')}</AlertTitle>
-            <AlertDescription className="break-words">{t('wizard.playlist.probeLimitAlertDesc', { count: playlistLimit })}</AlertDescription>
+            <AlertDescription className="break-words">{probeLimitDescription}</AlertDescription>
           </div>
           <PlaylistProbeLimitSelector testId="playlist-alert-probe-limit" showCurrent={false} onLimitChanged={() => retryFormatProbe()} className="w-40" />
         </Alert>

--- a/src/renderer/src/dev/browserMockScenarios.ts
+++ b/src/renderer/src/dev/browserMockScenarios.ts
@@ -1,10 +1,10 @@
 import { defaultAppSettings, DEFAULT_PLAYLIST_PROBE_LIMIT } from '@shared/constants.js';
 import { QUEUE_STATUS, STATUS_KEY, YT_DLP_ERROR_KINDS } from '@shared/schemas.js';
-import type { AppSettings, DependencyDiagnostic, DependencyId, InstallChannel, PlaylistEntry, ProbeError, ProbeResult, QueueItem, UpdateAvailablePayload, WarmUpOutput } from '@shared/types.js';
+import type { AppSettings, DependencyDiagnostic, DependencyId, InstallChannel, PlaylistEntry, PlaylistScope, ProbeError, ProbePlaylistMode, ProbeResult, QueueItem, UpdateAvailablePayload, WarmUpOutput } from '@shared/types.js';
 import type { YtDlpErrorKind } from '@shared/schemas.js';
 import type { BrowserMockKnobs } from './browserMockKnobs.js';
 
-export const BROWSER_MOCK_SCENARIO_IDS = ['default', 'single-normal', 'playlist-normal', 'playlist-no-thumbnails', 'playlist-long-titles', 'probe-audio-only', 'probe-with-subtitles', 'probe-no-formats', 'probe-live-stream', 'dialog-mixed-url', 'dialog-cookies-issue', 'update-direct', 'update-homebrew', 'update-scoop', 'update-portable', 'update-darwin-dmg', 'update-winget', 'update-flatpak', 'update-none', 'queue-empty', 'queue-running', 'queue-paused-active', 'queue-paused-held', 'queue-cancelled', 'queue-error', 'queue-completed', 'queue-subtitles-failed', 'queue-multi', 'diagnostics-all-ok', 'diagnostics-ytdlp-missing', 'diagnostics-ffmpeg-broken', 'diagnostics-deno-missing', 'diagnostics-ffprobe-broken', 'diagnostics-all-missing', 'diagnostics-warmup-running'] as const;
+export const BROWSER_MOCK_SCENARIO_IDS = ['default', 'single-normal', 'playlist-normal', 'playlist-scope-empty-reload', 'playlist-no-thumbnails', 'playlist-long-titles', 'probe-audio-only', 'probe-with-subtitles', 'probe-no-formats', 'probe-live-stream', 'dialog-mixed-url', 'dialog-cookies-issue', 'update-direct', 'update-homebrew', 'update-scoop', 'update-portable', 'update-darwin-dmg', 'update-winget', 'update-flatpak', 'update-none', 'queue-empty', 'queue-running', 'queue-paused-active', 'queue-paused-held', 'queue-cancelled', 'queue-error', 'queue-completed', 'queue-subtitles-failed', 'queue-multi', 'diagnostics-all-ok', 'diagnostics-ytdlp-missing', 'diagnostics-ffmpeg-broken', 'diagnostics-deno-missing', 'diagnostics-ffprobe-broken', 'diagnostics-all-missing', 'diagnostics-warmup-running'] as const;
 
 export type BrowserMockScenarioId = (typeof BROWSER_MOCK_SCENARIO_IDS)[number];
 export type BrowserMockScenarioGroup = 'General' | 'Playlist' | 'Probe Results' | 'Probe Errors' | 'Dialogs' | 'Updates' | 'Queue' | 'Diagnostics';
@@ -79,6 +79,7 @@ export const BROWSER_MOCK_SCENARIOS: readonly BrowserMockScenario[] = [
   { id: 'single-normal', group: 'General', title: 'Single video normal', description: 'Happy-path YouTube video with formats, subtitles, and SponsorBlock steps.', kind: 'probe' },
 
   { id: 'playlist-normal', group: 'Playlist', title: 'Playlist normal', description: 'Happy-path playlist with thumbnails, durations, and default preset selection.', kind: 'probe' },
+  { id: 'playlist-scope-empty-reload', group: 'Playlist', title: 'Scope reload empty', description: 'Playlist opens normally; applying any non-default scope reload returns no entries and should stay inline.', kind: 'probe' },
   { id: 'playlist-no-thumbnails', group: 'Playlist', title: 'No thumbnails', description: 'Playlist rows with no thumbnail column.', kind: 'probe' },
   { id: 'playlist-long-titles', group: 'Playlist', title: 'Long titles', description: 'Playlist rows with intentionally long titles.', kind: 'probe' },
 
@@ -135,20 +136,24 @@ export function getScenario(id: string | null | undefined): BrowserMockScenario 
 }
 
 export function isHappyPathScenario(scenario: Pick<BrowserMockScenario, 'id'>): boolean {
-  return scenario.id === 'single-normal' || scenario.id === 'playlist-normal';
+  return scenario.id === 'single-normal' || scenario.id === 'playlist-normal' || scenario.id === 'playlist-scope-empty-reload';
 }
 
 export function mockStepForScenario(scenario: Pick<BrowserMockScenario, 'id'>, step: BrowserMockStep | null): BrowserMockStep | null {
   if (step === null) return null;
   if (scenario.id === 'single-normal' && (SINGLE_NORMAL_MOCK_STEPS as readonly string[]).includes(step)) return step;
-  if (scenario.id === 'playlist-normal' && (PLAYLIST_NORMAL_MOCK_STEPS as readonly string[]).includes(step)) return step;
+  if ((scenario.id === 'playlist-normal' || scenario.id === 'playlist-scope-empty-reload') && (PLAYLIST_NORMAL_MOCK_STEPS as readonly string[]).includes(step)) return step;
   return null;
 }
 
 export function mockStepsForScenario(scenario: Pick<BrowserMockScenario, 'id'>): readonly BrowserMockStep[] {
   if (scenario.id === 'single-normal') return SINGLE_NORMAL_MOCK_STEPS;
-  if (scenario.id === 'playlist-normal') return PLAYLIST_NORMAL_MOCK_STEPS;
+  if (scenario.id === 'playlist-normal' || scenario.id === 'playlist-scope-empty-reload') return PLAYLIST_NORMAL_MOCK_STEPS;
   return [];
+}
+
+export function shouldMockEmptyPlaylistScopeReload(scenario: Pick<BrowserMockScenario, 'id'>, playlistMode: ProbePlaylistMode | undefined, playlistScope: PlaylistScope | undefined): boolean {
+  return scenario.id === 'playlist-scope-empty-reload' && playlistMode === 'playlist' && playlistScope !== undefined && playlistScope.items.kind !== 'app-limit';
 }
 
 export function buildScenarioAppApiState(scenario: BrowserMockScenario, params?: BrowserMockUrlParams, knobs?: BrowserMockKnobs): BrowserMockState {
@@ -195,6 +200,7 @@ function buildProbeResult(scenario: BrowserMockScenario, params?: BrowserMockUrl
     case 'single-normal':
       return normalVideoProbe();
     case 'playlist-normal':
+    case 'playlist-scope-empty-reload':
       return playlistProbe(12, { fullThumbnails: true });
     case 'playlist-no-thumbnails':
       return playlistProbe(100, { thumbnails: false });

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -1,5 +1,5 @@
 import type { StoreApi } from 'zustand';
-import type { AppSettings, AudioBitrate, CookiesBrowser, CookiesMode, DependencyDiagnostic, DependencyId, FormatOption, PlaylistEntry, PlaylistSelection, Preset, ProbeError, ProbeDegradationReason, QueueItem, QueueLane, QuickDownloadStatus, SubtitleFormat, SubtitleMap, SubtitleMode, SponsorBlockMode, SponsorBlockCategory, SupportedLang, UiTheme } from '@shared/types.js';
+import type { AppSettings, AudioBitrate, CookiesBrowser, CookiesMode, DependencyDiagnostic, DependencyId, FormatOption, PlaylistEntry, PlaylistScope, PlaylistSelection, Preset, ProbeError, ProbeDegradationReason, QueueItem, QueueLane, QuickDownloadStatus, SubtitleFormat, SubtitleMap, SubtitleMode, SponsorBlockMode, SponsorBlockCategory, SupportedLang, UiTheme } from '@shared/types.js';
 import type { AudioSelection } from '@shared/schemas.js';
 import type { IncompleteCookiesConfigIssue } from '@shared/cookiesConfig.js';
 export type { AudioSelection };
@@ -49,6 +49,9 @@ export interface ProbeOrchestratorSlice {
   playlistIsMultiVideo: boolean;
   playlistLikelyCapped: boolean;
   playlistProbeLoading: boolean;
+  playlistScopeReloading: boolean;
+  playlistScopeError: string | null;
+  playlistScope: PlaylistScope;
   playlistSelection: PlaylistSelection | null;
   quickDownloadStatus: QuickDownloadStatus;
   quickDownloadError: string | null;
@@ -64,6 +67,8 @@ export interface ProbeOrchestratorSlice {
   quickDownload: () => Promise<void>;
   dismissMixedPrompt: (choice: 'video' | 'playlist') => Promise<void>;
   setPlaylistItemSelected: (id: string, checked: boolean) => void;
+  setPlaylistScope: (scope: PlaylistScope) => void;
+  reloadPlaylistWithScope: (scope: PlaylistScope) => Promise<void>;
   selectAllPlaylistItems: () => void;
   selectNonePlaylistItems: () => void;
   selectPlaylistRange: (from: number, to: number) => void;

--- a/src/renderer/src/store/wizard/commands.ts
+++ b/src/renderer/src/store/wizard/commands.ts
@@ -5,7 +5,7 @@
 
 import { DEFAULTS } from '@shared/constants.js';
 import { DEFAULT_AUDIO_BITRATE } from '@shared/schemas.js';
-import type { FormatOption, PlaylistEntry, PlaylistSelection, SubtitleMap } from '@shared/types.js';
+import type { FormatOption, PlaylistEntry, PlaylistScope, PlaylistSelection, SubtitleMap } from '@shared/types.js';
 import type { SetState, WizardMode, WizardStep } from '../types.js';
 
 // Full wizard reset state — owned conceptually by the four slices but applied
@@ -33,6 +33,9 @@ export const RESET_WIZARD_STATE = {
   playlistIsMultiVideo: false,
   playlistLikelyCapped: false,
   playlistProbeLoading: false,
+  playlistScopeReloading: false,
+  playlistScopeError: null as string | null,
+  playlistScope: { items: { kind: 'app-limit' } } as PlaylistScope,
   playlistSelection: null as PlaylistSelection | null,
   quickDownloadStatus: 'idle' as const,
   quickDownloadError: null as string | null,

--- a/src/renderer/src/store/wizard/probeOrchestrator.ts
+++ b/src/renderer/src/store/wizard/probeOrchestrator.ts
@@ -9,7 +9,7 @@
 // one transition so the UI never sees a half-updated wizard.
 
 import { DEFAULTS } from '@shared/constants.js';
-import type { AppSettings, PlaylistSelection, ProbePlaylistMode, ProbeResult, WizardTransition } from '@shared/types.js';
+import type { AppSettings, PlaylistScope, PlaylistSelection, ProbePlaylistMode, ProbeResult, WizardTransition } from '@shared/types.js';
 import { DEFAULT_PLAYLIST_SELECTION } from '@shared/schemas.js';
 import { getIncompleteCookiesConfigIssue } from '@shared/cookiesConfig.js';
 import { cleanUrl } from '@shared/cleanUrl.js';
@@ -133,7 +133,13 @@ function pickWizardSnapshot(state: AppState): Record<string, unknown> {
     writeM3u: state.wizardWriteM3u,
     outputDir: state.wizardOutputDir,
     subfolderEnabled: state.wizardSubfolderEnabled,
-    subfolderName: state.wizardSubfolderName
+    subfolderName: state.wizardSubfolderName,
+    playlistScope: state.playlistScope,
+    playlistItemsCount: state.playlistItems.length,
+    selectedPlaylistItemsCount: state.selectedPlaylistItemIds.length,
+    playlistLikelyCapped: state.playlistLikelyCapped,
+    playlistScopeReloading: state.playlistScopeReloading,
+    playlistScopeError: state.playlistScopeError
   };
 }
 
@@ -233,11 +239,20 @@ function applyVideoProbeResult(probe: Extract<ProbeResult, { kind: 'video' }>, s
   });
 }
 
+function playlistVisibleLimit(state: AppState): number {
+  const scope = state.playlistScope;
+  if (scope.items.kind === 'first') return scope.items.count;
+  if (scope.items.kind === 'range') return scope.items.to - scope.items.from + 1;
+  return resolvePlaylistProbeLimit(state.settings?.common);
+}
+
 function applyPlaylistProbeResult(probe: Extract<ProbeResult, { kind: 'playlist' }>, set: SetState, get: GetState, firstProbe: boolean): void {
-  const settings = get().settings;
-  const playlistLimit = resolvePlaylistProbeLimit(settings?.common);
-  const playlistLikelyCapped = probe.entries.length > playlistLimit;
-  const playlistItems = playlistLikelyCapped ? probe.entries.slice(0, playlistLimit) : probe.entries;
+  const state = get();
+  const settings = state.settings;
+  const playlistLimit = playlistVisibleLimit(state);
+  const hasSentinel = probe.entries.length > playlistLimit;
+  const playlistLikelyCapped = hasSentinel && state.playlistScope.items.kind === 'app-limit';
+  const playlistItems = hasSentinel ? probe.entries.slice(0, playlistLimit) : probe.entries;
   // Audio-only sources skip the persisted video selection and default to
   // audio-best — the user came to a music host, video presets would fail.
   const persistedSelection: PlaylistSelection = settings?.playlist?.lastPlaylistSelection ?? DEFAULT_PLAYLIST_SELECTION;
@@ -255,6 +270,7 @@ function applyPlaylistProbeResult(probe: Extract<ProbeResult, { kind: 'playlist'
     playlistId: probe.playlistId,
     playlistIsMultiVideo: probe.isMultiVideo,
     playlistLikelyCapped,
+    playlistScopeError: null,
     playlistProbeLoading: false,
     formatsLoading: false,
     wizardFormats: [],
@@ -270,6 +286,13 @@ function applyPlaylistProbeResult(probe: Extract<ProbeResult, { kind: 'playlist'
   });
 }
 
+function playlistScopeReloadErrorMessage(error: Parameters<typeof formatProbeError>[0]): string {
+  if (error?.kind === 'other' && error.message === 'Playlist returned no entries') {
+    return 'No videos matched that playlist scope. Your previous list is still shown.';
+  }
+  return formatProbeError(error) || 'Could not reload that playlist scope. Your previous list is still shown.';
+}
+
 async function runProbe(url: string, playlistMode: ProbePlaylistMode, set: SetState, get: GetState, firstProbe = true): Promise<void> {
   void window.appApi.downloads.probeCancel();
   const fromStep = get().wizardStep;
@@ -280,6 +303,7 @@ async function runProbe(url: string, playlistMode: ProbePlaylistMode, set: SetSt
     wizardMode: playlistMode === 'playlist' ? 'playlist' : 'single',
     formatsLoading: playlistMode !== 'playlist',
     playlistProbeLoading: playlistMode !== 'video',
+    playlistScopeError: null,
     wizardError: null,
     cookiesConfigDialogIssue: null,
     wizardFormats: [],
@@ -298,6 +322,7 @@ async function runProbe(url: string, playlistMode: ProbePlaylistMode, set: SetSt
     playlistId: '',
     playlistIsMultiVideo: false,
     playlistLikelyCapped: false,
+    playlistScopeReloading: false,
     syncedDownloadedIds: [],
     syncScanState: 'idle',
     wizardExtractor: '',
@@ -306,7 +331,8 @@ async function runProbe(url: string, playlistMode: ProbePlaylistMode, set: SetSt
   });
   logStep('submitUrl', fromStep, initialStep, pickWizardSnapshot(get()));
 
-  const result = await window.appApi.downloads.probe({ url, playlistMode });
+  const playlistScope = get().playlistScope;
+  const result = await window.appApi.downloads.probe({ url, playlistMode, ...(playlistMode === 'video' ? {} : { playlistScope }) });
   if (!result.ok) {
     set({
       wizardStep: 'error',
@@ -327,6 +353,85 @@ async function runProbe(url: string, playlistMode: ProbePlaylistMode, set: SetSt
   } else {
     applyVideoProbeResult(result.data, set, get, firstProbe);
   }
+}
+
+async function reloadPlaylistWithScope(scope: PlaylistScope, set: SetState, get: GetState): Promise<void> {
+  const state = get();
+  const url = state.wizardUrl;
+  if (!url || state.playlistScopeReloading) {
+    logStep('playlistScopeReloadIgnored', state.wizardStep, state.wizardStep, {
+      ...pickWizardSnapshot(state),
+      requestedScope: scope,
+      reason: !url ? 'missing-url' : 'already-reloading'
+    });
+    return;
+  }
+  const previousScope = state.playlistScope;
+  const previousItemsCount = state.playlistItems.length;
+
+  void window.appApi.downloads.probeCancel();
+  logStep('playlistScopeReloadStart', state.wizardStep, state.wizardStep, {
+    ...pickWizardSnapshot(state),
+    requestedScope: scope,
+    previousScope,
+    previousItemsCount
+  });
+  set({
+    playlistScope: scope,
+    playlistScopeReloading: true,
+    playlistScopeError: null,
+    playlistLikelyCapped: false
+  });
+
+  const result = await window.appApi.downloads.probe({ url, playlistMode: 'playlist', playlistScope: scope });
+  if (!result.ok) {
+    const message = playlistScopeReloadErrorMessage(result.error);
+    set({
+      playlistScope: previousScope,
+      playlistScopeReloading: false,
+      playlistScopeError: message
+    });
+    logStep('playlistScopeReloadFailure', get().wizardStep, get().wizardStep, {
+      ...pickWizardSnapshot(get()),
+      requestedScope: scope,
+      restoredScope: previousScope,
+      previousItemsCount,
+      errorKind: result.error.kind,
+      message
+    });
+    return;
+  }
+
+  if (result.data.kind !== 'playlist') {
+    const message = 'No videos matched that playlist scope. Your previous list is still shown.';
+    set({
+      playlistScope: previousScope,
+      playlistScopeReloading: false,
+      playlistScopeError: message
+    });
+    logStep('playlistScopeReloadFailure', get().wizardStep, get().wizardStep, {
+      ...pickWizardSnapshot(get()),
+      requestedScope: scope,
+      restoredScope: previousScope,
+      previousItemsCount,
+      resultKind: result.data.kind,
+      message
+    });
+    return;
+  }
+
+  const returnedEntryCount = result.data.entries.length;
+  applyPlaylistProbeResult(result.data, set, get, false);
+  set({ playlistScopeReloading: false, playlistScopeError: null });
+  logStep('playlistScopeReloadSuccess', get().wizardStep, get().wizardStep, {
+    ...pickWizardSnapshot(get()),
+    requestedScope: scope,
+    previousScope,
+    previousItemsCount,
+    returnedEntryCount,
+    visibleItemsCount: get().playlistItems.length
+  });
+  void get().scanDownloadedInFolder();
 }
 
 export function createProbeOrchestratorSlice(set: SetState, get: GetState): ProbeOrchestratorSlice {
@@ -351,6 +456,9 @@ export function createProbeOrchestratorSlice(set: SetState, get: GetState): Prob
     playlistIsMultiVideo: RESET_WIZARD_STATE.playlistIsMultiVideo,
     playlistLikelyCapped: RESET_WIZARD_STATE.playlistLikelyCapped,
     playlistProbeLoading: RESET_WIZARD_STATE.playlistProbeLoading,
+    playlistScopeReloading: RESET_WIZARD_STATE.playlistScopeReloading,
+    playlistScopeError: RESET_WIZARD_STATE.playlistScopeError,
+    playlistScope: RESET_WIZARD_STATE.playlistScope,
     playlistSelection: RESET_WIZARD_STATE.playlistSelection,
     quickDownloadStatus: RESET_WIZARD_STATE.quickDownloadStatus,
     quickDownloadError: RESET_WIZARD_STATE.quickDownloadError,
@@ -439,6 +547,12 @@ export function createProbeOrchestratorSlice(set: SetState, get: GetState): Prob
       set((state) => ({
         selectedPlaylistItemIds: checked ? (state.selectedPlaylistItemIds.includes(id) ? state.selectedPlaylistItemIds : [...state.selectedPlaylistItemIds, id]) : state.selectedPlaylistItemIds.filter((x) => x !== id)
       })),
+
+    setPlaylistScope: (scope) => set({ playlistScope: scope }),
+
+    reloadPlaylistWithScope: async (scope) => {
+      await reloadPlaylistWithScope(scope, set, get);
+    },
 
     selectAllPlaylistItems: () => set((state) => ({ selectedPlaylistItemIds: state.playlistItems.map((e) => e.id) })),
 

--- a/src/renderer/src/store/wizard/probeOrchestrator.ts
+++ b/src/renderer/src/store/wizard/probeOrchestrator.ts
@@ -293,6 +293,12 @@ function playlistScopeReloadErrorMessage(error: Parameters<typeof formatProbeErr
   return formatProbeError(error) || 'Could not reload that playlist scope. Your previous list is still shown.';
 }
 
+function unknownErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === 'string' && error.length > 0) return error;
+  return 'Unknown error';
+}
+
 async function runProbe(url: string, playlistMode: ProbePlaylistMode, set: SetState, get: GetState, firstProbe = true): Promise<void> {
   void window.appApi.downloads.probeCancel();
   const fromStep = get().wizardStep;
@@ -383,7 +389,27 @@ async function reloadPlaylistWithScope(scope: PlaylistScope, set: SetState, get:
     playlistLikelyCapped: false
   });
 
-  const result = await window.appApi.downloads.probe({ url, playlistMode: 'playlist', playlistScope: scope });
+  let result: Awaited<ReturnType<typeof window.appApi.downloads.probe>>;
+  try {
+    result = await window.appApi.downloads.probe({ url, playlistMode: 'playlist', playlistScope: scope });
+  } catch (error) {
+    const message = `Could not reload that playlist scope: ${unknownErrorMessage(error)}. Your previous list is still shown.`;
+    set({
+      playlistScope: previousScope,
+      playlistScopeReloading: false,
+      playlistScopeError: message
+    });
+    logStep('playlistScopeReloadFailure', get().wizardStep, get().wizardStep, {
+      ...pickWizardSnapshot(get()),
+      requestedScope: scope,
+      restoredScope: previousScope,
+      previousItemsCount,
+      errorKind: 'exception',
+      message
+    });
+    return;
+  }
+
   if (!result.ok) {
     const message = playlistScopeReloadErrorMessage(result.error);
     set({

--- a/src/shared/i18n/locales/en.ts
+++ b/src/shared/i18n/locales/en.ts
@@ -116,7 +116,7 @@ const en = {
       syncNoneDesc: 'No videos from this playlist were found in {{dir}}.',
       alreadyDownloaded: 'Already downloaded',
       probeLimitAlertTitle: 'Playlist scan is capped',
-      probeLimitAlertDesc: 'Arroxy found more than {{count}} items, so the current scan limit is hiding the rest.'
+      probeLimitAlertDesc: 'Showing first {{count}} items. Increase the load limit to see more.'
     },
     mixedPrompt: {
       title: 'This link has a playlist',

--- a/src/shared/playlistScope.ts
+++ b/src/shared/playlistScope.ts
@@ -11,12 +11,16 @@ export interface PlaylistScopeLogFields {
   to?: number;
 }
 
-export function describePlaylistScopeForLog(scope: PlaylistScope | undefined, appLimit: number): PlaylistScopeLogFields {
+export type PlaylistScopeSentinelFields = Pick<PlaylistScopeLogFields, 'requestedCount' | 'sentinel' | 'ytDlpFlag' | 'ytDlpValue'>;
+
+function unreachablePlaylistScopeItem(item: never): never {
+  throw new Error(`Unsupported playlist scope item: ${JSON.stringify(item)}`);
+}
+
+export function playlistScopeSentinelFields(scope: PlaylistScope | undefined, appLimit: number): PlaylistScopeSentinelFields {
   const items = scope?.items;
-  if (!items || items.kind === 'app-limit') {
+  if (!items) {
     return {
-      kind: 'app-limit',
-      appLimit,
       requestedCount: appLimit,
       sentinel: true,
       ytDlpFlag: '--playlist-end',
@@ -24,23 +28,52 @@ export function describePlaylistScopeForLog(scope: PlaylistScope | undefined, ap
     };
   }
 
-  if (items.kind === 'first') {
+  switch (items.kind) {
+    case 'app-limit':
+      return {
+        requestedCount: appLimit,
+        sentinel: true,
+        ytDlpFlag: '--playlist-end',
+        ytDlpValue: String(appLimit + 1)
+      };
+    case 'first':
+      return {
+        requestedCount: items.count,
+        sentinel: true,
+        ytDlpFlag: '--playlist-items',
+        ytDlpValue: `1:${items.count + 1}`
+      };
+    case 'range':
+      return {
+        requestedCount: items.to - items.from + 1,
+        sentinel: true,
+        ytDlpFlag: '--playlist-items',
+        ytDlpValue: `${items.from}:${items.to + 1}`
+      };
+    default:
+      return unreachablePlaylistScopeItem(items);
+  }
+}
+
+export function describePlaylistScopeForLog(scope: PlaylistScope | undefined, appLimit: number): PlaylistScopeLogFields {
+  const items = scope?.items;
+  const sentinelFields = playlistScopeSentinelFields(scope, appLimit);
+  if (!items) {
     return {
-      kind: 'first',
-      requestedCount: items.count,
-      sentinel: true,
-      ytDlpFlag: '--playlist-items',
-      ytDlpValue: `1:${items.count + 1}`
+      kind: 'app-limit',
+      appLimit,
+      ...sentinelFields
     };
   }
 
-  return {
-    kind: 'range',
-    from: items.from,
-    to: items.to,
-    requestedCount: items.to - items.from + 1,
-    sentinel: true,
-    ytDlpFlag: '--playlist-items',
-    ytDlpValue: `${items.from}:${items.to + 1}`
-  };
+  switch (items.kind) {
+    case 'app-limit':
+      return { kind: 'app-limit', appLimit, ...sentinelFields };
+    case 'first':
+      return { kind: 'first', ...sentinelFields };
+    case 'range':
+      return { kind: 'range', from: items.from, to: items.to, ...sentinelFields };
+    default:
+      return unreachablePlaylistScopeItem(items);
+  }
 }

--- a/src/shared/playlistScope.ts
+++ b/src/shared/playlistScope.ts
@@ -1,0 +1,46 @@
+import type { PlaylistScope } from './schemas.js';
+
+export interface PlaylistScopeLogFields {
+  kind: PlaylistScope['items']['kind'];
+  requestedCount: number;
+  sentinel: boolean;
+  ytDlpFlag: '--playlist-end' | '--playlist-items';
+  ytDlpValue: string;
+  appLimit?: number;
+  from?: number;
+  to?: number;
+}
+
+export function describePlaylistScopeForLog(scope: PlaylistScope | undefined, appLimit: number): PlaylistScopeLogFields {
+  const items = scope?.items;
+  if (!items || items.kind === 'app-limit') {
+    return {
+      kind: 'app-limit',
+      appLimit,
+      requestedCount: appLimit,
+      sentinel: true,
+      ytDlpFlag: '--playlist-end',
+      ytDlpValue: String(appLimit + 1)
+    };
+  }
+
+  if (items.kind === 'first') {
+    return {
+      kind: 'first',
+      requestedCount: items.count,
+      sentinel: true,
+      ytDlpFlag: '--playlist-items',
+      ytDlpValue: `1:${items.count + 1}`
+    };
+  }
+
+  return {
+    kind: 'range',
+    from: items.from,
+    to: items.to,
+    requestedCount: items.to - items.from + 1,
+    sentinel: true,
+    ytDlpFlag: '--playlist-items',
+    ytDlpValue: `${items.from}:${items.to + 1}`
+  };
+}

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -177,9 +177,27 @@ export const MAX_SUBTITLE_LANGUAGES = 50;
 // match) and surfaces "Unsupported URL" via stderr if not.
 const webUrlSchema = z.url('URL must be valid').refine((value) => /^https?:\/\//i.test(value), { message: 'Only http/https URLs are supported' });
 
+const playlistScopeItemsSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('app-limit') }),
+  z.object({ kind: z.literal('first'), count: playlistProbeLimitSchema }),
+  z
+    .object({
+      kind: z.literal('range'),
+      from: playlistProbeLimitSchema,
+      to: playlistProbeLimitSchema
+    })
+    .refine((value) => value.from <= value.to, { message: 'Range start must be less than or equal to range end', path: ['to'] })
+]);
+
+export const playlistScopeSchema = z.object({
+  items: playlistScopeItemsSchema
+});
+export type PlaylistScope = z.infer<typeof playlistScopeSchema>;
+
 export const probeSchema = z.object({
   url: webUrlSchema,
-  playlistMode: z.enum(['auto', 'video', 'playlist']).optional()
+  playlistMode: z.enum(['auto', 'video', 'playlist']).optional(),
+  playlistScope: playlistScopeSchema.optional()
 });
 
 // PreparedJob discriminated-union schema. Type aliases live in

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6,12 +6,12 @@ export type { PreparedJob } from './preparedJob.js';
 // Re-export the enum types whose canonical definition lives in `schemas.ts`
 // (where they're z.enum schemas). Importing from `@shared/types` continues to
 // work for callers that don't care about the schema vs type distinction.
-export type { Preset, PlaylistSelection, PlaylistVideoTier, PlaylistAudioFormat, SubtitleMode, SubtitleFormat, SponsorBlockMode, SponsorBlockCategory, SupportedLang, UiTheme, QueueItemStatus, QueueLane, AudioConvertTarget, AudioBitrate, AudioConvert, AudioSelection, CookiesMode, CookiesBrowser, NetworkPacingPreset, QuickDownloadStatus } from './schemas.js';
+export type { Preset, PlaylistSelection, PlaylistScope, PlaylistVideoTier, PlaylistAudioFormat, SubtitleMode, SubtitleFormat, SponsorBlockMode, SponsorBlockCategory, SupportedLang, UiTheme, QueueItemStatus, QueueLane, AudioConvertTarget, AudioBitrate, AudioConvert, AudioSelection, CookiesMode, CookiesBrowser, NetworkPacingPreset, QuickDownloadStatus } from './schemas.js';
 
 export type { StatusKey } from './schemas.js';
 export type { LocalizedError, YtDlpErrorKind } from './i18n/types.js';
 
-import type { AudioSelection, Preset, SubtitleMode, SubtitleFormat, SponsorBlockMode, SponsorBlockCategory, SupportedLang, UiTheme, StatusKey, CookiesMode, CookiesBrowser, NetworkPacingPreset } from './schemas.js';
+import type { AudioSelection, Preset, PlaylistScope, SubtitleMode, SubtitleFormat, SponsorBlockMode, SponsorBlockCategory, SupportedLang, UiTheme, StatusKey, CookiesMode, CookiesBrowser, NetworkPacingPreset } from './schemas.js';
 
 export type AppErrorCode = 'validation' | 'token' | 'binary' | 'download' | 'ipc' | 'unknown';
 
@@ -203,6 +203,9 @@ export interface ProbeInput {
   // extractor decide; 'video' forces single-video resolution; 'playlist'
   // forces playlist enumeration.
   playlistMode?: ProbePlaylistMode;
+  // Probe-time scope for playlist/channel/search enumeration. Downloads still
+  // split into Arroxy queue items after this filtered flat probe.
+  playlistScope?: PlaylistScope;
 }
 
 export type ProbeDegradationReason = 'botWall' | 'extractor';
@@ -384,7 +387,7 @@ export type UpdateInstallResult = { ok: true } | { ok: false; error: string };
 
 export type WizardStepName = 'url' | 'playlistItems' | 'playlistPresets' | 'formats' | 'subtitles' | 'sponsorblock' | 'output' | 'folder' | 'confirm' | 'error';
 
-export type WizardTransition = 'submitUrl' | 'advance' | 'back' | 'skipSubtitles' | 'skipToConfirm' | 'retry' | 'reset';
+export type WizardTransition = 'submitUrl' | 'advance' | 'back' | 'skipSubtitles' | 'skipToConfirm' | 'retry' | 'reset' | 'playlistScopeReloadStart' | 'playlistScopeReloadSuccess' | 'playlistScopeReloadFailure' | 'playlistScopeReloadIgnored';
 
 export interface WizardStepSnapshot {
   transition: WizardTransition;

--- a/tests/browser/scenario-gallery.spec.ts
+++ b/tests/browser/scenario-gallery.spec.ts
@@ -70,7 +70,23 @@ test('normal happy path scenarios expose the screen picker', async ({ page }) =>
   await page.getByTestId('scenario-gallery-toggle').click();
   await expect(page.getByTestId('scenario-button-single-normal')).toBeVisible();
   await expect(page.getByTestId('scenario-button-playlist-normal')).toBeVisible();
+  await expect(page.getByTestId('scenario-button-playlist-scope-empty-reload')).toBeVisible();
   await expect(page.getByTestId('mock-step-select')).toBeVisible();
+});
+
+test('playlist scope empty reload scenario stays on playlist with inline error', async ({ page }) => {
+  await openScenario(page, 'playlist-scope-empty-reload');
+  await waitForPlaylist(page);
+
+  await page.getByTestId('playlist-scope-change').click();
+  await page.getByText('Range', { exact: true }).click();
+  await page.getByTestId('playlist-scope-range-from').fill('900');
+  await page.getByTestId('playlist-scope-range-to').fill('950');
+  await page.getByTestId('playlist-scope-apply').click();
+
+  await expect(page.getByTestId('playlist-scope-apply')).toHaveText('Reloading...');
+  await expect(page.getByTestId('playlist-scope-error')).toContainText('No videos matched that playlist scope');
+  await expect(page.getByTestId('step-playlist-items')).toBeVisible();
 });
 
 test('probe error dropdown shows all error kinds', async ({ page }) => {

--- a/tests/renderer/playlist-probe-limit-selector.test.tsx
+++ b/tests/renderer/playlist-probe-limit-selector.test.tsx
@@ -139,7 +139,7 @@ describe('playlist probe limit selector alert', () => {
 
     await waitFor(() => {
       expect(api.settings.update).toHaveBeenCalledWith({ common: { playlistProbeLimit: 100 } });
-      expect(api.downloads.probe).toHaveBeenCalledWith({ url: PLAYLIST_URL, playlistMode: 'playlist' });
+      expect(api.downloads.probe).toHaveBeenCalledWith({ url: PLAYLIST_URL, playlistMode: 'playlist', playlistScope: { items: { kind: 'app-limit' } } });
     });
   });
 

--- a/tests/renderer/playlist-scope-control.test.tsx
+++ b/tests/renderer/playlist-scope-control.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PlaylistScopeControl } from '@renderer/components/wizard/PlaylistScopeControl.js';
 import { StepPlaylistItems } from '@renderer/components/wizard/StepPlaylistItems.js';
 import { useAppStore } from '@renderer/store/useAppStore.js';
 import { RESET_WIZARD_STATE } from '@renderer/store/wizard/commands.js';
@@ -138,5 +139,21 @@ describe('PlaylistScopeControl', () => {
     await act(async () => {
       resolveProbe(ok(playlistProbe()));
     });
+  });
+
+  it('shows an inline dialog error when the apply callback rejects unexpectedly', async () => {
+    const onApplyScope = vi.fn().mockRejectedValue(new Error('IPC bridge crashed'));
+    render(<PlaylistScopeControl onApplyScope={onApplyScope} applyLabel="Apply and reload" pendingLabel="Reloading..." />);
+
+    fireEvent.click(screen.getByTestId('playlist-scope-change'));
+    fireEvent.click(await screen.findByText('First'));
+    fireEvent.change(screen.getByTestId('playlist-scope-first-input'), { target: { value: '50' } });
+    fireEvent.click(screen.getByTestId('playlist-scope-apply'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('playlist-scope-apply-error')).toHaveTextContent('IPC bridge crashed');
+    });
+    expect(screen.getByTestId('playlist-scope-dialog')).toBeInTheDocument();
+    expect(useAppStore.getState().playlistScope).toEqual({ items: { kind: 'app-limit' } });
   });
 });

--- a/tests/renderer/playlist-scope-control.test.tsx
+++ b/tests/renderer/playlist-scope-control.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { StepPlaylistItems } from '@renderer/components/wizard/StepPlaylistItems.js';
+import { useAppStore } from '@renderer/store/useAppStore.js';
+import { RESET_WIZARD_STATE } from '@renderer/store/wizard/commands.js';
+import { defaultAppSettings } from '@shared/constants.js';
+import type { PlaylistEntry, ProbeResult } from '@shared/types.js';
+import { buildMockAppApi } from '../shared/mockAppApi.js';
+import { ok } from '../shared/fixtures.js';
+import { fail } from '@shared/result.js';
+
+function playlistEntry(index: number): PlaylistEntry {
+  return {
+    id: `e${index}`,
+    url: `https://youtube.com/watch?v=e${index}`,
+    title: `Video ${index}`,
+    thumbnail: '',
+    playlistIndex: index,
+    videoId: `e${index}`
+  };
+}
+
+function playlistProbe(): Extract<ProbeResult, { kind: 'playlist' }> {
+  return {
+    kind: 'playlist',
+    extractor: 'youtube:playlist',
+    extractorKey: 'YoutubePlaylist',
+    webpageUrl: 'https://www.youtube.com/playlist?list=PLtest',
+    isAudioOnlySource: false,
+    playlistTitle: 'Playlist',
+    playlistId: 'PLtest',
+    isMultiVideo: false,
+    entries: [playlistEntry(500), playlistEntry(501)]
+  };
+}
+
+function resetStore(): void {
+  const playlistItems = [playlistEntry(1), playlistEntry(2)];
+  useAppStore.setState({
+    ...RESET_WIZARD_STATE,
+    initialized: true,
+    initializing: false,
+    settings: {
+      ...defaultAppSettings('/downloads'),
+      common: {
+        ...defaultAppSettings('/downloads').common,
+        playlistProbeLimit: 100,
+        shareInlineCardDismissed: true
+      }
+    },
+    wizardOutputDir: '/downloads',
+    wizardStep: 'playlistItems',
+    wizardMode: 'playlist',
+    wizardUrl: 'https://www.youtube.com/playlist?list=PLtest',
+    wizardExtractor: 'youtube:playlist',
+    playlistItems,
+    selectedPlaylistItemIds: playlistItems.map((entry) => entry.id),
+    playlistTitle: 'Playlist',
+    playlistSelection: { kind: 'video', tier: 'best', codec: 'best' },
+    queue: [],
+    drawerOpen: false
+  } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.platform = 'linux';
+  window.appApi = buildMockAppApi();
+  resetStore();
+});
+
+describe('PlaylistScopeControl', () => {
+  it('shows the app-limit summary on the playlist step', () => {
+    render(<StepPlaylistItems />);
+
+    expect(screen.getByTestId('playlist-scope-summary')).toHaveTextContent('Load first 100 items');
+  });
+
+  it('applies an item range from the playlist step and reloads the probe', async () => {
+    vi.mocked(window.appApi.downloads.probe).mockResolvedValue(ok(playlistProbe()));
+    render(<StepPlaylistItems />);
+
+    fireEvent.click(screen.getByTestId('playlist-scope-change'));
+    fireEvent.click(await screen.findByText('Range'));
+    fireEvent.change(screen.getByTestId('playlist-scope-range-from'), { target: { value: '500' } });
+    fireEvent.change(screen.getByTestId('playlist-scope-range-to'), { target: { value: '600' } });
+    fireEvent.click(screen.getByTestId('playlist-scope-apply'));
+
+    expect(screen.getByTestId('playlist-scope-summary')).toHaveTextContent('Load items 500-600');
+    expect(useAppStore.getState().playlistScope).toEqual({ items: { kind: 'range', from: 500, to: 600 } });
+    await waitFor(() => {
+      expect(window.appApi.downloads.probe).toHaveBeenCalledWith({
+        url: 'https://www.youtube.com/playlist?list=PLtest',
+        playlistMode: 'playlist',
+        playlistScope: { items: { kind: 'range', from: 500, to: 600 } }
+      });
+    });
+  });
+
+  it('keeps the playlist screen visible and shows an inline error when the scoped reload has no entries', async () => {
+    vi.mocked(window.appApi.downloads.probe).mockResolvedValue(fail({ kind: 'other', message: 'Playlist returned no entries' }));
+    render(<StepPlaylistItems />);
+
+    fireEvent.click(screen.getByTestId('playlist-scope-change'));
+    fireEvent.click(await screen.findByText('Range'));
+    fireEvent.change(screen.getByTestId('playlist-scope-range-from'), { target: { value: '900' } });
+    fireEvent.change(screen.getByTestId('playlist-scope-range-to'), { target: { value: '950' } });
+    fireEvent.click(screen.getByTestId('playlist-scope-apply'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('playlist-scope-error')).toHaveTextContent('No videos matched that playlist scope. Your previous list is still shown.');
+    });
+    expect(useAppStore.getState().wizardStep).toBe('playlistItems');
+    expect(useAppStore.getState().playlistItems.map((entry) => entry.title)).toEqual(['Video 1', 'Video 2']);
+    expect(screen.getByTestId('playlist-scope-summary')).toHaveTextContent('Load first 100 items');
+  });
+
+  it('disables apply while a scoped reload is in flight', async () => {
+    let resolveProbe: (value: Awaited<ReturnType<typeof window.appApi.downloads.probe>>) => void = () => {};
+    vi.mocked(window.appApi.downloads.probe).mockReturnValue(
+      new Promise((resolve) => {
+        resolveProbe = resolve;
+      })
+    );
+    render(<StepPlaylistItems />);
+
+    fireEvent.click(screen.getByTestId('playlist-scope-change'));
+    fireEvent.click(await screen.findByText('First'));
+    fireEvent.change(screen.getByTestId('playlist-scope-first-input'), { target: { value: '50' } });
+    fireEvent.click(screen.getByTestId('playlist-scope-apply'));
+
+    expect(screen.getByTestId('playlist-scope-apply')).toBeDisabled();
+    expect(screen.getByTestId('playlist-scope-apply')).toHaveTextContent('Reloading...');
+    fireEvent.click(screen.getByTestId('playlist-scope-apply'));
+    expect(window.appApi.downloads.probe).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveProbe(ok(playlistProbe()));
+    });
+  });
+});

--- a/tests/renderer/probe-orchestrator.test.tsx
+++ b/tests/renderer/probe-orchestrator.test.tsx
@@ -524,6 +524,43 @@ describe('submitUrl — playlist probe', () => {
       })
     );
   });
+
+  it('restores playlist state and logs when scoped playlist reload throws', async () => {
+    const api = buildMockAppApi();
+    vi.mocked(api.downloads.probe).mockRejectedValue(new Error('IPC bridge crashed'));
+    window.appApi = api;
+
+    useAppStore.setState({
+      wizardStep: 'playlistItems',
+      wizardUrl: 'https://www.youtube.com/playlist?list=PLtest',
+      playlistItems: PLAYLIST_PROBE.entries,
+      selectedPlaylistItemIds: PLAYLIST_PROBE.entries.map((entry) => entry.id),
+      playlistScope: { items: { kind: 'app-limit' } }
+    });
+
+    const requestedScope = { items: { kind: 'range' as const, from: 900, to: 950 } };
+    await useAppStore.getState().reloadPlaylistWithScope(requestedScope);
+
+    expect(useAppStore.getState().playlistScope).toEqual({ items: { kind: 'app-limit' } });
+    expect(useAppStore.getState().playlistScopeReloading).toBe(false);
+    expect(useAppStore.getState().playlistScopeError).toBe('Could not reload that playlist scope: IPC bridge crashed. Your previous list is still shown.');
+    expect(api.diagnostics.logWizardStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transition: 'playlistScopeReloadFailure',
+        fromStep: 'playlistItems',
+        toStep: 'playlistItems',
+        snapshot: expect.objectContaining({
+          requestedScope,
+          restoredScope: { items: { kind: 'app-limit' } },
+          previousItemsCount: 2,
+          playlistItemsCount: 2,
+          selectedPlaylistItemsCount: 2,
+          errorKind: 'exception',
+          message: 'Could not reload that playlist scope: IPC bridge crashed. Your previous list is still shown.'
+        })
+      })
+    );
+  });
 });
 
 describe('reset', () => {

--- a/tests/renderer/probe-orchestrator.test.tsx
+++ b/tests/renderer/probe-orchestrator.test.tsx
@@ -328,6 +328,39 @@ describe('submitUrl — playlist probe', () => {
     expect(selectedPlaylistItemIds).toEqual(playlistItems.map((e) => e.id));
   });
 
+  it('threads playlist scope into playlist probes', async () => {
+    const api = buildMockAppApi();
+    vi.mocked(api.downloads.probe).mockResolvedValue(ok(PLAYLIST_PROBE));
+    window.appApi = api;
+
+    useAppStore.setState({
+      wizardUrl: 'https://www.youtube.com/playlist?list=PLtest',
+      playlistScope: { items: { kind: 'range', from: 10, to: 20 } }
+    });
+    await useAppStore.getState().submitUrl();
+
+    expect(api.downloads.probe).toHaveBeenCalledWith({
+      url: 'https://www.youtube.com/playlist?list=PLtest',
+      playlistMode: 'auto',
+      playlistScope: { items: { kind: 'range', from: 10, to: 20 } }
+    });
+  });
+
+  it('keeps playlist-step range selection as selection-only', async () => {
+    const api = buildMockAppApi();
+    vi.mocked(api.downloads.probe).mockResolvedValue(ok(PLAYLIST_PROBE));
+    window.appApi = api;
+
+    useAppStore.setState({ wizardUrl: 'https://www.youtube.com/playlist?list=PLtest' });
+    await useAppStore.getState().submitUrl();
+    vi.mocked(api.downloads.probe).mockClear();
+
+    useAppStore.getState().selectPlaylistRange(2, 2);
+
+    expect(useAppStore.getState().selectedPlaylistItemIds).toEqual(['e2']);
+    expect(api.downloads.probe).not.toHaveBeenCalled();
+  });
+
   it('trims the sentinel entry and marks the playlist as likely capped', async () => {
     const api = buildMockAppApi();
     vi.mocked(api.downloads.probe).mockResolvedValue(ok(playlistProbeWithEntries(101)));
@@ -367,6 +400,129 @@ describe('submitUrl — playlist probe', () => {
     const state = useAppStore.getState();
     expect(state.playlistItems).toHaveLength(100);
     expect(state.playlistLikelyCapped).toBe(false);
+  });
+
+  it('trims first-count scoped probes without showing the app-limit cap alert', async () => {
+    const api = buildMockAppApi();
+    vi.mocked(api.downloads.probe).mockResolvedValue(ok(playlistProbeWithEntries(51)));
+    window.appApi = api;
+
+    useAppStore.setState({
+      wizardUrl: 'https://www.youtube.com/playlist?list=PLtest',
+      playlistScope: { items: { kind: 'first', count: 50 } },
+      settings: {
+        common: { defaultOutputDir: '/tmp', rememberLastOutputDir: false, clipboardWatchEnabled: false, playlistProbeLimit: 100 },
+        single: {},
+        playlist: {}
+      }
+    });
+    await useAppStore.getState().submitUrl();
+
+    const state = useAppStore.getState();
+    expect(state.playlistItems).toHaveLength(50);
+    expect(state.playlistLikelyCapped).toBe(false);
+  });
+
+  it('trims range scoped probes to the requested inclusive count', async () => {
+    const api = buildMockAppApi();
+    vi.mocked(api.downloads.probe).mockResolvedValue(ok(playlistProbeWithEntries(102)));
+    window.appApi = api;
+
+    useAppStore.setState({
+      wizardUrl: 'https://www.youtube.com/playlist?list=PLtest',
+      playlistScope: { items: { kind: 'range', from: 500, to: 600 } },
+      settings: {
+        common: { defaultOutputDir: '/tmp', rememberLastOutputDir: false, clipboardWatchEnabled: false, playlistProbeLimit: 100 },
+        single: {},
+        playlist: {}
+      }
+    });
+    await useAppStore.getState().submitUrl();
+
+    const state = useAppStore.getState();
+    expect(state.playlistItems).toHaveLength(101);
+    expect(state.playlistLikelyCapped).toBe(false);
+  });
+
+  it('logs scoped playlist reload start and success diagnostics', async () => {
+    const api = buildMockAppApi();
+    vi.mocked(api.downloads.probe).mockResolvedValue(ok(playlistProbeWithEntries(51)));
+    window.appApi = api;
+
+    useAppStore.setState({
+      wizardStep: 'playlistItems',
+      wizardUrl: 'https://www.youtube.com/playlist?list=PLtest',
+      playlistItems: PLAYLIST_PROBE.entries,
+      selectedPlaylistItemIds: PLAYLIST_PROBE.entries.map((entry) => entry.id),
+      playlistScope: { items: { kind: 'app-limit' } }
+    });
+
+    const requestedScope = { items: { kind: 'first' as const, count: 50 } };
+    await useAppStore.getState().reloadPlaylistWithScope(requestedScope);
+
+    expect(api.diagnostics.logWizardStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transition: 'playlistScopeReloadStart',
+        fromStep: 'playlistItems',
+        toStep: 'playlistItems',
+        snapshot: expect.objectContaining({
+          requestedScope,
+          previousScope: { items: { kind: 'app-limit' } },
+          previousItemsCount: 2,
+          playlistItemsCount: 2,
+          selectedPlaylistItemsCount: 2
+        })
+      })
+    );
+    expect(api.diagnostics.logWizardStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transition: 'playlistScopeReloadSuccess',
+        fromStep: 'playlistItems',
+        toStep: 'playlistItems',
+        snapshot: expect.objectContaining({
+          requestedScope,
+          previousItemsCount: 2,
+          returnedEntryCount: 51,
+          visibleItemsCount: 50,
+          playlistItemsCount: 50,
+          selectedPlaylistItemsCount: 50
+        })
+      })
+    );
+  });
+
+  it('logs scoped playlist reload failures with the restored scope', async () => {
+    const api = buildMockAppApi();
+    vi.mocked(api.downloads.probe).mockResolvedValue(fail({ kind: 'other', message: 'Playlist returned no entries' }));
+    window.appApi = api;
+
+    useAppStore.setState({
+      wizardStep: 'playlistItems',
+      wizardUrl: 'https://www.youtube.com/playlist?list=PLtest',
+      playlistItems: PLAYLIST_PROBE.entries,
+      selectedPlaylistItemIds: PLAYLIST_PROBE.entries.map((entry) => entry.id),
+      playlistScope: { items: { kind: 'app-limit' } }
+    });
+
+    const requestedScope = { items: { kind: 'range' as const, from: 900, to: 950 } };
+    await useAppStore.getState().reloadPlaylistWithScope(requestedScope);
+
+    expect(api.diagnostics.logWizardStep).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transition: 'playlistScopeReloadFailure',
+        fromStep: 'playlistItems',
+        toStep: 'playlistItems',
+        snapshot: expect.objectContaining({
+          requestedScope,
+          restoredScope: { items: { kind: 'app-limit' } },
+          previousItemsCount: 2,
+          playlistItemsCount: 2,
+          selectedPlaylistItemsCount: 2,
+          errorKind: 'other',
+          message: 'No videos matched that playlist scope. Your previous list is still shown.'
+        })
+      })
+    );
   });
 });
 

--- a/tests/renderer/wizard-cookies-config.test.tsx
+++ b/tests/renderer/wizard-cookies-config.test.tsx
@@ -100,51 +100,14 @@ beforeEach(() => {
 });
 
 describe('advanced network settings', () => {
-  it('renders playlist probe limit controls and saves a preset', async () => {
+  it('renders network pacing settings without playlist scope controls', async () => {
     render(<StepUrlInput />);
 
     const advanced = screen.getByTestId('advanced-section');
     if (advanced instanceof HTMLDetailsElement) advanced.open = true;
 
     expect(screen.getByTestId('network-pacing-section')).toBeInTheDocument();
-    const playlistSection = screen.getByTestId('playlist-probe-limit-section');
-    fireEvent.click(within(playlistSection).getByTestId('playlist-probe-limit-trigger'));
-    fireEvent.click(await screen.findByTestId('playlist-probe-limit-option-250'));
-
-    await waitFor(() => {
-      expect(mockApi.settings.update).toHaveBeenCalledWith({ common: { playlistProbeLimit: 250 } });
-    });
-  });
-
-  it('saves a custom playlist probe limit from the dialog', async () => {
-    render(<StepUrlInput />);
-
-    const advanced = screen.getByTestId('advanced-section');
-    if (advanced instanceof HTMLDetailsElement) advanced.open = true;
-
-    const playlistSection = screen.getByTestId('playlist-probe-limit-section');
-    fireEvent.click(within(playlistSection).getByTestId('playlist-probe-limit-trigger'));
-    fireEvent.click(await screen.findByTestId('playlist-probe-limit-option-custom'));
-    fireEvent.change(await screen.findByTestId('playlist-probe-limit-custom-input'), { target: { value: '375' } });
-    fireEvent.click(screen.getByTestId('playlist-probe-limit-custom-save'));
-
-    await waitFor(() => {
-      expect(mockApi.settings.update).toHaveBeenCalledWith({ common: { playlistProbeLimit: 375 } });
-    });
-  });
-
-  it('does not save an invalid custom playlist probe limit', async () => {
-    render(<StepUrlInput />);
-
-    const advanced = screen.getByTestId('advanced-section');
-    if (advanced instanceof HTMLDetailsElement) advanced.open = true;
-
-    const playlistSection = screen.getByTestId('playlist-probe-limit-section');
-    fireEvent.click(within(playlistSection).getByTestId('playlist-probe-limit-trigger'));
-    fireEvent.click(await screen.findByTestId('playlist-probe-limit-option-custom'));
-    fireEvent.change(await screen.findByTestId('playlist-probe-limit-custom-input'), { target: { value: '5001' } });
-
-    expect(screen.getByTestId('playlist-probe-limit-custom-save')).toBeDisabled();
+    expect(screen.queryByTestId('playlist-probe-limit-section')).not.toBeInTheDocument();
     expect(mockApi.settings.update).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/browser-mock-scenarios.test.ts
+++ b/tests/unit/browser-mock-scenarios.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildScenarioAppApiState, getScenario, mockStepForScenario, readScenarioIdFromUrl, readUrlParams } from '@renderer/dev/browserMockScenarios.js';
+import { buildScenarioAppApiState, getScenario, mockStepForScenario, readScenarioIdFromUrl, readUrlParams, shouldMockEmptyPlaylistScopeReload } from '@renderer/dev/browserMockScenarios.js';
 
 describe('browser mock scenarios', () => {
   it('reads known scenario ids from URLs', () => {
@@ -12,6 +12,7 @@ describe('browser mock scenarios', () => {
   it('falls back to the default scenario for unknown ids', () => {
     expect(getScenario('single-normal').id).toBe('single-normal');
     expect(getScenario('playlist-normal').id).toBe('playlist-normal');
+    expect(getScenario('playlist-scope-empty-reload').id).toBe('playlist-scope-empty-reload');
     expect(getScenario('probe-audio-only').id).toBe('probe-audio-only');
     expect(getScenario('not-real').id).toBe('default');
   });
@@ -24,6 +25,7 @@ describe('browser mock scenarios', () => {
     expect(mockStepForScenario(getScenario('single-normal'), 'subtitles')).toBe('subtitles');
     expect(mockStepForScenario(getScenario('single-normal'), 'playlistPresets')).toBeNull();
     expect(mockStepForScenario(getScenario('playlist-normal'), 'playlistPresets')).toBe('playlistPresets');
+    expect(mockStepForScenario(getScenario('playlist-scope-empty-reload'), 'playlistItems')).toBe('playlistItems');
     expect(mockStepForScenario(getScenario('playlist-normal'), 'formats')).toBeNull();
   });
 
@@ -72,6 +74,21 @@ describe('browser mock scenarios', () => {
     expect(playlist.probeResult.entries).toHaveLength(12);
     expect(playlist.probeResult.entries.every((entry) => entry.thumbnail !== '')).toBe(true);
     expect(playlist.probeResult.entries.every((entry) => entry.duration !== undefined)).toBe(true);
+
+    const scopeEmptyReload = buildScenarioAppApiState(getScenario('playlist-scope-empty-reload'));
+    expect(scopeEmptyReload.probeResult?.kind).toBe('playlist');
+    if (scopeEmptyReload.probeResult?.kind !== 'playlist') throw new Error('expected playlist probe');
+    expect(scopeEmptyReload.probeResult.entries).toHaveLength(12);
+  });
+
+  it('flags only scoped playlist reloads for the empty-scope scenario', () => {
+    const scenario = getScenario('playlist-scope-empty-reload');
+
+    expect(shouldMockEmptyPlaylistScopeReload(scenario, 'auto', { items: { kind: 'range', from: 50, to: 60 } })).toBe(false);
+    expect(shouldMockEmptyPlaylistScopeReload(scenario, 'playlist', { items: { kind: 'app-limit' } })).toBe(false);
+    expect(shouldMockEmptyPlaylistScopeReload(scenario, 'playlist', { items: { kind: 'first', count: 50 } })).toBe(true);
+    expect(shouldMockEmptyPlaylistScopeReload(scenario, 'playlist', { items: { kind: 'range', from: 50, to: 60 } })).toBe(true);
+    expect(shouldMockEmptyPlaylistScopeReload(getScenario('playlist-normal'), 'playlist', { items: { kind: 'range', from: 50, to: 60 } })).toBe(false);
   });
 
   it('builds probe errors via ?probeError=kind param', () => {

--- a/tests/unit/playlist-scope.test.ts
+++ b/tests/unit/playlist-scope.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { describePlaylistScopeForLog } from '@shared/playlistScope.js';
+import { describePlaylistScopeForLog, playlistScopeSentinelFields } from '@shared/playlistScope.js';
 
 describe('describePlaylistScopeForLog', () => {
   it('describes the app limit with a sentinel playlist-end value', () => {
@@ -32,6 +32,15 @@ describe('describePlaylistScopeForLog', () => {
       sentinel: true,
       ytDlpFlag: '--playlist-items',
       ytDlpValue: '500:601'
+    });
+  });
+
+  it('exposes the same sentinel fields used by yt-dlp args', () => {
+    expect(playlistScopeSentinelFields({ items: { kind: 'range', from: 20, to: 40 } }, 100)).toEqual({
+      requestedCount: 21,
+      sentinel: true,
+      ytDlpFlag: '--playlist-items',
+      ytDlpValue: '20:41'
     });
   });
 });

--- a/tests/unit/playlist-scope.test.ts
+++ b/tests/unit/playlist-scope.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { describePlaylistScopeForLog } from '@shared/playlistScope.js';
+
+describe('describePlaylistScopeForLog', () => {
+  it('describes the app limit with a sentinel playlist-end value', () => {
+    expect(describePlaylistScopeForLog(undefined, 100)).toEqual({
+      kind: 'app-limit',
+      appLimit: 100,
+      requestedCount: 100,
+      sentinel: true,
+      ytDlpFlag: '--playlist-end',
+      ytDlpValue: '101'
+    });
+  });
+
+  it('describes first-count scopes with a sentinel playlist-items value', () => {
+    expect(describePlaylistScopeForLog({ items: { kind: 'first', count: 50 } }, 100)).toEqual({
+      kind: 'first',
+      requestedCount: 50,
+      sentinel: true,
+      ytDlpFlag: '--playlist-items',
+      ytDlpValue: '1:51'
+    });
+  });
+
+  it('describes range scopes with an inclusive requested count and exclusive sentinel end', () => {
+    expect(describePlaylistScopeForLog({ items: { kind: 'range', from: 500, to: 600 } }, 100)).toEqual({
+      kind: 'range',
+      from: 500,
+      to: 600,
+      requestedCount: 101,
+      sentinel: true,
+      ytDlpFlag: '--playlist-items',
+      ytDlpValue: '500:601'
+    });
+  });
+});

--- a/tests/unit/schemas.test.ts
+++ b/tests/unit/schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { startDownloadSchema, queueArraySchema, audioConvertSchema, MAX_SUBTITLE_LANGUAGES, infoDictSchema, updateSettingsSchema, PLAYLIST_VIDEO_TIERS } from '@shared/schemas.js';
+import { startDownloadSchema, queueArraySchema, audioConvertSchema, MAX_SUBTITLE_LANGUAGES, infoDictSchema, updateSettingsSchema, PLAYLIST_VIDEO_TIERS, probeSchema } from '@shared/schemas.js';
 import { DEFAULTS } from '@shared/constants.js';
 
 const IDENTITY = { extractor: 'youtube', extractorKey: 'Youtube' };
@@ -47,6 +47,18 @@ describe('startDownloadSchema — multi-site URL acceptance', () => {
 describe('playlist video tiers', () => {
   it('preserves highest-to-lowest presentation order', () => {
     expect(PLAYLIST_VIDEO_TIERS).toEqual(['best', '2160', '1440', '1080', '720', '480', '360']);
+  });
+});
+
+describe('probeSchema — playlist scope', () => {
+  const url = 'https://www.youtube.com/playlist?list=PLabc';
+
+  it.each([{ items: { kind: 'app-limit' } }, { items: { kind: 'first', count: 50 } }, { items: { kind: 'range', from: 500, to: 600 } }])('accepts %j', (playlistScope) => {
+    expect(probeSchema.safeParse({ url, playlistMode: 'playlist', playlistScope }).success).toBe(true);
+  });
+
+  it.each([{ items: { kind: 'first', count: 0 } }, { items: { kind: 'first', count: 1.5 } }, { items: { kind: 'range', from: 0, to: 10 } }, { items: { kind: 'range', from: 20, to: 10 } }])('rejects %j', (playlistScope) => {
+    expect(probeSchema.safeParse({ url, playlistMode: 'playlist', playlistScope }).success).toBe(false);
   });
 });
 

--- a/tests/unit/ytdlp-args.test.ts
+++ b/tests/unit/ytdlp-args.test.ts
@@ -93,6 +93,37 @@ describe('YtDlp — probe args', () => {
     const args = getArgs();
     expect(args[args.indexOf('--playlist-end') + 1]).toBe('251');
   });
+
+  it('playlist scope first count maps to --playlist-items with a sentinel', async () => {
+    await makeYtDlp().run({ kind: 'probe', url: URL, playlistScope: { items: { kind: 'first', count: 50 } } });
+    const args = getArgs();
+    expect(args).toContain('--playlist-items');
+    expect(args[args.indexOf('--playlist-items') + 1]).toBe('1:51');
+    expect(args).not.toContain('--playlist-end');
+  });
+
+  it('playlist scope range maps to --playlist-items with an exclusive sentinel end', async () => {
+    await makeYtDlp().run({ kind: 'probe', url: URL, playlistScope: { items: { kind: 'range', from: 500, to: 600 } } });
+    const args = getArgs();
+    expect(args).toContain('--playlist-items');
+    expect(args[args.indexOf('--playlist-items') + 1]).toBe('500:601');
+    expect(args).not.toContain('--playlist-end');
+  });
+
+  it("playlistMode='video' ignores playlist scope args", async () => {
+    await makeYtDlp().run({
+      kind: 'probe',
+      url: URL,
+      playlistMode: 'video',
+      playlistScope: { items: { kind: 'range', from: 10, to: 20 } }
+    });
+    const args = getArgs();
+    expect(args).toContain('--no-playlist');
+    expect(args).not.toContain('--playlist-items');
+    expect(args).not.toContain('--playlist-end');
+    expect(args).not.toContain('--dateafter');
+    expect(args).not.toContain('--extractor-args');
+  });
 });
 
 describe('YtDlp — outputTemplate', () => {


### PR DESCRIPTION
## Summary

Adds playlist scope controls so users can reload a playlist preview by app limit, first N items, or an inclusive item range. The scope is validated in shared schemas, threaded through IPC/probe/yt-dlp args with sentinel trimming, and logged through probe and wizard diagnostics.

## Base branch

- [x] This PR targets `main` per current repository branch policy.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling
- [ ] Docs

## Checks

Run from the repo root and confirm clean:

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run knip`
- [x] `bun run test` (if your change touches code under test)

Also ran full local gate:

- [x] `rtk bun run check`

## Testing

- Browser-mock sanity check for the playlist scope dialog on `playlist-normal`: confirmed only app-limit, first, and range controls are shown.
- Browser-mock sanity check for `playlist-scope-empty-reload`: confirmed empty scoped reload stays on the playlist step and keeps the previous list with an inline error.
- Inspected `/home/anton/.config/arroxy/logs/main.log` for the tested flow: app-limit and range probes logged expected yt-dlp args and no warnings/errors.

## Notes for the reviewer

Date filtering is intentionally not included because the fast `--flat-playlist` probe does not reliably include machine-readable upload dates. Count/range scope is implemented at probe time with yt-dlp playlist item flags, then Arroxy trims the sentinel entry before rendering or queueing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-facing changes

- New PlaylistScopeControl UI in the playlist wizard step to choose enumeration limits:
  - App limit (default), First N items, or inclusive item range (from/to).
- Users can apply a scope and trigger an inline playlist reload; UI shows loading and inline error state when reloads fail.
- Localization update: sync message now reads "Showing first {{count}} items. Increase the load limit to see more."

## Internal / refactor changes

- IPC: downloadsProbe handler now accepts optional playlistScope (probeSchema updated to include playlistScope).
- ProbeService: probe(...) signature extended to accept and thread playlistScope through probe attempts and logging.
- YtDlp: probe request type supports playlistScope; added playlistScopeArgs() translating scope -> yt-dlp args (uses --playlist-items and/or --playlist-end with sentinel semantics); probe logging now includes playlistMode and human-readable playlistScope.
- State/store: wizard probe slice adds playlistScope, playlistScopeReloading, playlistScopeError fields and exposes setPlaylistScope() and reloadPlaylistWithScope(scope) with cancellation and diagnostic logging.
- Validation & types: added playlistScopeSchema (discriminated union for app-limit / first / range with range refinements) and PlaylistScope type; ProbeInput type updated to include optional playlistScope.
- Logging: describePlaylistScopeForLog() and playlistScopeSentinelFields() convert scopes into structured log fields and yt-dlp sentinel arguments.
- Dev/test helpers: browser-mock scenario 'playlist-scope-empty-reload' and shouldMockEmptyPlaylistScopeReload() added to simulate scoped reloads that produce no entries.
- UI/UX: removed PlaylistProbeLimitSelector from NetworkPacingSettings and moved probe-limit controls into the playlist step scope control.
- Many tests added/updated to cover schema, yt-dlp arg generation, probe-orchestrator scope behavior, PlaylistScopeControl UI, and browser-mock scenario behavior.

## Risk areas

- IPC / input validation: renderer -> main probe calls are validated by probeSchema at the IPC boundary (downloadsProbe uses probeSchema). Ensure no other code paths bypass that schema. Confirm renderer-side parsing uses playlistScopeSchema.safeParse where applicable (UI uses safeParse before applying).
- yt-dlp argument semantics and sentinel logic: scope enforcement relies on sentinel-encoded exclusive upper bounds and mixing --playlist-items / --playlist-end. If yt-dlp changes arg semantics or outputs become misaligned with sentinel assumptions, scope trimming or visible counts may be incorrect.
- Scope trimming correctness: probeOrchestrator trims probe requests to the visible limit and relies on sentinel behavior to detect caps; off-by-one or incorrect sentinel math could expose more items or hide items within scope.
- Error/recovery UX: scoped reload failures are surfaced inline and the previous item list is preserved. Verify that failure states are consistently reset on subsequent actions and do not block navigation or other wizard steps.
- IPC surface expansion: adding playlistScope increases structured data passed to main. Audit for any new sensitive-surface concerns (no new native modules or dependencies were added in this changeset).
- Build / release: removed UI block in NetworkPacingSettings; confirm consumers of that UI are updated. No dependency version changes detected in this PR summary.

## Tests / checks to run

- rtk bun run check (lint + types + tests) — already exercised in PR.
- Unit tests added/updated:
  - schemas.test.ts (probeSchema — playlist scope)
  - playlist-scope.test.ts (describePlaylistScopeForLog / sentinel fields)
  - ytdlp-args.test.ts (yt-dlp probe arg generation for first/range and video mode)
  - ytdlp-playlist-args.test.ts / related yt-dlp unit tests
- Renderer tests:
  - PlaylistScopeControl tests (playlist-scope-control.test.tsx)
  - probe-orchestrator tests covering scoped reloads, trimming, diagnostics (probe-orchestrator.test.tsx)
  - playlist-probe-limit-selector updated expectation (playlist-probe-limit-selector.test.tsx)
- Browser / E2E:
  - Browser-mock sanity for playlist scope dialog and empty scoped reload (scenario-gallery.spec.ts)
  - Playwright browser-mock scenarios where applicable
- Manual / log checks:
  - Inspect main.log for probe/reload diagnostics, scope descriptions, and sentinel fields when exercising playlist probes.
- Regression: verify cookie validation behavior still blocks probes when cookies are incomplete (IPC handler retains cookies validation path).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->