### PR TITLE
Add package-manager yt-dlp repair

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -197,15 +197,12 @@ if (hasSingleInstanceLock) {
 
     // Enable analytics now that we know it's a real (non-smoke) session.
     setAnalyticsEnabled(initialSettings.common.analyticsEnabled ?? true);
-    const isFirstRun = !initialSettings.common.firstRunCompleted;
-    if (isFirstRun) {
-      await settingsStore.update({ common: { firstRunCompleted: true } });
-    }
+    const launch = await settingsStore.recordLaunch();
     const arch: string = process.arch === 'arm64' ? 'arm64' : 'x64';
     trackMain('app_started', {
       install_channel: detectInstallChannel(app.getName()),
       platform_arch: `${process.platform}-${arch}`,
-      is_first_run: isFirstRun
+      is_first_run: launch.isFirstRun
     });
 
     const mainWindow = createMainWindow();

--- a/src/main/ipc/appHandlers.ts
+++ b/src/main/ipc/appHandlers.ts
@@ -4,17 +4,20 @@ import { IPC_CHANNELS } from '@shared/ipc.js';
 import { supportedLangSchema } from '@shared/schemas.js';
 import type { SupportedLang } from '@shared/i18n/types.js';
 import type { WarmupService } from '@main/services/WarmupService.js';
-import { handleRaw } from './utils.js';
+import type { BinaryManager } from '@main/services/BinaryManager.js';
+import { ok } from '@shared/result.js';
+import { handleRaw, toUnknownFailure } from './utils.js';
 
 interface AppHandlerDeps {
   warmupService: WarmupService;
+  binaryManager: BinaryManager;
   languageRef: { current: SupportedLang };
 }
 
 const warmUpInputSchema = z.object({ force: z.boolean().optional() }).optional();
 
 export function registerAppHandlers(deps: AppHandlerDeps): void {
-  const { warmupService, languageRef } = deps;
+  const { warmupService, binaryManager, languageRef } = deps;
 
   handleRaw(IPC_CHANNELS.appWarmUp, (_, payload: unknown) => {
     const parsed = warmUpInputSchema.safeParse(payload);
@@ -27,6 +30,24 @@ export function registerAppHandlers(deps: AppHandlerDeps): void {
 
   handleRaw(IPC_CHANNELS.appCancelWarmup, () => {
     warmupService.cancel();
+  });
+
+  handleRaw(IPC_CHANNELS.appInstallYtDlpHomebrew, async () => {
+    try {
+      const installedPath = await binaryManager.installYtDlpWithHomebrew();
+      return ok({ installedPath });
+    } catch (error) {
+      return toUnknownFailure(error);
+    }
+  });
+
+  handleRaw(IPC_CHANNELS.appInstallYtDlpWinget, async () => {
+    try {
+      const installedPath = await binaryManager.installYtDlpWithWinget();
+      return ok({ installedPath });
+    } catch (error) {
+      return toUnknownFailure(error);
+    }
   });
 
   handleRaw(IPC_CHANNELS.appSetLanguage, (_, payload: unknown) => {

--- a/src/main/ipc/fileHandlers.ts
+++ b/src/main/ipc/fileHandlers.ts
@@ -65,7 +65,7 @@ export function registerFileHandlers(mainWindow: BrowserWindow, binaryManager: B
   handleRaw(IPC_CHANNELS.logsOpenDir, async () => {
     try {
       const logPath = log.transports.file.getFile().path;
-      if (process.platform === 'win32') {
+      if (process.platform === 'win32' || process.platform === 'darwin') {
         shell.showItemInFolder(logPath);
         return ok({ opened: true });
       }

--- a/src/main/ipc/registerIpcHandlers.ts
+++ b/src/main/ipc/registerIpcHandlers.ts
@@ -41,7 +41,7 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
   const { mainWindow, downloadService, probeService, settingsStore, queueService, binaryManager, tokenService, languageRef, clipboardWatcher, playlistManifestStore } = deps;
 
   const warmupService = new WarmupService({ binaryManager, tokenService, window: mainWindow });
-  registerAppHandlers({ warmupService, languageRef });
+  registerAppHandlers({ warmupService, binaryManager, languageRef });
   registerWindowHandlers(mainWindow);
   registerDownloadHandlers({ downloadService, probeService, settingsStore });
   registerSettingsHandlers({ settingsStore, clipboardWatcher });

--- a/src/main/services/BinaryManager.ts
+++ b/src/main/services/BinaryManager.ts
@@ -13,8 +13,11 @@ const execFileAsync = promisify(execFile);
 
 import { trackMain } from '@main/services/analytics.js';
 import { FAILURE_CODE, type BinaryOverrides, type DependencyAttempt, type DependencyDiagnostic, type DependencyFailure, type DependencyId, type DependencySource, type StatusKey } from '@shared/types.js';
-import { probeArgs, probeBinary, whereOnPath, classifyProbeError, cancelError, PROBE_TIMEOUT_MS } from './binary/BinaryProbe.js';
+import { probeArgs, probeBinary, whereOnPath, classifyProbeError, cancelError, fallbackPathCandidates, PROBE_TIMEOUT_MS } from './binary/BinaryProbe.js';
 import { classifyDownloadError, downloadErrorDetails, downloadFile, downloadText, parseShaLine, parseStandaloneSha256, parsePowerShellFileHash, parseTagFromLocation, sha256ForFile, wrapDownloadProgressEmitter, parseContentRangeStart, resolvePartialResponseMode, HTTP_HEADERS, HTTP_RETRY, HTTP_TIMEOUT, type DownloadProgressCallback, type ProgressEmitter } from './binary/BinaryDownloader.js';
+import { installYtDlpWithHomebrew } from './binary/HomebrewRepair.js';
+import { ManagedSetupError, managedSetupCause, managedSetupStep, sourceTelemetry, withManagedSetupStep } from './binary/ManagedSetup.js';
+import { installYtDlpWithWinget } from './binary/WingetRepair.js';
 
 function stringifyHeader(header: string | string[] | undefined): string | null {
   if (!header) return null;
@@ -231,19 +234,22 @@ export class BinaryManager {
   // whether to fall through to the next attempt.
   private async probeAndAccept(id: DependencyId, source: DependencySource, candidatePath: string, attempts: DependencyAttempt[], onProgress?: ProgressEmitter, signal?: AbortSignal): Promise<DependencyDiagnostic | null> {
     onProgress?.({ binary: id, phase: 'probing', source });
-    const probe = await probeBinary(candidatePath, probeArgs(id), PROBE_TIMEOUT_MS, signal);
+    const args = probeArgs(id);
+    const startedAt = Date.now();
+    const probe = await probeBinary(candidatePath, args, PROBE_TIMEOUT_MS, signal);
+    const elapsedMs = Date.now() - startedAt;
     if (probe.ok) {
       attempts.push(makeAttempt(source));
       this.resolved[id] = candidatePath;
       onProgress?.({ binary: id, phase: 'done', source });
       const diag = runnableDiagnostic(id, source, candidatePath, attempts, probe.output);
       this.lastDiagnostics[id] = diag;
-      logger.info(`${id} probe ok`, { source, path: candidatePath, version: probe.output.split('\n')[0] });
+      logger.info(`${id} probe ok`, { source, path: candidatePath, args, elapsedMs, version: probe.output.split('\n')[0] });
       return diag;
     }
     attempts.push(makeAttempt(source, probe.failure));
     onProgress?.({ binary: id, phase: 'failed', source, failureKind: probe.failure.kind });
-    logger.warn(`${id} probe failed`, { source, path: candidatePath, failureKind: probe.failure.kind, message: probe.failure.message });
+    logger.warn(`${id} probe failed`, { source, path: candidatePath, args, timeoutMs: PROBE_TIMEOUT_MS, elapsedMs, failureKind: probe.failure.kind, message: probe.failure.message });
     return null;
   }
 
@@ -260,11 +266,7 @@ export class BinaryManager {
         destinationPath,
         downloadUrl,
         expectedSha256: async () => {
-          try {
-            return parseShaLine(await downloadText(`${channelSource.download}/SHA2-256SUMS`, signal), assetName);
-          } catch {
-            return null;
-          }
+          return parseShaLine(await downloadText(`${channelSource.download}/SHA2-256SUMS`, signal), assetName);
         },
         onStatus: opts.onStatus,
         onDownloadProgress: makeDownloadProgress(id, source, onProgress),
@@ -273,7 +275,13 @@ export class BinaryManager {
         signal
       })
     );
-    if (!downloadOk) return null;
+    if (!downloadOk) {
+      if (await this.isUsableBinary(destinationPath)) {
+        logger.warn('Using existing yt-dlp after managed update failed', { channel, path: destinationPath });
+        return this.probeAndAccept(id, source, destinationPath, attempts, onProgress, signal);
+      }
+      return null;
+    }
     return this.probeAndAccept(id, source, destinationPath, attempts, onProgress, signal);
   }
 
@@ -326,23 +334,34 @@ export class BinaryManager {
   // Wraps a managed-download attempt, recording download/extract/hash failures
   // as attempts on the chain. Returns true if the file is on disk after the
   // call (probe still has to run separately).
-  private recordManagedFailure(id: DependencyId, attempts: DependencyAttempt[], source: DependencySource, onProgress: ProgressEmitter | undefined, err: unknown): void {
-    const failure: DependencyFailure = { kind: classifyDownloadError(err), message: errorMessage(err) };
+  private recordManagedFailure(id: DependencyId, attempts: DependencyAttempt[], source: DependencySource, onProgress: ProgressEmitter | undefined, err: unknown, elapsedMs: number): void {
+    const cause = managedSetupCause(err);
+    const failure: DependencyFailure = { kind: classifyDownloadError(cause), message: errorMessage(cause) };
     attempts.push(makeAttempt(source, failure));
     onProgress?.({ binary: id, phase: 'failed', source, failureKind: failure.kind });
     const tracked = id === 'yt-dlp' ? 'ytdlp' : id;
-    trackMain('binary_setup_failed', { binary: tracked, phase: failure.kind, code: FAILURE_CODE[failure.kind], ...downloadErrorDetails(err) });
-    logger.warn(`${id} managed download failed`, { source, error: failure.message });
+    trackMain('binary_setup_failed', {
+      binary: tracked,
+      phase: failure.kind,
+      code: FAILURE_CODE[failure.kind],
+      operation: 'managed-download',
+      setup_step: managedSetupStep(err),
+      ...sourceTelemetry(source),
+      elapsed_ms: elapsedMs,
+      ...downloadErrorDetails(cause)
+    });
+    logger.warn(`${id} managed download failed`, { source, setupStep: managedSetupStep(err), elapsedMs, error: failure.message });
   }
 
   private async tryManagedDownload(id: DependencyId, attempts: DependencyAttempt[], source: DependencySource, onProgress: ProgressEmitter | undefined, run: () => Promise<void>): Promise<boolean> {
     onProgress?.({ binary: id, phase: 'downloading', source });
+    const startedAt = Date.now();
     try {
       await run();
       onProgress?.({ binary: id, phase: 'extracting', source });
       return true;
     } catch (err) {
-      this.recordManagedFailure(id, attempts, source, onProgress, err);
+      this.recordManagedFailure(id, attempts, source, onProgress, err, Date.now() - startedAt);
       return false;
     }
   }
@@ -361,6 +380,14 @@ export class BinaryManager {
       throw new Error(diag.failure?.message ?? 'yt-dlp could not be resolved');
     }
     return diag.resolvedPath;
+  }
+
+  async installYtDlpWithHomebrew(): Promise<string> {
+    return installYtDlpWithHomebrew();
+  }
+
+  async installYtDlpWithWinget(): Promise<string> {
+    return installYtDlpWithWinget();
   }
 
   // ffmpeg + ffprobe ship via electron-builder extraResources at build time.
@@ -610,7 +637,7 @@ export class BinaryManager {
   private async downloadBinary(config: EnsureBinaryConfig): Promise<void> {
     const maxAttempts = 3;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      if (config.signal?.aborted) throw cancelError();
+      if (config.signal?.aborted) throw new ManagedSetupError('preflight', cancelError());
       try {
         await this.attemptDownload(config);
         return;
@@ -635,32 +662,34 @@ export class BinaryManager {
     onStatus?.('downloadingBinary', { name });
     logger.info(`Downloading ${name}`, { downloadUrl, destinationPath });
 
-    await downloadFile(downloadUrl, tempPath, onDownloadProgress, true, signal);
+    await withManagedSetupStep('download', () => downloadFile(downloadUrl, tempPath, onDownloadProgress, true, signal));
 
     if (expectedSha256) {
-      const expected = await expectedSha256();
+      const expected = await withManagedSetupStep('checksum_lookup', () => expectedSha256());
       if (!expected && requiredChecksum) {
         await fsPromises.rm(tempPath, { force: true });
-        throw new Error(`Checksum source unavailable for ${name}. Refusing to use unverified binary.`);
+        throw new ManagedSetupError('checksum_lookup', new Error(`Checksum source unavailable for ${name}. Refusing to use unverified binary.`));
       }
 
       if (expected) {
-        const actual = await sha256ForFile(tempPath);
+        const actual = await withManagedSetupStep('checksum_verify', () => sha256ForFile(tempPath));
         if (actual !== expected) {
           await fsPromises.rm(tempPath, { force: true });
-          throw new Error(`${name} checksum mismatch. Expected ${expected.slice(0, 8)}..., got ${actual.slice(0, 8)}...`);
+          throw new ManagedSetupError('checksum_verify', new Error(`${name} checksum mismatch. Expected ${expected.slice(0, 8)}..., got ${actual.slice(0, 8)}...`));
         }
       } else {
         logger.warn(`Checksum unavailable for ${name}, proceeding without verification`);
       }
     }
 
-    await fsPromises.mkdir(path.dirname(destinationPath), { recursive: true });
-    await fsPromises.rename(tempPath, destinationPath);
+    await withManagedSetupStep('install', async () => {
+      await fsPromises.mkdir(path.dirname(destinationPath), { recursive: true });
+      await fsPromises.rename(tempPath, destinationPath);
 
-    if (process.platform !== 'win32') {
-      await fsPromises.chmod(destinationPath, 0o755);
-    }
+      if (process.platform !== 'win32') {
+        await fsPromises.chmod(destinationPath, 0o755);
+      }
+    });
   }
 
   private async isYtDlpUpToDate(binaryPath: string, releaseLatestUrl: string, signal?: AbortSignal): Promise<boolean> {
@@ -691,9 +720,10 @@ export class BinaryManager {
 
   private async getLocalYtDlpVersion(binaryPath: string, signal?: AbortSignal): Promise<string | null> {
     try {
-      const { stdout } = await execFileAsync(binaryPath, ['--version'], { signal });
+      const { stdout } = await execFileAsync(binaryPath, ['--version'], { timeout: PROBE_TIMEOUT_MS, signal });
       return stdout.trim();
-    } catch {
+    } catch (err) {
+      logger.warn('yt-dlp local version check failed', { path: binaryPath, timeoutMs: PROBE_TIMEOUT_MS, error: errorMessage(err) });
       return null;
     }
   }
@@ -746,5 +776,6 @@ export const binaryInternals = {
   classifyProbeError,
   classifyDownloadError,
   whereOnPath,
+  fallbackPathCandidates,
   bundledBinaryPath
 };

--- a/src/main/services/analytics.ts
+++ b/src/main/services/analytics.ts
@@ -42,7 +42,7 @@ const ALLOWED: Record<string, readonly string[]> = {
   download_cancelled: ['duration_bucket'],
   download_failed: ['duration_bucket', 'size_bucket', 'error_category'],
   tray_close_chosen: ['choice', 'remember'],
-  binary_setup_failed: ['binary', 'phase', 'code', 'error_code', 'status_code'],
+  binary_setup_failed: ['binary', 'phase', 'code', 'error_code', 'status_code', 'operation', 'setup_step', 'source_kind', 'source_channel', 'elapsed_ms'],
   crash_detected: ['type', 'reason'],
   wizard_started: [],
   share_dialog_opened: ['via'],
@@ -67,6 +67,19 @@ function mapOperatingSystem(platform: NodeJS.Platform): string {
 // UAParser): a generic Node fetch UA matches its server-event regex, so the
 // server skips sessionId/deviceId/os/browser. Sending a Chrome-shaped UA makes
 // it parse correctly and mint a session.
+function darwinReleaseToMacOsUserAgentVersion(systemVersion: string | undefined): string {
+  if (!systemVersion) return '10_15_7';
+  const parts = systemVersion.split('.').map((part) => Number.parseInt(part, 10));
+  const major = parts[0];
+  if (!Number.isFinite(major)) return '10_15_7';
+  const minor = Number.isFinite(parts[1]) ? parts[1] : 0;
+  const patch = Number.isFinite(parts[2]) ? parts[2] : 0;
+  if (major >= 20) return `${major - 9}_${minor}_${patch}`;
+  if (major === 19) return `10_15_${minor}`;
+  if (major >= 4) return `10_${major - 4}_${minor}`;
+  return '10_15_7';
+}
+
 function buildBrowserishUserAgent(info?: DeviceInfo): string {
   const chromeVersion = process.versions.chrome ?? '124.0.0.0';
   const platform = info?.platform ?? process.platform;
@@ -75,7 +88,7 @@ function buildBrowserishUserAgent(info?: DeviceInfo): string {
   if (platform === 'win32') {
     osPart = 'Windows NT 10.0; Win64; x64';
   } else if (platform === 'darwin') {
-    osPart = 'Macintosh; Intel Mac OS X 10_15_7';
+    osPart = `Macintosh; Intel Mac OS X ${darwinReleaseToMacOsUserAgentVersion(info?.systemVersion)}`;
   } else {
     const linuxArch = arch === 'arm64' ? 'aarch64' : 'x86_64';
     osPart = `X11; Linux ${linuxArch}`;

--- a/src/main/services/binary/BinaryProbe.ts
+++ b/src/main/services/binary/BinaryProbe.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { constants as fsConstants } from 'node:fs';
 import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -38,6 +39,22 @@ export function fallbackPathCandidates(name: string, platform: NodeJS.Platform =
 
   const exeName = name.toLowerCase().endsWith('.exe') ? name : `${name}.exe`;
   return [process.env.LOCALAPPDATA ? path.join(process.env.LOCALAPPDATA, 'Microsoft', 'WindowsApps', exeName) : null, process.env.LOCALAPPDATA ? path.join(process.env.LOCALAPPDATA, 'Microsoft', 'WinGet', 'Links', exeName) : null, process.env.ProgramFiles ? path.join(process.env.ProgramFiles, 'WinGet', 'Links', exeName) : null, process.env['ProgramFiles(x86)'] ? path.join(process.env['ProgramFiles(x86)'], 'WinGet', 'Links', exeName) : null].filter((candidate): candidate is string => candidate !== null);
+}
+
+async function isExecutable(filePath: string): Promise<boolean> {
+  try {
+    await fsPromises.access(filePath, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function firstExecutable(candidates: string[]): Promise<string | null> {
+  for (const candidate of candidates) {
+    if (await isExecutable(candidate)) return candidate;
+  }
+  return null;
 }
 
 export function classifyProbeError(err: NodeJS.ErrnoException, stderr?: string): DependencyFailure {

--- a/src/main/services/binary/BinaryProbe.ts
+++ b/src/main/services/binary/BinaryProbe.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import fsPromises from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import type { DependencyFailure, DependencyId } from '@shared/types.js';
@@ -27,6 +28,16 @@ function abortFailure(message: string): DependencyFailure {
 export function probeArgs(id: DependencyId): string[] {
   if (id === 'ffmpeg' || id === 'ffprobe') return ['-version'];
   return ['--version'];
+}
+
+const MACOS_HOMEBREW_BIN_DIRS = ['/opt/homebrew/bin', '/usr/local/bin'] as const;
+
+export function fallbackPathCandidates(name: string, platform: NodeJS.Platform = process.platform): string[] {
+  if (platform === 'darwin') return MACOS_HOMEBREW_BIN_DIRS.map((dir) => path.join(dir, name));
+  if (platform !== 'win32') return [];
+
+  const exeName = name.toLowerCase().endsWith('.exe') ? name : `${name}.exe`;
+  return [process.env.LOCALAPPDATA ? path.join(process.env.LOCALAPPDATA, 'Microsoft', 'WindowsApps', exeName) : null, process.env.LOCALAPPDATA ? path.join(process.env.LOCALAPPDATA, 'Microsoft', 'WinGet', 'Links', exeName) : null, process.env.ProgramFiles ? path.join(process.env.ProgramFiles, 'WinGet', 'Links', exeName) : null, process.env['ProgramFiles(x86)'] ? path.join(process.env['ProgramFiles(x86)'], 'WinGet', 'Links', exeName) : null].filter((candidate): candidate is string => candidate !== null);
 }
 
 export function classifyProbeError(err: NodeJS.ErrnoException, stderr?: string): DependencyFailure {
@@ -91,15 +102,29 @@ export async function probeBinary(filePath: string, args: string[], timeoutMs: n
 // Discover binaries on PATH. On Windows uses `where.exe`; on POSIX uses `which`.
 // Returns absolute paths in PATH order. Empty array on failure.
 export async function whereOnPath(name: string, signal?: AbortSignal): Promise<string[]> {
+  const found: string[] = [];
   try {
     const tool = process.platform === 'win32' ? 'where' : 'which';
     const args = process.platform === 'win32' ? [name] : ['-a', name];
     const { stdout } = await execFileAsync(tool, args, { windowsHide: true, signal });
-    return stdout
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0);
+    found.push(
+      ...stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+    );
   } catch {
-    return [];
+    // PATH lookup failed; macOS GUI apps often miss Homebrew's bin dirs.
   }
+
+  for (const candidate of fallbackPathCandidates(name)) {
+    try {
+      await fsPromises.access(candidate);
+      found.push(candidate);
+    } catch {
+      // absent fallback path
+    }
+  }
+
+  return [...new Set(found)];
 }

--- a/src/main/services/binary/HomebrewRepair.ts
+++ b/src/main/services/binary/HomebrewRepair.ts
@@ -1,29 +1,11 @@
 import { execFile } from 'node:child_process';
-import { constants as fsConstants } from 'node:fs';
-import fsPromises from 'node:fs/promises';
 import { promisify } from 'node:util';
 import log from 'electron-log/main.js';
-import { whereOnPath } from './BinaryProbe.js';
+import { firstExecutable, whereOnPath } from './BinaryProbe.js';
 
 const execFileAsync = promisify(execFile);
 const logger = log.scope('homebrew-repair');
 const HOMEBREW_INSTALL_TIMEOUT_MS = 10 * 60 * 1000;
-
-async function isExecutable(filePath: string): Promise<boolean> {
-  try {
-    await fsPromises.access(filePath, fsConstants.X_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function firstExecutable(candidates: string[]): Promise<string | null> {
-  for (const candidate of candidates) {
-    if (await isExecutable(candidate)) return candidate;
-  }
-  return null;
-}
 
 export async function installYtDlpWithHomebrew(): Promise<string> {
   if (process.platform !== 'darwin') {

--- a/src/main/services/binary/HomebrewRepair.ts
+++ b/src/main/services/binary/HomebrewRepair.ts
@@ -1,0 +1,53 @@
+import { execFile } from 'node:child_process';
+import { constants as fsConstants } from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import { promisify } from 'node:util';
+import log from 'electron-log/main.js';
+import { whereOnPath } from './BinaryProbe.js';
+
+const execFileAsync = promisify(execFile);
+const logger = log.scope('homebrew-repair');
+const HOMEBREW_INSTALL_TIMEOUT_MS = 10 * 60 * 1000;
+
+async function isExecutable(filePath: string): Promise<boolean> {
+  try {
+    await fsPromises.access(filePath, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function firstExecutable(candidates: string[]): Promise<string | null> {
+  for (const candidate of candidates) {
+    if (await isExecutable(candidate)) return candidate;
+  }
+  return null;
+}
+
+export async function installYtDlpWithHomebrew(): Promise<string> {
+  if (process.platform !== 'darwin') {
+    throw new Error('Homebrew repair is only available on macOS.');
+  }
+
+  const brewPath = await firstExecutable(await whereOnPath('brew'));
+  if (!brewPath) {
+    throw new Error('Homebrew was not found. Install Homebrew first, then retry setup.');
+  }
+
+  logger.info('Installing yt-dlp with Homebrew', { brewPath });
+  await execFileAsync(brewPath, ['install', 'yt-dlp'], {
+    timeout: HOMEBREW_INSTALL_TIMEOUT_MS,
+    maxBuffer: 4 * 1024 * 1024,
+    env: {
+      ...process.env,
+      NONINTERACTIVE: '1',
+      HOMEBREW_NO_ANALYTICS: '1'
+    }
+  });
+
+  const installed = await firstExecutable(await whereOnPath('yt-dlp'));
+  if (installed) return installed;
+
+  throw new Error('Homebrew finished, but yt-dlp was not found in Homebrew bin paths.');
+}

--- a/src/main/services/binary/ManagedSetup.ts
+++ b/src/main/services/binary/ManagedSetup.ts
@@ -1,0 +1,38 @@
+import type { DependencySource } from '@shared/types.js';
+
+export type ManagedSetupStep = 'preflight' | 'download' | 'checksum_lookup' | 'checksum_verify' | 'install' | 'unknown';
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export class ManagedSetupError extends Error {
+  constructor(
+    readonly step: ManagedSetupStep,
+    readonly inner: unknown
+  ) {
+    super(errorMessage(inner));
+    this.name = 'ManagedSetupError';
+  }
+}
+
+export async function withManagedSetupStep<T>(step: ManagedSetupStep, run: () => Promise<T>): Promise<T> {
+  try {
+    return await run();
+  } catch (err) {
+    if (err instanceof ManagedSetupError) throw err;
+    throw new ManagedSetupError(step, err);
+  }
+}
+
+export function managedSetupCause(err: unknown): unknown {
+  return err instanceof ManagedSetupError ? err.inner : err;
+}
+
+export function managedSetupStep(err: unknown): ManagedSetupStep {
+  return err instanceof ManagedSetupError ? err.step : 'unknown';
+}
+
+export function sourceTelemetry(source: DependencySource): { source_kind: string; source_channel?: string } {
+  return source.kind === 'managed' ? { source_kind: source.kind, source_channel: source.channel } : { source_kind: source.kind };
+}

--- a/src/main/services/binary/WingetRepair.ts
+++ b/src/main/services/binary/WingetRepair.ts
@@ -1,0 +1,49 @@
+import { execFile } from 'node:child_process';
+import { constants as fsConstants } from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import { promisify } from 'node:util';
+import log from 'electron-log/main.js';
+import { whereOnPath } from './BinaryProbe.js';
+
+const execFileAsync = promisify(execFile);
+const logger = log.scope('winget-repair');
+const WINGET_INSTALL_TIMEOUT_MS = 10 * 60 * 1000;
+
+async function isExecutable(filePath: string): Promise<boolean> {
+  try {
+    await fsPromises.access(filePath, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function firstExecutable(candidates: string[]): Promise<string | null> {
+  for (const candidate of candidates) {
+    if (await isExecutable(candidate)) return candidate;
+  }
+  return null;
+}
+
+export async function installYtDlpWithWinget(): Promise<string> {
+  if (process.platform !== 'win32') {
+    throw new Error('WinGet repair is only available on Windows.');
+  }
+
+  const wingetPath = await firstExecutable(await whereOnPath('winget.exe'));
+  if (!wingetPath) {
+    throw new Error('WinGet was not found. Install App Installer from Microsoft Store, then retry setup.');
+  }
+
+  logger.info('Installing yt-dlp with WinGet', { wingetPath });
+  await execFileAsync(wingetPath, ['install', '--id', 'yt-dlp.yt-dlp', '--exact', '--silent', '--accept-package-agreements', '--accept-source-agreements'], {
+    timeout: WINGET_INSTALL_TIMEOUT_MS,
+    maxBuffer: 4 * 1024 * 1024,
+    windowsHide: true
+  });
+
+  const installed = await firstExecutable(await whereOnPath('yt-dlp.exe'));
+  if (installed) return installed;
+
+  throw new Error('WinGet finished, but yt-dlp was not found in WinGet links.');
+}

--- a/src/main/services/binary/WingetRepair.ts
+++ b/src/main/services/binary/WingetRepair.ts
@@ -1,28 +1,16 @@
 import { execFile } from 'node:child_process';
-import { constants as fsConstants } from 'node:fs';
-import fsPromises from 'node:fs/promises';
 import { promisify } from 'node:util';
 import log from 'electron-log/main.js';
-import { whereOnPath } from './BinaryProbe.js';
+import { firstExecutable, whereOnPath } from './BinaryProbe.js';
 
 const execFileAsync = promisify(execFile);
 const logger = log.scope('winget-repair');
 const WINGET_INSTALL_TIMEOUT_MS = 10 * 60 * 1000;
+const WINGET_ALREADY_INSTALLED_CODES = new Set([-1978335135, -1978334963, -1978335189, 2316632161, 2316632333, 2316632107]);
 
-async function isExecutable(filePath: string): Promise<boolean> {
-  try {
-    await fsPromises.access(filePath, fsConstants.X_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function firstExecutable(candidates: string[]): Promise<string | null> {
-  for (const candidate of candidates) {
-    if (await isExecutable(candidate)) return candidate;
-  }
-  return null;
+function isIdempotentWingetInstallExit(error: unknown): boolean {
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'number' && WINGET_ALREADY_INSTALLED_CODES.has(code);
 }
 
 export async function installYtDlpWithWinget(): Promise<string> {
@@ -36,11 +24,16 @@ export async function installYtDlpWithWinget(): Promise<string> {
   }
 
   logger.info('Installing yt-dlp with WinGet', { wingetPath });
-  await execFileAsync(wingetPath, ['install', '--id', 'yt-dlp.yt-dlp', '--exact', '--silent', '--accept-package-agreements', '--accept-source-agreements'], {
-    timeout: WINGET_INSTALL_TIMEOUT_MS,
-    maxBuffer: 4 * 1024 * 1024,
-    windowsHide: true
-  });
+  try {
+    await execFileAsync(wingetPath, ['install', '--id', 'yt-dlp.yt-dlp', '--exact', '--silent', '--accept-package-agreements', '--accept-source-agreements'], {
+      timeout: WINGET_INSTALL_TIMEOUT_MS,
+      maxBuffer: 4 * 1024 * 1024,
+      windowsHide: true
+    });
+  } catch (error) {
+    if (!isIdempotentWingetInstallExit(error)) throw error;
+    logger.info('WinGet reported yt-dlp is already installed', { wingetPath, code: (error as { code?: unknown }).code });
+  }
 
   const installed = await firstExecutable(await whereOnPath('yt-dlp.exe'));
   if (installed) return installed;

--- a/src/main/stores/SettingsStore.ts
+++ b/src/main/stores/SettingsStore.ts
@@ -142,6 +142,6 @@ export class SettingsStore {
       }
     };
     this.store.set(next);
-    return { settings: this.store.store, isFirstRun, launchCount };
+    return { settings: next, isFirstRun, launchCount };
   }
 }

--- a/src/main/stores/SettingsStore.ts
+++ b/src/main/stores/SettingsStore.ts
@@ -5,7 +5,7 @@ import type { SettingsPatch } from '@shared/api.js';
 
 export type { SettingsPatch };
 
-const COMMON_FLAT_KEYS = ['defaultOutputDir', 'rememberLastOutputDir', 'uiZoom', 'uiTheme', 'language', 'commonPaths', 'cookiesPath', 'cookiesMode', 'cookiesBrowser', 'proxyUrl', 'limitRate', 'playlistProbeLimit', 'networkPacingPreset', 'pacingSleepRequests', 'pacingSleepInterval', 'pacingMaxSleepInterval', 'pacingSleepSubtitles', 'pacingConcurrentFragments', 'clipboardWatchEnabled', 'includeIdInSingleFilenames', 'closeBehavior', 'embedChapters', 'embedMetadata', 'embedThumbnail', 'writeDescription', 'writeThumbnail', 'lastSponsorBlockMode', 'lastSponsorBlockCategories', 'analyticsEnabled', 'firstRunCompleted', 'drawerOpen', 'installId', 'lastSubfolderEnabled', 'lastSubfolder'] as const;
+const COMMON_FLAT_KEYS = ['defaultOutputDir', 'rememberLastOutputDir', 'uiZoom', 'uiTheme', 'language', 'commonPaths', 'cookiesPath', 'cookiesMode', 'cookiesBrowser', 'proxyUrl', 'limitRate', 'playlistProbeLimit', 'networkPacingPreset', 'pacingSleepRequests', 'pacingSleepInterval', 'pacingMaxSleepInterval', 'pacingSleepSubtitles', 'pacingConcurrentFragments', 'clipboardWatchEnabled', 'includeIdInSingleFilenames', 'closeBehavior', 'embedChapters', 'embedMetadata', 'embedThumbnail', 'writeDescription', 'writeThumbnail', 'lastSponsorBlockMode', 'lastSponsorBlockCategories', 'analyticsEnabled', 'firstRunCompleted', 'launchCount', 'drawerOpen', 'installId', 'lastSubfolderEnabled', 'lastSubfolder'] as const;
 
 // Legacy keys retained only so the flat-to-nested migration can pick them up
 // from old settings files. The values are normalized in `migrateCookiesMode`
@@ -126,5 +126,22 @@ export class SettingsStore {
     const merged = deepMerge(this.store.store, patch);
     this.store.set(merged);
     return this.store.store;
+  }
+
+  async recordLaunch(): Promise<{ settings: AppSettings; isFirstRun: boolean; launchCount: number }> {
+    const current = this.store.store;
+    const isFirstRun = !current.common.firstRunCompleted;
+    const baselineLaunchCount = current.common.launchCount ?? (isFirstRun ? 0 : 2);
+    const launchCount = baselineLaunchCount + 1;
+    const next: AppSettings = {
+      ...current,
+      common: {
+        ...current.common,
+        firstRunCompleted: true,
+        launchCount
+      }
+    };
+    this.store.set(next);
+    return { settings: this.store.store, isFirstRun, launchCount };
   }
 }

--- a/src/preload/createPreloadApi.ts
+++ b/src/preload/createPreloadApi.ts
@@ -18,6 +18,8 @@ export function createPreloadApi(ipcRenderer: PreloadIpcRenderer): AppApi {
     app: {
       warmUp: (input) => ipcRenderer.invoke(IPC_CHANNELS.appWarmUp, input ?? {}),
       cancelWarmup: () => ipcRenderer.invoke(IPC_CHANNELS.appCancelWarmup),
+      installYtDlpWithHomebrew: () => ipcRenderer.invoke(IPC_CHANNELS.appInstallYtDlpHomebrew),
+      installYtDlpWithWinget: () => ipcRenderer.invoke(IPC_CHANNELS.appInstallYtDlpWinget),
       setLanguage: (language) => ipcRenderer.invoke(IPC_CHANNELS.appSetLanguage, language)
     },
     window: {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -30,7 +30,7 @@ function buildDebugInfo(): string {
 
 export function App(): JSX.Element {
   const { t } = useTranslation();
-  const { initialized, initialize, openLogs, uiZoom, setUiZoom, uiTheme, warmupBlocking, warmupDiagnostics, warmupProgress, setAboutDialogOpen, openShareDialog } = useAppStore();
+  const { initialized, initialize, openLogs, uiZoom, setUiZoom, uiTheme, warmupBlocking, warmupDiagnostics, warmupProgress, settings, setAboutDialogOpen, openShareDialog } = useAppStore();
   const update = useUpdateChannel();
   const [debugCopied, setDebugCopied] = useState(false);
   const [showNudge, setShowNudge] = useState(false);
@@ -138,7 +138,7 @@ export function App(): JSX.Element {
           </div>
         </footer>
 
-        <SplashScreen initialized={initialized} warmupBlocking={warmupBlocking} warmupDiagnostics={warmupDiagnostics} warmupProgress={warmupProgress} />
+        <SplashScreen initialized={initialized} warmupBlocking={warmupBlocking} warmupDiagnostics={warmupDiagnostics} warmupProgress={warmupProgress} showGreeting={settings?.common?.launchCount === 2} />
         <AboutDialog />
         <ShareDialog />
         {SHOW_SCENARIO_GALLERY && <ScenarioGallery />}

--- a/src/renderer/src/browserMock.ts
+++ b/src/renderer/src/browserMock.ts
@@ -269,6 +269,14 @@ export function installBrowserMock(): void {
       cancelWarmup: async () => {
         /* no-op in browser */
       },
+      installYtDlpWithHomebrew: async () => {
+        await delay(800);
+        return { ok: true, data: { installedPath: '/opt/homebrew/bin/yt-dlp' } };
+      },
+      installYtDlpWithWinget: async () => {
+        await delay(800);
+        return { ok: true, data: { installedPath: 'C:\\Users\\mock\\AppData\\Local\\Microsoft\\WinGet\\Links\\yt-dlp.exe' } };
+      },
       setLanguage: async () => {
         /* no-op in browser */
       }

--- a/src/renderer/src/components/system/RepairPanel.tsx
+++ b/src/renderer/src/components/system/RepairPanel.tsx
@@ -51,8 +51,9 @@ export function RepairPanel({ diagnostics, blocking }: Props): JSX.Element {
   const warmupCancellable = useAppStore((s) => s.warmupCancellable);
   const settings = useAppStore((s) => s.settings);
   const overrides = settings?.common?.binaryOverrides;
-  const isMac = typeof navigator !== 'undefined' && /Mac/i.test(navigator.platform);
-  const isWindows = typeof navigator !== 'undefined' && /Win/i.test(navigator.platform);
+  const platform = typeof navigator !== 'undefined' ? ((navigator as { userAgentData?: { platform?: string } }).userAgentData?.platform ?? navigator.platform ?? '') : '';
+  const isMac = /Mac/i.test(platform);
+  const isWindows = /Win/i.test(platform);
 
   async function pickAndOverride(id: DependencyId): Promise<void> {
     const result = await window.appApi.dialog.chooseExecutable(id);

--- a/src/renderer/src/components/system/RepairPanel.tsx
+++ b/src/renderer/src/components/system/RepairPanel.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AlertTriangle, FolderOpen, RefreshCw, FileSearch, RotateCcw, X } from 'lucide-react';
+import { AlertTriangle, FolderOpen, RefreshCw, FileSearch, RotateCcw, X, PackagePlus } from 'lucide-react';
 import type { BinaryOverrides, DependencyDiagnostic, DependencyFailureKind, DependencyId } from '@shared/types.js';
 import { FAILURE_CODE } from '@shared/types.js';
 import { useAppStore } from '../../store/useAppStore.js';
@@ -40,14 +40,19 @@ const OVERRIDE_KEY: Record<DependencyId, keyof BinaryOverrides> = {
 export function RepairPanel({ diagnostics, blocking }: Props): JSX.Element {
   const { t } = useTranslation();
   const repairWarmup = useAppStore((s) => s.repairWarmup);
+  const repairYtDlpWithHomebrew = useAppStore((s) => s.repairYtDlpWithHomebrew);
+  const repairYtDlpWithWinget = useAppStore((s) => s.repairYtDlpWithWinget);
   const cancelWarmup = useAppStore((s) => s.cancelWarmup);
   const setBinaryOverride = useAppStore((s) => s.setBinaryOverride);
   const clearBinaryOverride = useAppStore((s) => s.clearBinaryOverride);
   const openBinariesDir = useAppStore((s) => s.openBinariesDir);
   const openLogs = useAppStore((s) => s.openLogs);
   const warmupRunning = useAppStore((s) => s.warmupRunning);
+  const warmupCancellable = useAppStore((s) => s.warmupCancellable);
   const settings = useAppStore((s) => s.settings);
   const overrides = settings?.common?.binaryOverrides;
+  const isMac = typeof navigator !== 'undefined' && /Mac/i.test(navigator.platform);
+  const isWindows = typeof navigator !== 'undefined' && /Win/i.test(navigator.platform);
 
   async function pickAndOverride(id: DependencyId): Promise<void> {
     const result = await window.appApi.dialog.chooseExecutable(id);
@@ -92,6 +97,16 @@ export function RepairPanel({ diagnostics, blocking }: Props): JSX.Element {
                 <Button size="sm" variant="outline" onClick={() => void pickAndOverride(id)} disabled={warmupRunning}>
                   <FileSearch size={14} /> {t('repair.actions.chooseExecutable')}
                 </Button>
+                {id === 'yt-dlp' && isMac && (
+                  <Button size="sm" variant="outline" onClick={() => void repairYtDlpWithHomebrew()} disabled={warmupRunning}>
+                    <PackagePlus size={14} /> {t('repair.actions.installWithHomebrew')}
+                  </Button>
+                )}
+                {id === 'yt-dlp' && isWindows && (
+                  <Button size="sm" variant="outline" onClick={() => void repairYtDlpWithWinget()} disabled={warmupRunning}>
+                    <PackagePlus size={14} /> {t('repair.actions.installWithWinget')}
+                  </Button>
+                )}
                 {overrideActive && (
                   <Button size="sm" variant="outline" onClick={() => void clearBinaryOverride(id)} disabled={warmupRunning}>
                     <RotateCcw size={14} /> {t('repair.actions.resetToDefault')}
@@ -106,7 +121,7 @@ export function RepairPanel({ diagnostics, blocking }: Props): JSX.Element {
         <Button size="sm" onClick={() => void repairWarmup()} disabled={warmupRunning}>
           <RefreshCw size={14} className={warmupRunning ? 'animate-spin' : undefined} /> {t('repair.actions.retrySetup')}
         </Button>
-        {warmupRunning && (
+        {warmupRunning && warmupCancellable && (
           <Button size="sm" variant="outline" onClick={() => void cancelWarmup()}>
             <X size={14} /> {t('repair.actions.cancel')}
           </Button>

--- a/src/renderer/src/components/system/SplashScreen.tsx
+++ b/src/renderer/src/components/system/SplashScreen.tsx
@@ -58,7 +58,11 @@ export function SplashScreen({ initialized, warmupBlocking, warmupDiagnostics, w
     >
       <img src={mainImg} alt="" className="splash-mascot" />
       <div className="splash-text">
-        {showGreeting && <p className="splash-greeting">{t('splash.greeting')}</p>}
+        {showGreeting && (
+          <p className="splash-greeting" data-testid="splash-greeting">
+            {t('splash.greeting')}
+          </p>
+        )}
         {showProgress ? (
           <>
             <p className="splash-name">{activeEntry ? t('splash.downloading', { binary: activeEntry.binary }) : t('splash.warmup')}</p>

--- a/src/renderer/src/components/system/SplashScreen.tsx
+++ b/src/renderer/src/components/system/SplashScreen.tsx
@@ -9,6 +9,7 @@ interface Props {
   warmupBlocking: DependencyId[];
   warmupDiagnostics: Record<DependencyId, DependencyDiagnostic> | null;
   warmupProgress: Partial<Record<DependencyId, WarmupProgressEvent>> | null;
+  showGreeting: boolean;
 }
 
 const MIN_MS = 3000;
@@ -18,7 +19,7 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-export function SplashScreen({ initialized, warmupBlocking, warmupDiagnostics, warmupProgress }: Props): JSX.Element | null {
+export function SplashScreen({ initialized, warmupBlocking, warmupDiagnostics, warmupProgress, showGreeting }: Props): JSX.Element | null {
   const { t } = useTranslation();
   const [minPassed, setMinPassed] = useState(false);
   const [gone, setGone] = useState(false);
@@ -57,7 +58,7 @@ export function SplashScreen({ initialized, warmupBlocking, warmupDiagnostics, w
     >
       <img src={mainImg} alt="" className="splash-mascot" />
       <div className="splash-text">
-        <p className="splash-greeting">{t('splash.greeting')}</p>
+        {showGreeting && <p className="splash-greeting">{t('splash.greeting')}</p>}
         {showProgress ? (
           <>
             <p className="splash-name">{activeEntry ? t('splash.downloading', { binary: activeEntry.binary }) : t('splash.warmup')}</p>

--- a/src/renderer/src/store/systemSlice.ts
+++ b/src/renderer/src/store/systemSlice.ts
@@ -81,6 +81,7 @@ export function createSystemSlice(set: SetState, get: GetState): SystemSlice {
     warmupDiagnostics: null,
     warmupBlocking: [],
     warmupRunning: false,
+    warmupCancellable: false,
     warmupProgress: null,
     settings: null,
     // Guard `navigator` so vitest's node-env tests (e.g. format-selection-view)
@@ -203,7 +204,7 @@ export function createSystemSlice(set: SetState, get: GetState): SystemSlice {
         }));
       });
 
-      set({ warmupRunning: true });
+      set({ warmupRunning: true, warmupCancellable: true });
       const settingsPromise = window.appApi.settings.get();
       const warmUpPromise = window.appApi.app.warmUp();
       const snapshotPromise = window.appApi.queue.cmd.getSnapshot();
@@ -236,7 +237,7 @@ export function createSystemSlice(set: SetState, get: GetState): SystemSlice {
       const warmupDiagnostics = warmUpResult.ok ? warmUpResult.data.dependencies : null;
       const warmupBlocking = warmUpResult.ok ? warmUpResult.data.blockingFailures : [];
 
-      set({ initialized: true, initializing: false, warmupRunning: false, warmupDiagnostics, warmupBlocking });
+      set({ initialized: true, initializing: false, warmupRunning: false, warmupCancellable: false, warmupDiagnostics, warmupBlocking });
     },
 
     cancelWarmup: async () => {
@@ -249,7 +250,7 @@ export function createSystemSlice(set: SetState, get: GetState): SystemSlice {
 
     repairWarmup: async () => {
       if (get().warmupRunning) return;
-      set({ warmupRunning: true });
+      set({ warmupRunning: true, warmupCancellable: true });
       try {
         const result = await window.appApi.app.warmUp({ force: true });
         if (result.ok) {
@@ -260,7 +261,53 @@ export function createSystemSlice(set: SetState, get: GetState): SystemSlice {
       } catch (err) {
         notify.warmupFailed('repair threw', err);
       } finally {
-        set({ warmupRunning: false });
+        set({ warmupRunning: false, warmupCancellable: false });
+      }
+    },
+
+    repairYtDlpWithHomebrew: async () => {
+      if (get().warmupRunning) return;
+      set({ warmupRunning: true, warmupCancellable: false });
+      try {
+        const install = await window.appApi.app.installYtDlpWithHomebrew();
+        if (!install.ok) {
+          notify.warmupFailed('homebrew repair failed', install.error);
+          return;
+        }
+        set({ warmupCancellable: true });
+        const result = await window.appApi.app.warmUp({ force: true });
+        if (result.ok) {
+          set({ warmupDiagnostics: result.data.dependencies, warmupBlocking: result.data.blockingFailures });
+        } else {
+          notify.warmupFailed('post-homebrew repair failed', result.error);
+        }
+      } catch (err) {
+        notify.warmupFailed('homebrew repair threw', err);
+      } finally {
+        set({ warmupRunning: false, warmupCancellable: false });
+      }
+    },
+
+    repairYtDlpWithWinget: async () => {
+      if (get().warmupRunning) return;
+      set({ warmupRunning: true, warmupCancellable: false });
+      try {
+        const install = await window.appApi.app.installYtDlpWithWinget();
+        if (!install.ok) {
+          notify.warmupFailed('winget repair failed', install.error);
+          return;
+        }
+        set({ warmupCancellable: true });
+        const result = await window.appApi.app.warmUp({ force: true });
+        if (result.ok) {
+          set({ warmupDiagnostics: result.data.dependencies, warmupBlocking: result.data.blockingFailures });
+        } else {
+          notify.warmupFailed('post-winget repair failed', result.error);
+        }
+      } catch (err) {
+        notify.warmupFailed('winget repair threw', err);
+      } finally {
+        set({ warmupRunning: false, warmupCancellable: false });
       }
     },
 

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -217,6 +217,7 @@ export interface SystemSlice {
   warmupDiagnostics: Record<DependencyId, DependencyDiagnostic> | null;
   warmupBlocking: DependencyId[];
   warmupRunning: boolean;
+  warmupCancellable: boolean;
   warmupProgress: Partial<Record<DependencyId, import('@shared/types.js').WarmupProgressEvent>> | null;
   settings: AppSettings | null;
   language: SupportedLang;
@@ -225,6 +226,8 @@ export interface SystemSlice {
   shareDialogTrigger: ShareTrigger | null;
   initialize: () => Promise<void>;
   repairWarmup: () => Promise<void>;
+  repairYtDlpWithHomebrew: () => Promise<void>;
+  repairYtDlpWithWinget: () => Promise<void>;
   cancelWarmup: () => Promise<void>;
   setBinaryOverride: (id: DependencyId, path: string) => Promise<void>;
   clearBinaryOverride: (id: DependencyId) => Promise<void>;

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -21,6 +21,8 @@ export interface AppApi {
   app: {
     warmUp(input?: { force?: boolean }): Promise<Result<WarmUpOutput>>;
     cancelWarmup(): Promise<void>;
+    installYtDlpWithHomebrew(): Promise<Result<{ installedPath: string }>>;
+    installYtDlpWithWinget(): Promise<Result<{ installedPath: string }>>;
     setLanguage(language: SupportedLang): Promise<void>;
   };
   window: WindowApi;

--- a/src/shared/i18n/locales/am.ts
+++ b/src/shared/i18n/locales/am.ts
@@ -1,6 +1,7 @@
 const am = {
   common: {
     back: 'ተመለስ',
+    cancel: 'ሰርዝ',
     continue: 'ቀጥል',
     retry: 'እንደገና ሞክር',
     startOver: 'ከመጀመሪያ ጀምር'
@@ -57,6 +58,8 @@ const am = {
     },
     actions: {
       chooseExecutable: 'ፈፃሚ ፋይል ምረጥ',
+      installWithHomebrew: 'በHomebrew ጫን',
+      installWithWinget: 'በWinGet ጫን',
       resetToDefault: 'ወደ ነባሪ መልስ',
       retrySetup: 'ማዋቀሩን እንደገና ሞክር',
       cancel: 'ሰርዝ',
@@ -86,10 +89,17 @@ const am = {
     },
     playlist: {
       heading: 'የ Playlist ቪዲዮዎች',
+      bulkHeading: 'ብዙ URLዎች',
       itemCount_one: '{{count}} ቪዲዮ',
       itemCount_other: '{{count}} ቪዲዮዎች',
       itemCountAudio_one: '{{count}} ዘፈን',
       itemCountAudio_other: '{{count}} ዘፈኖች',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URLዎች',
+      bulkMetadataResolving: 'የቪዲዮ ዝርዝሮች በመ 가져오는 ላይ… {{done}}/{{total}}',
+      bulkRowWaiting: 'በመጠባበቅ ላይ',
+      bulkRowResolving: 'ዝርዝሮች በመ 가져오는 ላይ',
+      bulkRowFailed: 'ዝርዝሮች አይገኙም',
       selectAll: 'ሁሉ ምረጥ',
       selectNone: 'ምንም አትምረጥ',
       rangeFrom: 'ከ',
@@ -111,6 +121,22 @@ const am = {
       alreadyDownloaded: 'ቀድሞ ወርዷል',
       probeLimitAlertTitle: 'የ Playlist ቃኝት ተገድቧል',
       probeLimitAlertDesc: 'Arroxy ከ {{count}} በላይ ንጥሎችን አግኝቷል፣ ስለዚህ የአሁኑ ቃኝት ገደብ የቀሩትን እየደበቀ ነው።'
+    },
+    bulk: {
+      title: 'ብዙ URLዎች',
+      description: 'የቪዲዮ ወይም የድምጽ URLዎችን ለብቻ ለብቻ ለጥፍ። Arroxy ተደጋጋሚዎችን ያጸዳል እና የplaylist ወይም channel አገናኞችን ያሳያል።',
+      textareaLabel: 'የURL ዝርዝር',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'ዝግጁ',
+      ignoredCount: 'ተተው',
+      emptyPreview: 'ቡድኑን ለማየት ቢያንስ ሁለት URLዎች ለጥፍ።',
+      needsTwo: 'ለመቀጠል ቢያንስ ሁለት የሚደገፉ URLዎች ጨምር።',
+      confirm: 'እነዚህን URLዎች ተጠቀም',
+      reject: {
+        duplicate: 'ተደጋጋሚ',
+        playlist: 'የplaylist ፍሰት ተጠቀም',
+        channel: 'የchannel ፍሰት ተጠቀም'
+      }
     },
     playlistPresets: {
       heading: 'ለቡድኑ ጥራት ይምረጡ',
@@ -142,6 +168,8 @@ const am = {
       quickProbeFailed: 'መፈተሹ አልተሳካም',
       quickPrepareFailed: 'የወረፋ ንጥል ማዘጋጀት አልተቻለም',
       quickFailed: 'ይህን ማከል አልተቻለም፦ {{error}}',
+      bulkButton: 'ብዙ URLዎች',
+      bulkTooltip: 'የተለዩ URLዎችን ዝርዝር ለጥፍ፣ የተጸዳውን ዝርዝር ተመልከት፣ ከዚያ በአንድ የጥራት preset ወደ queue አክል።',
       features: {
         heading: 'Arroxy ምን ሊያወርድ ይችላል',
         youtube: {
@@ -175,6 +203,11 @@ const am = {
         dialog: {
           title: 'YouTube URL ተገኝቷል',
           body: 'ይህን አገናኝ ከቅጂ ሰሌዳ ይጠቀሙ?',
+          bulkTitle: 'ብዙ URLዎች ተገኙ',
+          bulkBody: 'እነዚህን የclipboard አገናኞች እንደ ብዙ ዳውንሎድ ትጠቀም?',
+          bulkSummary: '{{count}} URLዎች ዝግጁ',
+          bulkIgnored: '{{count}} ተተው',
+          bulkButton: 'ብዙ አውርድ',
           useButton: 'URL ጠቀም',
           disableButton: 'አሰናክል',
           cancelButton: 'ሰርዝ',
@@ -444,12 +477,15 @@ const am = {
       pullIt: 'ሳቡት! ↓',
       pullItTooltip: 'ወዲያው ይጀምራል — ከሌሎች ዳውንሎዶች ጋር ይሰራል',
       labelPlaylist: 'Playlist',
+      labelBulk: 'ብዙ URLዎች',
       labelPreset: 'ቅድመ-ቅንብር',
       labelItems: 'ቁጥር',
       itemsValue_one: '{{count}} ከ {{total}} ቪዲዮ',
       itemsValue_other: '{{count}} ከ {{total}} ቪዲዮዎች',
       itemsValueAudio_one: '{{count}} ከ {{total}} ዘፈን',
-      itemsValueAudio_other: '{{count}} ከ {{total}} ዘፈኖች'
+      itemsValueAudio_other: '{{count}} ከ {{total}} ዘፈኖች',
+      itemsValueBulk_one: '{{count}} ከ{{total}} URL',
+      itemsValueBulk_other: '{{count}} ከ{{total}} URLዎች'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/ar.ts
+++ b/src/shared/i18n/locales/ar.ts
@@ -1,6 +1,7 @@
 const ar = {
   common: {
     back: 'رجوع',
+    cancel: 'إلغاء',
     continue: 'متابعة',
     retry: 'إعادة المحاولة',
     startOver: 'البدء من جديد'
@@ -57,6 +58,8 @@ const ar = {
     },
     actions: {
       chooseExecutable: 'اختر الملف القابل للتنفيذ',
+      installWithHomebrew: 'التثبيت عبر Homebrew',
+      installWithWinget: 'التثبيت عبر WinGet',
       resetToDefault: 'إعادة إلى الافتراضي',
       retrySetup: 'إعادة محاولة الإعداد',
       cancel: 'إلغاء',
@@ -86,10 +89,17 @@ const ar = {
     },
     playlist: {
       heading: 'عناصر القائمة',
+      bulkHeading: 'روابط متعددة',
       itemCount_one: '{{count}} فيديو',
       itemCount_other: '{{count}} مقاطع فيديو',
       itemCountAudio_one: '{{count}} مقطع صوتي',
       itemCountAudio_other: '{{count}} مقاطع صوتية',
+      itemCountBulk_one: '{{count}} رابط',
+      itemCountBulk_other: '{{count}} روابط',
+      bulkMetadataResolving: 'جارٍ جلب تفاصيل الفيديو… {{done}}/{{total}}',
+      bulkRowWaiting: 'بانتظار',
+      bulkRowResolving: 'جارٍ جلب التفاصيل',
+      bulkRowFailed: 'التفاصيل غير متاحة',
       selectAll: 'تحديد الكل',
       selectNone: 'إلغاء تحديد الكل',
       rangeFrom: 'من',
@@ -111,6 +121,22 @@ const ar = {
       alreadyDownloaded: 'تم تنزيله بالفعل',
       probeLimitAlertTitle: 'فحص قائمة التشغيل محدود',
       probeLimitAlertDesc: 'عثر Arroxy على أكثر من {{count}} عنصر، لذا يُخفي حد الفحص الحالي بقية العناصر.'
+    },
+    bulk: {
+      title: 'روابط متعددة',
+      description: 'الصق روابط فيديو أو صوت منفردة. سيزيل Arroxy التكرارات ويعلّم روابط قوائم التشغيل أو القنوات قبل إضافتها إلى الطابور.',
+      textareaLabel: 'قائمة الروابط',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'جاهزة',
+      ignoredCount: 'متجاهلة',
+      emptyPreview: 'الصق رابطين على الأقل لمعاينة الدفعة.',
+      needsTwo: 'أضف رابطين مدعومين على الأقل للمتابعة.',
+      confirm: 'استخدم هذه الروابط',
+      reject: {
+        duplicate: 'مكرر',
+        playlist: 'استخدم مسار قائمة التشغيل',
+        channel: 'استخدم مسار القناة'
+      }
     },
     playlistPresets: {
       heading: 'اختر الجودة للدفعة',
@@ -142,6 +168,8 @@ const ar = {
       quickProbeFailed: 'فشل الفحص',
       quickPrepareFailed: 'تعذر تحضير عنصر قائمة الانتظار',
       quickFailed: 'تعذرت إضافة هذا العنصر: {{error}}',
+      bulkButton: 'روابط متعددة',
+      bulkTooltip: 'الصق قائمة روابط منفردة، راجع القائمة المنظفة، ثم أضفها إلى الطابور بإعداد جودة مشترك.',
       features: {
         heading: 'ما الذي يستطيع Arroxy سحبه',
         youtube: {
@@ -175,6 +203,11 @@ const ar = {
         dialog: {
           title: 'تم اكتشاف رابط YouTube',
           body: 'هل تريد استخدام هذا الرابط من الحافظة؟',
+          bulkTitle: 'تم اكتشاف روابط متعددة',
+          bulkBody: 'استخدام روابط الحافظة هذه كتنزيل دفعي؟',
+          bulkSummary: '{{count}} روابط جاهزة',
+          bulkIgnored: '{{count}} متجاهلة',
+          bulkButton: 'تنزيل دفعي',
           useButton: 'استخدام الرابط',
           disableButton: 'تعطيل',
           cancelButton: 'إلغاء',
@@ -444,12 +477,15 @@ const ar = {
       pullIt: 'اسحبه! ↓',
       pullItTooltip: 'يبدأ فوراً — يعمل جنباً إلى جنب مع التنزيلات النشطة الأخرى',
       labelPlaylist: 'قائمة التشغيل',
+      labelBulk: 'روابط متعددة',
       labelPreset: 'الإعداد المسبق',
       labelItems: 'العناصر',
       itemsValue_one: '{{count}} من {{total}} فيديو',
       itemsValue_other: '{{count}} من {{total}} مقاطع فيديو',
       itemsValueAudio_one: '{{count}} من {{total}} مقطع صوتي',
-      itemsValueAudio_other: '{{count}} من {{total}} مقاطع صوتية'
+      itemsValueAudio_other: '{{count}} من {{total}} مقاطع صوتية',
+      itemsValueBulk_one: '{{count}} من {{total}} رابط',
+      itemsValueBulk_other: '{{count}} من {{total}} روابط'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/bn.ts
+++ b/src/shared/i18n/locales/bn.ts
@@ -1,6 +1,7 @@
 const bn = {
   common: {
     back: 'পেছনে',
+    cancel: 'বাতিল',
     continue: 'চালিয়ে যান',
     retry: 'আবার চেষ্টা করুন',
     startOver: 'নতুন করে শুরু করুন'
@@ -57,6 +58,8 @@ const bn = {
     },
     actions: {
       chooseExecutable: 'এক্সিকিউটেবল বেছে নিন',
+      installWithHomebrew: 'Homebrew দিয়ে ইনস্টল করুন',
+      installWithWinget: 'WinGet দিয়ে ইনস্টল করুন',
       resetToDefault: 'ডিফল্টে ফিরুন',
       retrySetup: 'সেটআপ আবার চেষ্টা করুন',
       cancel: 'বাতিল',
@@ -86,10 +89,17 @@ const bn = {
     },
     playlist: {
       heading: 'Playlist আইটেম',
+      bulkHeading: 'বাল্ক URL',
       itemCount_one: '{{count}}টি ভিডিও',
       itemCount_other: '{{count}}টি ভিডিও',
       itemCountAudio_one: '{{count}}টি ট্র্যাক',
       itemCountAudio_other: '{{count}}টি ট্র্যাক',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URL',
+      bulkMetadataResolving: 'ভিডিওর বিস্তারিত আনা হচ্ছে… {{done}}/{{total}}',
+      bulkRowWaiting: 'অপেক্ষা করছে',
+      bulkRowResolving: 'বিস্তারিত আনা হচ্ছে',
+      bulkRowFailed: 'বিস্তারিত নেই',
       selectAll: 'সব নির্বাচন করুন',
       selectNone: 'কোনোটি নির্বাচন করবেন না',
       rangeFrom: 'থেকে',
@@ -111,6 +121,22 @@ const bn = {
       alreadyDownloaded: 'ইতিমধ্যেই ডাউনলোড করা',
       probeLimitAlertTitle: 'প্লেলিস্ট স্ক্যান সীমাবদ্ধ করা হয়েছে',
       probeLimitAlertDesc: 'Arroxy {{count}}-এর বেশি আইটেম খুঁজে পেয়েছে, তাই বর্তমান স্ক্যান সীমা বাকিগুলো লুকিয়ে রাখছে।'
+    },
+    bulk: {
+      title: 'বাল্ক URL',
+      description: 'আলাদা ভিডিও বা অডিও URL পেস্ট করুন। Arroxy ডুপ্লিকেট সরাবে এবং সারিতে দেওয়ার আগে playlist বা channel লিংক চিহ্নিত করবে।',
+      textareaLabel: 'URL তালিকা',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'প্রস্তুত',
+      ignoredCount: 'উপেক্ষিত',
+      emptyPreview: 'ব্যাচ দেখতে অন্তত দুটি URL পেস্ট করুন।',
+      needsTwo: 'চালিয়ে যেতে অন্তত দুটি সমর্থিত URL যোগ করুন।',
+      confirm: 'এই URLগুলো ব্যবহার করুন',
+      reject: {
+        duplicate: 'ডুপ্লিকেট',
+        playlist: 'playlist flow ব্যবহার করুন',
+        channel: 'channel flow ব্যবহার করুন'
+      }
     },
     playlistPresets: {
       heading: 'ব্যাচের জন্য মান বেছে নিন',
@@ -142,6 +168,8 @@ const bn = {
       quickProbeFailed: 'প্রোব ব্যর্থ হয়েছে',
       quickPrepareFailed: 'কিউ আইটেম প্রস্তুত করা যায়নি',
       quickFailed: 'এটি যোগ করা যায়নি: {{error}}',
+      bulkButton: 'বাল্ক URL',
+      bulkTooltip: 'আলাদা URL-এর তালিকা পেস্ট করুন, পরিষ্কার তালিকা দেখুন, তারপর একটি quality preset দিয়ে সারিতে দিন।',
       features: {
         heading: 'Arroxy যা নামাতে পারে',
         youtube: {
@@ -175,6 +203,11 @@ const bn = {
         dialog: {
           title: 'YouTube URL পাওয়া গেছে',
           body: 'ক্লিপবোর্ডের এই লিংকটি ব্যবহার করবেন?',
+          bulkTitle: 'বাল্ক URL পাওয়া গেছে',
+          bulkBody: 'clipboard-এর এই লিংকগুলো bulk download হিসেবে ব্যবহার করবেন?',
+          bulkSummary: '{{count}} URL প্রস্তুত',
+          bulkIgnored: '{{count}} উপেক্ষিত',
+          bulkButton: 'বাল্ক ডাউনলোড',
           useButton: 'URL ব্যবহার করুন',
           disableButton: 'বন্ধ করুন',
           cancelButton: 'বাতিল',
@@ -444,12 +477,15 @@ const bn = {
       pullIt: 'নামিয়ে নিন! ↓',
       pullItTooltip: 'এখনই শুরু হবে — অন্য সক্রিয় ডাউনলোডের সাথে চলবে',
       labelPlaylist: 'Playlist',
+      labelBulk: 'বাল্ক URL',
       labelPreset: 'প্রিসেট',
       labelItems: 'আইটেম',
       itemsValue_one: '{{total}}-এর মধ্যে {{count}}টি ভিডিও',
       itemsValue_other: '{{total}}-এর মধ্যে {{count}}টি ভিডিও',
       itemsValueAudio_one: '{{total}}-এর মধ্যে {{count}}টি ট্র্যাক',
-      itemsValueAudio_other: '{{total}}-এর মধ্যে {{count}}টি ট্র্যাক'
+      itemsValueAudio_other: '{{total}}-এর মধ্যে {{count}}টি ট্র্যাক',
+      itemsValueBulk_one: '{{total}} URL-এর মধ্যে {{count}}',
+      itemsValueBulk_other: '{{total}} URL-এর মধ্যে {{count}}'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/de.ts
+++ b/src/shared/i18n/locales/de.ts
@@ -1,6 +1,7 @@
 const de = {
   common: {
     back: 'Zurück',
+    cancel: 'Abbrechen',
     continue: 'Weiter',
     retry: 'Erneut versuchen',
     startOver: 'Von vorn beginnen'
@@ -57,6 +58,8 @@ const de = {
     },
     actions: {
       chooseExecutable: 'Ausführbare Datei wählen',
+      installWithHomebrew: 'Mit Homebrew installieren',
+      installWithWinget: 'Mit WinGet installieren',
       resetToDefault: 'Auf Standard zurücksetzen',
       retrySetup: 'Einrichtung wiederholen',
       cancel: 'Abbrechen',
@@ -86,10 +89,17 @@ const de = {
     },
     playlist: {
       heading: 'Playlist-Elemente',
+      bulkHeading: 'Bulk-URLs',
       itemCount_one: '{{count}} video',
       itemCount_other: '{{count}} videos',
       itemCountAudio_one: '{{count}} Titel',
       itemCountAudio_other: '{{count}} Titel',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URLs',
+      bulkMetadataResolving: 'Videodetails werden geladen… {{done}}/{{total}}',
+      bulkRowWaiting: 'Wartet',
+      bulkRowResolving: 'Details werden geladen',
+      bulkRowFailed: 'Details nicht verfügbar',
       selectAll: 'Alle auswählen',
       selectNone: 'Keine auswählen',
       rangeFrom: 'Von',
@@ -111,6 +121,22 @@ const de = {
       alreadyDownloaded: 'Bereits heruntergeladen',
       probeLimitAlertTitle: 'Playlist-Scan ist begrenzt',
       probeLimitAlertDesc: 'Arroxy hat mehr als {{count}} Einträge gefunden, daher verbirgt das aktuelle Scan-Limit den Rest.'
+    },
+    bulk: {
+      title: 'Bulk-URLs',
+      description: 'Füge einzelne Video- oder Audio-URLs ein. Arroxy bereinigt Duplikate und markiert Playlist- oder Kanal-Links vor dem Einreihen.',
+      textareaLabel: 'URL-Liste',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'Bereit',
+      ignoredCount: 'Ignoriert',
+      emptyPreview: 'Füge mindestens zwei URLs ein, um den Stapel anzuzeigen.',
+      needsTwo: 'Füge mindestens zwei unterstützte URLs hinzu, um fortzufahren.',
+      confirm: 'Diese URLs verwenden',
+      reject: {
+        duplicate: 'Duplikat',
+        playlist: 'Playlist-Ablauf verwenden',
+        channel: 'Kanal-Ablauf verwenden'
+      }
     },
     playlistPresets: {
       heading: 'Qualität für den Stapel wählen',
@@ -142,6 +168,8 @@ const de = {
       quickProbeFailed: 'Prüfung fehlgeschlagen',
       quickPrepareFailed: 'Warteschlangeneintrag konnte nicht vorbereitet werden',
       quickFailed: 'Konnte dieses Element nicht hinzufügen: {{error}}',
+      bulkButton: 'Bulk-URLs',
+      bulkTooltip: 'Füge eine Liste einzelner URLs ein, prüfe die bereinigte Liste und stelle sie dann mit einer gemeinsamen Qualitätsvorgabe in die Warteschlange.',
       features: {
         heading: 'Was Arroxy laden kann',
         youtube: {
@@ -175,6 +203,11 @@ const de = {
         dialog: {
           title: 'YouTube-URL erkannt',
           body: 'Diesen Link aus deiner Zwischenablage verwenden?',
+          bulkTitle: 'Bulk-URLs erkannt',
+          bulkBody: 'Diese Links aus der Zwischenablage als Bulk-Download verwenden?',
+          bulkSummary: '{{count}} URLs bereit',
+          bulkIgnored: '{{count}} ignoriert',
+          bulkButton: 'Bulk-Download',
           useButton: 'URL verwenden',
           disableButton: 'Deaktivieren',
           cancelButton: 'Abbrechen',
@@ -444,12 +477,15 @@ const de = {
       pullIt: "Hol's rein! ↓",
       pullItTooltip: 'Startet sofort — läuft parallel zu anderen aktiven Downloads',
       labelPlaylist: 'Playlist',
+      labelBulk: 'Bulk-URLs',
       labelPreset: 'Voreinstellung',
       labelItems: 'Elemente',
       itemsValue_one: '{{count}} von {{total}} Video',
       itemsValue_other: '{{count}} von {{total}} Videos',
       itemsValueAudio_one: '{{count}} von {{total}} Titel',
-      itemsValueAudio_other: '{{count}} von {{total}} Titeln'
+      itemsValueAudio_other: '{{count}} von {{total}} Titeln',
+      itemsValueBulk_one: '{{count}} von {{total}} URL',
+      itemsValueBulk_other: '{{count}} von {{total}} URLs'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/el.ts
+++ b/src/shared/i18n/locales/el.ts
@@ -1,6 +1,7 @@
 const el = {
   common: {
     back: 'Πίσω',
+    cancel: 'Ακύρωση',
     continue: 'Συνέχεια',
     retry: 'Επανάληψη',
     startOver: 'Επανεκκίνηση'
@@ -57,6 +58,8 @@ const el = {
     },
     actions: {
       chooseExecutable: 'Επιλογή εκτελέσιμου',
+      installWithHomebrew: 'Εγκατάσταση με Homebrew',
+      installWithWinget: 'Εγκατάσταση με WinGet',
       resetToDefault: 'Επαναφορά στις προεπιλογές',
       retrySetup: 'Επανάληψη ρύθμισης',
       cancel: 'Ακύρωση',
@@ -86,10 +89,17 @@ const el = {
     },
     playlist: {
       heading: 'Στοιχεία playlist',
+      bulkHeading: 'Μαζικά URL',
       itemCount_one: '{{count}} βίντεο',
       itemCount_other: '{{count}} βίντεο',
       itemCountAudio_one: '{{count}} κομμάτι',
       itemCountAudio_other: '{{count}} κομμάτια',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URL',
+      bulkMetadataResolving: 'Ανάκτηση λεπτομερειών βίντεο… {{done}}/{{total}}',
+      bulkRowWaiting: 'Σε αναμονή',
+      bulkRowResolving: 'Ανάκτηση λεπτομερειών',
+      bulkRowFailed: 'Οι λεπτομέρειες δεν είναι διαθέσιμες',
       selectAll: 'Επιλογή όλων',
       selectNone: 'Αποεπιλογή όλων',
       rangeFrom: 'Από',
@@ -111,6 +121,22 @@ const el = {
       alreadyDownloaded: 'Ήδη κατεβασμένο',
       probeLimitAlertTitle: 'Η σάρωση playlist έχει περιοριστεί',
       probeLimitAlertDesc: 'Το Arroxy βρήκε περισσότερα από {{count}} στοιχεία, οπότε το τρέχον όριο σάρωσης αποκρύπτει τα υπόλοιπα.'
+    },
+    bulk: {
+      title: 'Μαζικά URL',
+      description: 'Επικολλήστε μεμονωμένα URL βίντεο ή ήχου. Το Arroxy θα καθαρίσει τα διπλότυπα και θα επισημάνει συνδέσμους playlist ή καναλιού πριν την ουρά.',
+      textareaLabel: 'Λίστα URL',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'Έτοιμα',
+      ignoredCount: 'Αγνοήθηκαν',
+      emptyPreview: 'Επικολλήστε τουλάχιστον δύο URL για προεπισκόπηση της παρτίδας.',
+      needsTwo: 'Προσθέστε τουλάχιστον δύο υποστηριζόμενα URL για συνέχεια.',
+      confirm: 'Χρήση αυτών των URL',
+      reject: {
+        duplicate: 'Διπλότυπο',
+        playlist: 'Χρήση ροής playlist',
+        channel: 'Χρήση ροής καναλιού'
+      }
     },
     playlistPresets: {
       heading: 'Επιλογή ποιότητας για την ομαδική λήψη',
@@ -142,6 +168,8 @@ const el = {
       quickProbeFailed: 'Ο έλεγχος απέτυχε',
       quickPrepareFailed: 'Δεν ήταν δυνατή η προετοιμασία του στοιχείου ουράς',
       quickFailed: 'Δεν ήταν δυνατή η προσθήκη: {{error}}',
+      bulkButton: 'Μαζικά URL',
+      bulkTooltip: 'Επικολλήστε μια λίστα μεμονωμένων URL, δείτε την καθαρισμένη λίστα και βάλτε τα στην ουρά με κοινή ποιότητα.',
       features: {
         heading: 'Τι μπορεί να κατεβάσει το Arroxy',
         youtube: {
@@ -175,6 +203,11 @@ const el = {
         dialog: {
           title: 'Εντοπίστηκε YouTube URL',
           body: 'Να χρησιμοποιηθεί αυτός ο σύνδεσμος από το πρόχειρο;',
+          bulkTitle: 'Εντοπίστηκαν μαζικά URL',
+          bulkBody: 'Χρήση αυτών των συνδέσμων από το πρόχειρο ως μαζική λήψη;',
+          bulkSummary: '{{count}} URL έτοιμα',
+          bulkIgnored: '{{count}} αγνοήθηκαν',
+          bulkButton: 'Μαζική λήψη',
           useButton: 'Χρήση URL',
           disableButton: 'Απενεργοποίηση',
           cancelButton: 'Ακύρωση',
@@ -444,12 +477,15 @@ const el = {
       pullIt: 'Κατέβασέ το! ↓',
       pullItTooltip: 'Ξεκινά αμέσως — εκτελείται παράλληλα με άλλες ενεργές λήψεις',
       labelPlaylist: 'Playlist',
+      labelBulk: 'Μαζικά URL',
       labelPreset: 'Προεπιλογή',
       labelItems: 'Στοιχεία',
       itemsValue_one: '{{count}} από {{total}} βίντεο',
       itemsValue_other: '{{count}} από {{total}} βίντεο',
       itemsValueAudio_one: '{{count}} από {{total}} κομμάτι',
-      itemsValueAudio_other: '{{count}} από {{total}} κομμάτια'
+      itemsValueAudio_other: '{{count}} από {{total}} κομμάτια',
+      itemsValueBulk_one: '{{count}} από {{total}} URL',
+      itemsValueBulk_other: '{{count}} από {{total}} URL'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/en.ts
+++ b/src/shared/i18n/locales/en.ts
@@ -58,6 +58,8 @@ const en = {
     },
     actions: {
       chooseExecutable: 'Choose executable',
+      installWithHomebrew: 'Install with Homebrew',
+      installWithWinget: 'Install with WinGet',
       resetToDefault: 'Reset to default',
       retrySetup: 'Retry setup',
       cancel: 'Cancel',

--- a/src/shared/i18n/locales/es.ts
+++ b/src/shared/i18n/locales/es.ts
@@ -1,6 +1,7 @@
 const es = {
   common: {
     back: 'Atrás',
+    cancel: 'Cancelar',
     continue: 'Continuar',
     retry: 'Reintentar',
     startOver: 'Empezar de nuevo'
@@ -57,6 +58,8 @@ const es = {
     },
     actions: {
       chooseExecutable: 'Elegir ejecutable',
+      installWithHomebrew: 'Instalar con Homebrew',
+      installWithWinget: 'Instalar con WinGet',
       resetToDefault: 'Restablecer predeterminado',
       retrySetup: 'Reintentar configuración',
       cancel: 'Cancelar',
@@ -86,10 +89,17 @@ const es = {
     },
     playlist: {
       heading: 'Elementos de la Playlist',
+      bulkHeading: 'URLs en lote',
       itemCount_one: '{{count}} video',
       itemCount_other: '{{count}} videos',
       itemCountAudio_one: '{{count}} pista',
       itemCountAudio_other: '{{count}} pistas',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URLs',
+      bulkMetadataResolving: 'Obteniendo detalles del vídeo… {{done}}/{{total}}',
+      bulkRowWaiting: 'Esperando',
+      bulkRowResolving: 'Obteniendo detalles',
+      bulkRowFailed: 'Detalles no disponibles',
       selectAll: 'Seleccionar todo',
       selectNone: 'Deseleccionar todo',
       rangeFrom: 'Desde',
@@ -111,6 +121,22 @@ const es = {
       alreadyDownloaded: 'Ya descargado',
       probeLimitAlertTitle: 'El escaneo de la playlist está limitado',
       probeLimitAlertDesc: 'Arroxy encontró más de {{count}} elementos, por lo que el límite de escaneo actual está ocultando el resto.'
+    },
+    bulk: {
+      title: 'URLs en lote',
+      description: 'Pega URLs individuales de vídeo o audio. Arroxy limpiará duplicados y marcará enlaces de playlist o canal antes de enviarlos a la cola.',
+      textareaLabel: 'Lista de URLs',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'Listas',
+      ignoredCount: 'Ignoradas',
+      emptyPreview: 'Pega al menos dos URLs para previsualizar el lote.',
+      needsTwo: 'Añade al menos dos URLs compatibles para continuar.',
+      confirm: 'Usar estas URLs',
+      reject: {
+        duplicate: 'Duplicado',
+        playlist: 'Usar flujo de playlist',
+        channel: 'Usar flujo de canal'
+      }
     },
     playlistPresets: {
       heading: 'Elige la calidad para el lote',
@@ -141,6 +167,8 @@ const es = {
       quickProbeFailed: 'Falló el análisis',
       quickPrepareFailed: 'No se pudo preparar el elemento de la cola',
       quickFailed: 'No se pudo añadir: {{error}}',
+      bulkButton: 'URLs en lote',
+      bulkTooltip: 'Pega una lista de URLs individuales, revisa la lista limpia y ponlas en cola con una calidad compartida.',
       features: {
         heading: 'Qué puede bajar Arroxy',
         youtube: {
@@ -174,6 +202,11 @@ const es = {
         dialog: {
           title: 'URL de YouTube detectada',
           body: '¿Usar este enlace de tu portapapeles?',
+          bulkTitle: 'URLs en lote detectadas',
+          bulkBody: '¿Usar estos enlaces del portapapeles como descarga en lote?',
+          bulkSummary: '{{count}} URLs listas',
+          bulkIgnored: '{{count}} ignoradas',
+          bulkButton: 'Descarga en lote',
           useButton: 'Usar URL',
           disableButton: 'Desactivar',
           cancelButton: 'Cancelar',
@@ -443,12 +476,15 @@ const es = {
       pullIt: '¡Bájalo! ↓',
       pullItTooltip: 'Empieza al instante — corre junto a otras descargas activas',
       labelPlaylist: 'Playlist',
+      labelBulk: 'URLs en lote',
       labelPreset: 'Calidad',
       labelItems: 'Elementos',
       itemsValue_one: '{{count}} de {{total}} vídeo',
       itemsValue_other: '{{count}} de {{total}} vídeos',
       itemsValueAudio_one: '{{count}} de {{total}} pista',
-      itemsValueAudio_other: '{{count}} de {{total}} pistas'
+      itemsValueAudio_other: '{{count}} de {{total}} pistas',
+      itemsValueBulk_one: '{{count}} de {{total}} URL',
+      itemsValueBulk_other: '{{count}} de {{total}} URLs'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/fr.ts
+++ b/src/shared/i18n/locales/fr.ts
@@ -1,6 +1,7 @@
 const fr = {
   common: {
     back: 'Retour',
+    cancel: 'Annuler',
     continue: 'Continuer',
     retry: 'Réessayer',
     startOver: 'Recommencer'
@@ -57,6 +58,8 @@ const fr = {
     },
     actions: {
       chooseExecutable: 'Choisir un exécutable',
+      installWithHomebrew: 'Installer avec Homebrew',
+      installWithWinget: 'Installer avec WinGet',
       resetToDefault: 'Réinitialiser par défaut',
       retrySetup: 'Relancer la configuration',
       cancel: 'Annuler',
@@ -86,10 +89,17 @@ const fr = {
     },
     playlist: {
       heading: 'Éléments de la Playlist',
+      bulkHeading: 'URLs en lot',
       itemCount_one: '{{count}} vidéo',
       itemCount_other: '{{count}} vidéos',
       itemCountAudio_one: '{{count}} piste',
       itemCountAudio_other: '{{count}} pistes',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URLs',
+      bulkMetadataResolving: 'Récupération des détails vidéo… {{done}}/{{total}}',
+      bulkRowWaiting: 'En attente',
+      bulkRowResolving: 'Récupération des détails',
+      bulkRowFailed: 'Détails indisponibles',
       selectAll: 'Tout sélectionner',
       selectNone: 'Tout désélectionner',
       rangeFrom: 'De',
@@ -111,6 +121,22 @@ const fr = {
       alreadyDownloaded: 'Déjà téléchargé',
       probeLimitAlertTitle: 'Le scan de la playlist est limité',
       probeLimitAlertDesc: 'Arroxy a trouvé plus de {{count}} éléments, donc la limite de scan actuelle masque le reste.'
+    },
+    bulk: {
+      title: 'URLs en lot',
+      description: 'Collez des URLs vidéo ou audio individuelles. Arroxy supprimera les doublons et signalera les liens de playlist ou de chaîne avant la mise en file.',
+      textareaLabel: 'Liste d’URLs',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'Prêtes',
+      ignoredCount: 'Ignorées',
+      emptyPreview: 'Collez au moins deux URLs pour prévisualiser le lot.',
+      needsTwo: 'Ajoutez au moins deux URLs prises en charge pour continuer.',
+      confirm: 'Utiliser ces URLs',
+      reject: {
+        duplicate: 'Doublon',
+        playlist: 'Utiliser le flux playlist',
+        channel: 'Utiliser le flux chaîne'
+      }
     },
     playlistPresets: {
       heading: 'Choisir la qualité pour le lot',
@@ -142,6 +168,8 @@ const fr = {
       quickProbeFailed: 'Analyse échouée',
       quickPrepareFailed: 'Impossible de préparer l’élément de file',
       quickFailed: 'Impossible d’ajouter cet élément : {{error}}',
+      bulkButton: 'URLs en lot',
+      bulkTooltip: 'Collez une liste d’URLs individuelles, vérifiez la liste nettoyée, puis ajoutez-les avec un même préréglage qualité.',
       features: {
         heading: "Ce qu'Arroxy peut récupérer",
         youtube: {
@@ -175,6 +203,11 @@ const fr = {
         dialog: {
           title: 'URL YouTube détectée',
           body: 'Utiliser ce lien depuis votre presse-papiers ?',
+          bulkTitle: 'URLs en lot détectées',
+          bulkBody: 'Utiliser ces liens du presse-papiers comme téléchargement en lot ?',
+          bulkSummary: '{{count}} URLs prêtes',
+          bulkIgnored: '{{count}} ignorées',
+          bulkButton: 'Téléchargement en lot',
           useButton: "Utiliser l'URL",
           disableButton: 'Désactiver',
           cancelButton: 'Annuler',
@@ -444,12 +477,15 @@ const fr = {
       pullIt: 'Récupère-le ! ↓',
       pullItTooltip: 'Démarre tout de suite — en parallèle des autres téléchargements actifs',
       labelPlaylist: 'Playlist',
+      labelBulk: 'URLs en lot',
       labelPreset: 'Qualité',
       labelItems: 'Éléments',
       itemsValue_one: '{{count}} sur {{total}} vidéo',
       itemsValue_other: '{{count}} sur {{total}} vidéos',
       itemsValueAudio_one: '{{count}} sur {{total}} piste',
-      itemsValueAudio_other: '{{count}} sur {{total}} pistes'
+      itemsValueAudio_other: '{{count}} sur {{total}} pistes',
+      itemsValueBulk_one: '{{count}} URL sur {{total}}',
+      itemsValueBulk_other: '{{count}} URLs sur {{total}}'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/hi.ts
+++ b/src/shared/i18n/locales/hi.ts
@@ -1,6 +1,7 @@
 const hi = {
   common: {
     back: 'वापस',
+    cancel: 'रद्द करें',
     continue: 'जारी रखें',
     retry: 'फिर से कोशिश करें',
     startOver: 'फिर से शुरू करें'
@@ -57,6 +58,8 @@ const hi = {
     },
     actions: {
       chooseExecutable: 'एक्ज़ीक्यूटेबल चुनें',
+      installWithHomebrew: 'Homebrew से इंस्टॉल करें',
+      installWithWinget: 'WinGet से इंस्टॉल करें',
       resetToDefault: 'डिफ़ॉल्ट पर रीसेट करें',
       retrySetup: 'सेटअप पुनः प्रयास करें',
       cancel: 'रद्द करें',
@@ -86,10 +89,17 @@ const hi = {
     },
     playlist: {
       heading: 'Playlist आइटम',
+      bulkHeading: 'बल्क URLs',
       itemCount_one: '{{count}} वीडियो',
       itemCount_other: '{{count}} वीडियो',
       itemCountAudio_one: '{{count}} ट्रैक',
       itemCountAudio_other: '{{count}} ट्रैक',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URLs',
+      bulkMetadataResolving: 'वीडियो विवरण लाए जा रहे हैं… {{done}}/{{total}}',
+      bulkRowWaiting: 'प्रतीक्षा में',
+      bulkRowResolving: 'विवरण लाए जा रहे हैं',
+      bulkRowFailed: 'विवरण उपलब्ध नहीं',
       selectAll: 'सभी चुनें',
       selectNone: 'कोई नहीं चुनें',
       rangeFrom: 'से',
@@ -111,6 +121,22 @@ const hi = {
       alreadyDownloaded: 'पहले से डाउनलोड किया गया',
       probeLimitAlertTitle: 'प्लेलिस्ट स्कैन सीमित है',
       probeLimitAlertDesc: 'Arroxy को {{count}} से अधिक आइटम मिले, इसलिए वर्तमान स्कैन सीमा बाकी को छुपा रही है।'
+    },
+    bulk: {
+      title: 'बल्क URLs',
+      description: 'अलग-अलग वीडियो या ऑडियो URLs पेस्ट करें। Arroxy कतार में जोड़ने से पहले डुप्लिकेट साफ करेगा और playlist या channel links को चिह्नित करेगा।',
+      textareaLabel: 'URL सूची',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'तैयार',
+      ignoredCount: 'नज़रअंदाज़',
+      emptyPreview: 'बैच देखने के लिए कम से कम दो URLs पेस्ट करें।',
+      needsTwo: 'जारी रखने के लिए कम से कम दो समर्थित URLs जोड़ें।',
+      confirm: 'ये URLs इस्तेमाल करें',
+      reject: {
+        duplicate: 'डुप्लिकेट',
+        playlist: 'playlist flow इस्तेमाल करें',
+        channel: 'channel flow इस्तेमाल करें'
+      }
     },
     playlistPresets: {
       heading: 'बैच के लिए गुणवत्ता चुनें',
@@ -142,6 +168,8 @@ const hi = {
       quickProbeFailed: 'जाँच विफल रही',
       quickPrepareFailed: 'क्यू आइटम तैयार नहीं किया जा सका',
       quickFailed: 'इसे जोड़ा नहीं जा सका: {{error}}',
+      bulkButton: 'बल्क URLs',
+      bulkTooltip: 'अलग URLs की सूची पेस्ट करें, साफ सूची देखें, फिर एक साझा quality preset के साथ कतार में जोड़ें।',
       features: {
         heading: 'Arroxy क्या डाउनलोड कर सकता है',
         youtube: {
@@ -175,6 +203,11 @@ const hi = {
         dialog: {
           title: 'YouTube URL मिला',
           body: 'क्या आप अपने क्लिपबोर्ड का यह लिंक उपयोग करना चाहते हैं?',
+          bulkTitle: 'बल्क URLs मिले',
+          bulkBody: 'clipboard के इन links को bulk download के रूप में इस्तेमाल करें?',
+          bulkSummary: '{{count}} URLs तैयार',
+          bulkIgnored: '{{count}} नज़रअंदाज़',
+          bulkButton: 'बल्क डाउनलोड',
           useButton: 'URL उपयोग करें',
           disableButton: 'बंद करें',
           cancelButton: 'रद्द करें',
@@ -444,12 +477,15 @@ const hi = {
       pullIt: 'खींच लो! ↓',
       pullItTooltip: 'तुरंत शुरू — बाक़ी सक्रिय डाउनलोड के साथ-साथ चलेगा',
       labelPlaylist: 'Playlist',
+      labelBulk: 'बल्क URLs',
       labelPreset: 'प्रीसेट',
       labelItems: 'आइटम',
       itemsValue_one: '{{total}} में से {{count}} वीडियो',
       itemsValue_other: '{{total}} में से {{count}} वीडियो',
       itemsValueAudio_one: '{{total}} में से {{count}} ट्रैक',
-      itemsValueAudio_other: '{{total}} में से {{count}} ट्रैक'
+      itemsValueAudio_other: '{{total}} में से {{count}} ट्रैक',
+      itemsValueBulk_one: '{{total}} URL में से {{count}}',
+      itemsValueBulk_other: '{{total}} URLs में से {{count}}'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/ja.ts
+++ b/src/shared/i18n/locales/ja.ts
@@ -1,6 +1,7 @@
 const ja = {
   common: {
     back: '戻る',
+    cancel: 'キャンセル',
     continue: '続行',
     retry: '再試行',
     startOver: '最初からやり直す'
@@ -57,6 +58,8 @@ const ja = {
     },
     actions: {
       chooseExecutable: '実行ファイルを選択',
+      installWithHomebrew: 'Homebrew でインストール',
+      installWithWinget: 'WinGet でインストール',
       resetToDefault: 'デフォルトにリセット',
       retrySetup: 'セットアップを再試行',
       cancel: 'キャンセル',
@@ -86,10 +89,17 @@ const ja = {
     },
     playlist: {
       heading: 'Playlist アイテム',
+      bulkHeading: '一括 URL',
       itemCount_one: '{{count}} 本の動画',
       itemCount_other: '{{count}} 本の動画',
       itemCountAudio_one: '{{count}} 曲',
       itemCountAudio_other: '{{count}} 曲',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URL',
+      bulkMetadataResolving: '動画の詳細を取得中… {{done}}/{{total}}',
+      bulkRowWaiting: '待機中',
+      bulkRowResolving: '詳細を取得中',
+      bulkRowFailed: '詳細を取得できません',
       selectAll: 'すべて選択',
       selectNone: 'すべて解除',
       rangeFrom: '開始',
@@ -111,6 +121,22 @@ const ja = {
       alreadyDownloaded: 'ダウンロード済み',
       probeLimitAlertTitle: 'プレイリストのスキャンが上限に達しました',
       probeLimitAlertDesc: 'Arroxy は {{count}} 件を超えるアイテムを検出しましたが、現在のスキャン上限により残りは表示されていません。'
+    },
+    bulk: {
+      title: '一括 URL',
+      description: '個別の動画または音声 URL を貼り付けます。Arroxy は重複を整理し、キューに入れる前に playlist や channel のリンクを示します。',
+      textareaLabel: 'URL リスト',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: '準備完了',
+      ignoredCount: '無視',
+      emptyPreview: '一括内容を確認するには、少なくとも 2 件の URL を貼り付けてください。',
+      needsTwo: '続行するには、対応している URL を少なくとも 2 件追加してください。',
+      confirm: 'これらの URL を使う',
+      reject: {
+        duplicate: '重複',
+        playlist: 'playlist フローを使う',
+        channel: 'channel フローを使う'
+      }
     },
     playlistPresets: {
       heading: 'バッチの画質を選択',
@@ -142,6 +168,8 @@ const ja = {
       quickProbeFailed: '解析に失敗しました',
       quickPrepareFailed: 'キュー項目を準備できませんでした',
       quickFailed: '追加できませんでした: {{error}}',
+      bulkButton: '一括 URL',
+      bulkTooltip: '個別 URL のリストを貼り付け、整理後の一覧を確認してから、共通の品質プリセットでキューに追加します。',
       features: {
         heading: 'Arroxyで取得できるもの',
         youtube: {
@@ -175,6 +203,11 @@ const ja = {
         dialog: {
           title: 'YouTubeのURLを検出',
           body: 'クリップボードのこのリンクを使いますか?',
+          bulkTitle: '一括 URL を検出しました',
+          bulkBody: 'クリップボードのこれらのリンクを一括ダウンロードとして使いますか？',
+          bulkSummary: '{{count}} URL が準備完了',
+          bulkIgnored: '{{count}} 件を無視',
+          bulkButton: '一括ダウンロード',
           useButton: 'URLを使う',
           disableButton: '無効化',
           cancelButton: 'キャンセル',
@@ -444,12 +477,15 @@ const ja = {
       pullIt: '取得! ↓',
       pullItTooltip: 'すぐ開始 — 他のアクティブなダウンロードと並行実行',
       labelPlaylist: 'Playlist',
+      labelBulk: '一括 URL',
       labelPreset: 'プリセット',
       labelItems: '件数',
       itemsValue_one: '全{{total}}本中{{count}}本',
       itemsValue_other: '全{{total}}本中{{count}}本',
       itemsValueAudio_one: '全{{total}}曲中{{count}}曲',
-      itemsValueAudio_other: '全{{total}}曲中{{count}}曲'
+      itemsValueAudio_other: '全{{total}}曲中{{count}}曲',
+      itemsValueBulk_one: '{{count}} / {{total}} URL',
+      itemsValueBulk_other: '{{count}} / {{total}} URL'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/my.ts
+++ b/src/shared/i18n/locales/my.ts
@@ -1,6 +1,7 @@
 const my = {
   common: {
     back: 'နောက်သို့',
+    cancel: 'ပယ်ဖျက်မည်',
     continue: 'ဆက်လက်သွားမည်',
     retry: 'ထပ်မံကြိုးစားမည်',
     startOver: 'အစကနေပြန်စမည်'
@@ -57,6 +58,8 @@ const my = {
     },
     actions: {
       chooseExecutable: 'Executable ရွေးမည်',
+      installWithHomebrew: 'Homebrew ဖြင့် ထည့်သွင်းမည်',
+      installWithWinget: 'WinGet ဖြင့် ထည့်သွင်းမည်',
       resetToDefault: 'မူလသို့ပြန်ထားမည်',
       retrySetup: 'Setup ထပ်ကြိုးစားမည်',
       cancel: 'ပယ်ဖျက်မည်',
@@ -86,10 +89,17 @@ const my = {
     },
     playlist: {
       heading: 'Playlist အကြောင်းအရာများ',
+      bulkHeading: 'URL အများအပြား',
       itemCount_one: '{{count}} ဗီဒီယို',
       itemCount_other: '{{count}} ဗီဒီယိုများ',
       itemCountAudio_one: '{{count}} ခု သီချင်း',
       itemCountAudio_other: '{{count}} ခု သီချင်းများ',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URL',
+      bulkMetadataResolving: 'ဗီဒီယိုအသေးစိတ် ရယူနေသည်… {{done}}/{{total}}',
+      bulkRowWaiting: 'စောင့်နေသည်',
+      bulkRowResolving: 'အသေးစိတ် ရယူနေသည်',
+      bulkRowFailed: 'အသေးစိတ် မရနိုင်ပါ',
       selectAll: 'အားလုံးရွေးမည်',
       selectNone: 'အားလုံးဖြုတ်မည်',
       rangeFrom: 'မှ',
@@ -111,6 +121,22 @@ const my = {
       alreadyDownloaded: 'ဒေါင်းလုဒ်ပြီးသား',
       probeLimitAlertTitle: 'Playlist scan ကန့်သတ်ထားသည်',
       probeLimitAlertDesc: 'Arroxy သည် {{count}} ထက်ပိုသော အကြောင်းအရာများ တွေ့ရှိသောကြောင့် လက်ရှိ scan ကန့်သတ်ချက်ကြောင့် ကျန်သောအရာများ ဖျောက်ထားသည်။'
+    },
+    bulk: {
+      title: 'URL အများအပြား',
+      description: 'တစ်ခုချင်းစီသော video သို့မဟုတ် audio URL များကို paste လုပ်ပါ။ Arroxy သည် ထပ်နေသောအရာများကို ဖယ်ရှားပြီး queue မထည့်မီ playlist သို့မဟုတ် channel link များကို ဖော်ပြပါမည်။',
+      textareaLabel: 'URL စာရင်း',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'အဆင်သင့်',
+      ignoredCount: 'လျစ်လျူရှုထားသည်',
+      emptyPreview: 'batch ကိုကြည့်ရန် URL အနည်းဆုံးနှစ်ခု paste လုပ်ပါ။',
+      needsTwo: 'ဆက်လက်လုပ်ဆောင်ရန် supported URL အနည်းဆုံးနှစ်ခု ထည့်ပါ။',
+      confirm: 'ဤ URL များကိုသုံးမည်',
+      reject: {
+        duplicate: 'ထပ်နေသည်',
+        playlist: 'playlist flow သုံးမည်',
+        channel: 'channel flow သုံးမည်'
+      }
     },
     playlistPresets: {
       heading: 'Batch အတွက် အရည်အသွေးရွေးပါ',
@@ -142,6 +168,8 @@ const my = {
       quickProbeFailed: 'စစ်ဆေးမှု မအောင်မြင်ပါ',
       quickPrepareFailed: 'တန်းစီအရာကို မပြင်ဆင်နိုင်ပါ',
       quickFailed: 'ဤအရာကို ထည့်မရပါ: {{error}}',
+      bulkButton: 'URL အများအပြား',
+      bulkTooltip: 'URL တစ်ခုချင်းစီစာရင်းကို paste လုပ်ပါ၊ ရှင်းလင်းပြီးစာရင်းကိုကြည့်ပါ၊ ထို့နောက် quality preset တစ်ခုတည်းဖြင့် queue ထဲထည့်ပါ။',
       features: {
         heading: 'Arroxy ဆွဲထုတ်နိုင်သည်',
         youtube: {
@@ -175,6 +203,11 @@ const my = {
         dialog: {
           title: 'YouTube URL တွေ့ပြီ',
           body: 'ကလစ်ဘုတ်မှ ဤလင့်ခ်ကို အသုံးပြုမည်လား?',
+          bulkTitle: 'URL အများအပြား တွေ့ရှိသည်',
+          bulkBody: 'clipboard ထဲရှိ link များကို bulk download အဖြစ်သုံးမလား?',
+          bulkSummary: '{{count}} URL အဆင်သင့်',
+          bulkIgnored: '{{count}} လျစ်လျူရှုထားသည်',
+          bulkButton: 'Bulk download',
           useButton: 'URL အသုံးပြုမည်',
           disableButton: 'ပိတ်မည်',
           cancelButton: 'မလုပ်တော့ပါ',
@@ -444,12 +477,15 @@ const my = {
       pullIt: 'ဆွဲထုတ်မည်! ↓',
       pullItTooltip: 'ချက်ချင်းစတင်မည် — အခြားဒေါင်းလုဒ်များနှင့်အတူ အပြိုင်လုပ်မည်',
       labelPlaylist: 'Playlist',
+      labelBulk: 'URL အများအပြား',
       labelPreset: 'Preset',
       labelItems: 'အကြောင်းအရာ',
       itemsValue_one: '{{total}} ခုမှ {{count}} ဗီဒီယို',
       itemsValue_other: '{{total}} ခုမှ {{count}} ဗီဒီယိုများ',
       itemsValueAudio_one: '{{total}} ခုမှ {{count}} သီချင်း',
-      itemsValueAudio_other: '{{total}} ခုမှ {{count}} သီချင်းများ'
+      itemsValueAudio_other: '{{total}} ခုမှ {{count}} သီချင်းများ',
+      itemsValueBulk_one: '{{total}} URL မှ {{count}}',
+      itemsValueBulk_other: '{{total}} URL မှ {{count}}'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/om.ts
+++ b/src/shared/i18n/locales/om.ts
@@ -1,6 +1,7 @@
 const om = {
   common: {
     back: 'Duubatti',
+    cancel: 'Haqi',
     continue: 'Itti fufi',
     retry: "Irra deebi'i",
     startOver: "Jalqabbii irra deebi'i"
@@ -57,6 +58,8 @@ const om = {
     },
     actions: {
       chooseExecutable: 'Faayilii hojjetu filadhu',
+      installWithHomebrew: 'Homebrew dhaan fe’i',
+      installWithWinget: 'WinGet dhaan fe’i',
       resetToDefault: "Durtii irra deebi'i",
       retrySetup: "Qindaa'inaa irra deebi'i yaali",
       cancel: 'Haqdhaabi',
@@ -86,10 +89,17 @@ const om = {
     },
     playlist: {
       heading: 'Wantoota Playlist',
+      bulkHeading: 'URL hedduu',
       itemCount_one: '{{count}} viidiyoo',
       itemCount_other: '{{count}} viidiyoowwan',
       itemCountAudio_one: '{{count}} weellaa',
       itemCountAudio_other: '{{count}} weellaalee',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URL',
+      bulkMetadataResolving: 'Ibsa viidiyoo fidaa… {{done}}/{{total}}',
+      bulkRowWaiting: 'Eegaa jira',
+      bulkRowResolving: 'Ibsa fidaa jira',
+      bulkRowFailed: 'Ibsi hin argamne',
       selectAll: 'Hunda filadhu',
       selectNone: 'Tokkollee hin filin',
       rangeFrom: 'Irraa',
@@ -111,6 +121,22 @@ const om = {
       alreadyDownloaded: 'Duraan buufameera',
       probeLimitAlertTitle: 'Qorannaan playlist daangeffameera',
       probeLimitAlertDesc: 'Arroxy wantoota {{count}} ol argateera, kanaafuu daangaan qorannaa ammaa kan hafan dhoksaa jira.'
+    },
+    bulk: {
+      title: 'URL hedduu',
+      description: 'URL viidiyoo ykn sagalee kophaa as maxxansi. Arroxy irra-deebii ni qulqulleessa, hidhannoowwan playlist ykn channel immoo ni agarsiisa.',
+      textareaLabel: 'Tarree URL',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'Qophaa’e',
+      ignoredCount: 'Tuffatame',
+      emptyPreview: 'Garee ilaaluu dura URL yoo xiqqaate lama maxxansi.',
+      needsTwo: 'Itti fufuuf URL deeggaraman yoo xiqqaate lama dabali.',
+      confirm: 'URL kana fayyadami',
+      reject: {
+        duplicate: 'Irra-deebi',
+        playlist: 'Adeemsa playlist fayyadami',
+        channel: 'Adeemsa channel fayyadami'
+      }
     },
     playlistPresets: {
       heading: 'Kutaa gurmuu barbaadi',
@@ -141,6 +167,8 @@ const om = {
       quickProbeFailed: 'Sakatta’iinsi hin milkoofne',
       quickPrepareFailed: 'Wantoota tarree qopheessuu hin dandeenye',
       quickFailed: 'Kana dabaluun hin danda’amne: {{error}}',
+      bulkButton: 'URL hedduu',
+      bulkTooltip: 'Tarree URL kophaa maxxansi, tarree qulqullaa’e ilaali, sana booda filannoo qulqullina waliinii queue keessa galchi.',
       features: {
         heading: "Arroxy maal buufachuu danda'a",
         youtube: {
@@ -174,6 +202,11 @@ const om = {
         dialog: {
           title: 'YouTube URL argame',
           body: 'Liinkii kana kliipboordii kee irraa fayyadamduu?',
+          bulkTitle: 'URL hedduun argaman',
+          bulkBody: 'Hidhannoowwan clipboard kana buufannaa hedduuf fayyadamuu?',
+          bulkSummary: '{{count}} URL qophaa’e',
+          bulkIgnored: '{{count}} tuffatame',
+          bulkButton: 'Hedduu buusi',
           useButton: 'URL fayyadami',
           disableButton: 'Dhaabbi',
           cancelButton: 'Haqi',
@@ -443,12 +476,15 @@ const om = {
       pullIt: 'Buusi! ↓',
       pullItTooltip: 'Immediately jalqaba — daawniloodoonni biroo waliin hojjeta',
       labelPlaylist: 'Playlist',
+      labelBulk: 'URL hedduu',
       labelPreset: 'Preset',
       labelItems: 'Wantota',
       itemsValue_one: '{{count}} fi {{total}} keessaa viidiyoo',
       itemsValue_other: '{{count}} fi {{total}} keessaa viidiyoowwan',
       itemsValueAudio_one: '{{count}} fi {{total}} keessaa weellaa',
-      itemsValueAudio_other: '{{count}} fi {{total}} keessaa weellaalee'
+      itemsValueAudio_other: '{{count}} fi {{total}} keessaa weellaalee',
+      itemsValueBulk_one: '{{count}} URL keessaa {{total}}',
+      itemsValueBulk_other: '{{count}} URL keessaa {{total}}'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/ps.ts
+++ b/src/shared/i18n/locales/ps.ts
@@ -1,6 +1,7 @@
 const ps = {
   common: {
     back: 'شاته',
+    cancel: 'لغوه کړئ',
     continue: 'دوام ورکړه',
     retry: 'بیا هڅه وکړه',
     startOver: 'له سره پیل کړه'
@@ -57,6 +58,8 @@ const ps = {
     },
     actions: {
       chooseExecutable: 'د اجرا وړ فایل غوره کړئ',
+      installWithHomebrew: 'په Homebrew نصب کړئ',
+      installWithWinget: 'په WinGet نصب کړئ',
       resetToDefault: 'ډیفالټ ته بیرته شئ',
       retrySetup: 'نصب بیا وکړئ',
       cancel: 'لغوه کړئ',
@@ -86,10 +89,17 @@ const ps = {
     },
     playlist: {
       heading: 'د Playlist توکي',
+      bulkHeading: 'ډېر URLونه',
       itemCount_one: '{{count}} ویډیو',
       itemCount_other: '{{count}} ویډیوګانې',
       itemCountAudio_one: '{{count}} ټریک',
       itemCountAudio_other: '{{count}} ټریکونه',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URLونه',
+      bulkMetadataResolving: 'د ویډیو جزییات راوړل کېږي… {{done}}/{{total}}',
+      bulkRowWaiting: 'انتظار',
+      bulkRowResolving: 'جزییات راوړل کېږي',
+      bulkRowFailed: 'جزییات نشته',
       selectAll: 'ټول غوره کړئ',
       selectNone: 'هیڅ غوره مه کوئ',
       rangeFrom: 'له',
@@ -111,6 +121,22 @@ const ps = {
       alreadyDownloaded: 'مخکې ډاونلوډ شوی',
       probeLimitAlertTitle: 'د Playlist سکین محدود دی',
       probeLimitAlertDesc: 'Arroxy له {{count}} څخه زیات توکي وموندل، نو اوسنی سکین حد پاتې توکي پټوي.'
+    },
+    bulk: {
+      title: 'ډېر URLونه',
+      description: 'د ویډیو یا غږ جلا URLونه ونښلوئ. Arroxy به تکراري پاک کړي او د playlist یا channel لینکونه به د کتار مخکې وښيي.',
+      textareaLabel: 'د URL لست',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'چمتو',
+      ignoredCount: 'له پامه غورځول شوي',
+      emptyPreview: 'د ډلې د کتلو لپاره لږ تر لږه دوه URLونه ونښلوئ.',
+      needsTwo: 'د دوام لپاره لږ تر لږه دوه ملاتړ شوي URLونه زیات کړئ.',
+      confirm: 'دا URLونه وکاروئ',
+      reject: {
+        duplicate: 'تکراري',
+        playlist: 'د playlist لاره وکاروئ',
+        channel: 'د channel لاره وکاروئ'
+      }
     },
     playlistPresets: {
       heading: 'د بیچ لپاره کیفیت وټاکئ',
@@ -142,6 +168,8 @@ const ps = {
       quickProbeFailed: 'کتنه ناکامه شوه',
       quickPrepareFailed: 'د قطار توکی چمتو نه شو',
       quickFailed: 'دا ونه زیاتېدل: {{error}}',
+      bulkButton: 'ډېر URLونه',
+      bulkTooltip: 'د جلا URLونو لست ونښلوئ، پاک شوی لست وګورئ، بیا یې په ګډ quality preset سره کتار ته واچوئ.',
       features: {
         heading: 'Arroxy څه ډاونلوډ کولی شي',
         youtube: {
@@ -175,6 +203,11 @@ const ps = {
         dialog: {
           title: 'YouTube URL وموندل شو',
           body: 'ایا د کلیپبورډ دا لینک وکاروئ؟',
+          bulkTitle: 'ډېر URLونه وموندل شول',
+          bulkBody: 'د clipboard دا لینکونه د bulk download په توګه وکارول شي؟',
+          bulkSummary: '{{count}} URLونه چمتو',
+          bulkIgnored: '{{count}} له پامه غورځول شوي',
+          bulkButton: 'ډله‌ییز ډاونلوډ',
           useButton: 'URL وکاروئ',
           disableButton: 'غیر فعاله کړه',
           cancelButton: 'لغوه کړه',
@@ -444,12 +477,15 @@ const ps = {
       pullIt: 'راکش یې کړه! ↓',
       pullItTooltip: 'سمدلاسه پیل کیږي — د نورو فعالو ډاونلوډونو سره یوځای چلیږي',
       labelPlaylist: 'Playlist',
+      labelBulk: 'ډېر URLونه',
       labelPreset: 'Preset',
       labelItems: 'توکي',
       itemsValue_one: '{{count}} له {{total}} ویډیو',
       itemsValue_other: '{{count}} له {{total}} ویډیوګانې',
       itemsValueAudio_one: '{{count}} له {{total}} ټریک',
-      itemsValueAudio_other: '{{count}} له {{total}} ټریکونه'
+      itemsValueAudio_other: '{{count}} له {{total}} ټریکونه',
+      itemsValueBulk_one: '{{count}} له {{total}} URL',
+      itemsValueBulk_other: '{{count}} له {{total}} URLونو'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/ru.ts
+++ b/src/shared/i18n/locales/ru.ts
@@ -1,6 +1,7 @@
 const ru = {
   common: {
     back: 'Назад',
+    cancel: 'Отменить',
     continue: 'Продолжить',
     retry: 'Повторить',
     startOver: 'Начать заново'
@@ -57,6 +58,8 @@ const ru = {
     },
     actions: {
       chooseExecutable: 'Выбрать исполняемый файл',
+      installWithHomebrew: 'Установить через Homebrew',
+      installWithWinget: 'Установить через WinGet',
       resetToDefault: 'Сбросить по умолчанию',
       retrySetup: 'Повторить настройку',
       cancel: 'Отменить',
@@ -86,10 +89,17 @@ const ru = {
     },
     playlist: {
       heading: 'Элементы Playlist',
+      bulkHeading: 'Массовые URL',
       itemCount_one: '{{count}} видео',
       itemCount_other: '{{count}} видео',
       itemCountAudio_one: '{{count}} трек',
       itemCountAudio_other: '{{count}} треков',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URL',
+      bulkMetadataResolving: 'Получение сведений о видео… {{done}}/{{total}}',
+      bulkRowWaiting: 'Ожидание',
+      bulkRowResolving: 'Получение сведений',
+      bulkRowFailed: 'Сведения недоступны',
       selectAll: 'Выбрать все',
       selectNone: 'Снять выбор',
       rangeFrom: 'С',
@@ -111,6 +121,22 @@ const ru = {
       alreadyDownloaded: 'Уже скачано',
       probeLimitAlertTitle: 'Сканирование плейлиста ограничено',
       probeLimitAlertDesc: 'Arroxy нашёл более {{count}} элементов, поэтому текущий лимит сканирования скрывает остальные.'
+    },
+    bulk: {
+      title: 'Массовые URL',
+      description: 'Вставьте отдельные URL видео или аудио. Arroxy удалит дубликаты и отметит ссылки на плейлисты или каналы перед добавлением в очередь.',
+      textareaLabel: 'Список URL',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'Готово',
+      ignoredCount: 'Пропущено',
+      emptyPreview: 'Вставьте хотя бы два URL, чтобы просмотреть пакет.',
+      needsTwo: 'Добавьте хотя бы два поддерживаемых URL, чтобы продолжить.',
+      confirm: 'Использовать эти URL',
+      reject: {
+        duplicate: 'Дубликат',
+        playlist: 'Использовать сценарий плейлиста',
+        channel: 'Использовать сценарий канала'
+      }
     },
     playlistPresets: {
       heading: 'Выбери качество для пакетной загрузки',
@@ -142,6 +168,8 @@ const ru = {
       quickProbeFailed: 'Проверка не удалась',
       quickPrepareFailed: 'Не удалось подготовить элемент очереди',
       quickFailed: 'Не удалось добавить: {{error}}',
+      bulkButton: 'Массовые URL',
+      bulkTooltip: 'Вставьте список отдельных URL, проверьте очищенный список и добавьте их в очередь с общим пресетом качества.',
       features: {
         heading: 'Что умеет скачивать Arroxy',
         youtube: {
@@ -175,6 +203,11 @@ const ru = {
         dialog: {
           title: 'Найдена ссылка YouTube',
           body: 'Использовать эту ссылку из буфера обмена?',
+          bulkTitle: 'Обнаружены массовые URL',
+          bulkBody: 'Использовать эти ссылки из буфера как массовую загрузку?',
+          bulkSummary: '{{count}} URL готовы',
+          bulkIgnored: '{{count}} пропущено',
+          bulkButton: 'Массовая загрузка',
           useButton: 'Использовать URL',
           disableButton: 'Отключить',
           cancelButton: 'Отмена',
@@ -444,12 +477,15 @@ const ru = {
       pullIt: 'Качаем! ↓',
       pullItTooltip: 'Запускается сразу — параллельно с другими активными загрузками',
       labelPlaylist: 'Плейлист',
+      labelBulk: 'Массовые URL',
       labelPreset: 'Пресет',
       labelItems: 'Видео',
       itemsValue_one: '{{count}} из {{total}} видео',
       itemsValue_other: '{{count}} из {{total}} видео',
       itemsValueAudio_one: '{{count}} из {{total}} трека',
-      itemsValueAudio_other: '{{count}} из {{total}} треков'
+      itemsValueAudio_other: '{{count}} из {{total}} треков',
+      itemsValueBulk_one: '{{count}} из {{total}} URL',
+      itemsValueBulk_other: '{{count}} из {{total}} URL'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/sr.ts
+++ b/src/shared/i18n/locales/sr.ts
@@ -1,6 +1,7 @@
 const sr = {
   common: {
     back: 'Назад',
+    cancel: 'Откажи',
     continue: 'Настави',
     retry: 'Покушај поново',
     startOver: 'Почни испочетка'
@@ -57,6 +58,8 @@ const sr = {
     },
     actions: {
       chooseExecutable: 'Изабери извршну датотеку',
+      installWithHomebrew: 'Инсталирај преко Homebrew-а',
+      installWithWinget: 'Инсталирај преко WinGet-а',
       resetToDefault: 'Врати на подразумевано',
       retrySetup: 'Покушај подешавање поново',
       cancel: 'Откажи',
@@ -86,10 +89,17 @@ const sr = {
     },
     playlist: {
       heading: 'Ставке плејлисте',
+      bulkHeading: 'Групни URL-ови',
       itemCount_one: '{{count}} видео',
       itemCount_other: '{{count}} видеа',
       itemCountAudio_one: '{{count}} нумера',
       itemCountAudio_other: '{{count}} нумера',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URL-ова',
+      bulkMetadataResolving: 'Преузимање детаља видеа… {{done}}/{{total}}',
+      bulkRowWaiting: 'Чека',
+      bulkRowResolving: 'Преузимање детаља',
+      bulkRowFailed: 'Детаљи нису доступни',
       selectAll: 'Изабери све',
       selectNone: 'Поништи избор',
       rangeFrom: 'Од',
@@ -111,6 +121,22 @@ const sr = {
       alreadyDownloaded: 'Већ преузето',
       probeLimitAlertTitle: 'Скенирање плејлисте је ограничено',
       probeLimitAlertDesc: 'Arroxy је пронашао више од {{count}} ставки, па тренутно ограничење скенирања скрива остатак.'
+    },
+    bulk: {
+      title: 'Групни URL-ови',
+      description: 'Налепи појединачне видео или аудио URL-ове. Arroxy ће очистити дупликате и означити playlist или channel линкове пре додавања у ред.',
+      textareaLabel: 'Листа URL-ова',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'Спремно',
+      ignoredCount: 'Занемарено',
+      emptyPreview: 'Налепи најмање два URL-а за преглед групе.',
+      needsTwo: 'Додај најмање два подржана URL-а за наставак.',
+      confirm: 'Користи ове URL-ове',
+      reject: {
+        duplicate: 'Дупликат',
+        playlist: 'Користи playlist ток',
+        channel: 'Користи channel ток'
+      }
     },
     playlistPresets: {
       heading: 'Изабери квалитет за групно преузимање',
@@ -142,6 +168,8 @@ const sr = {
       quickProbeFailed: 'Provera nije uspela',
       quickPrepareFailed: 'Stavka reda nije mogla da se pripremi',
       quickFailed: 'Nije moguće dodati: {{error}}',
+      bulkButton: 'Групни URL-ови',
+      bulkTooltip: 'Налепи листу појединачних URL-ова, прегледај очишћену листу, па их додај у ред са заједничким quality preset-ом.',
       features: {
         heading: 'Шта Arroxy може да преузме',
         youtube: {
@@ -175,6 +203,11 @@ const sr = {
         dialog: {
           title: 'Откривен YouTube URL',
           body: 'Да ли да користиш овај линк из клипборда?',
+          bulkTitle: 'Откривени су групни URL-ови',
+          bulkBody: 'Користити ове линкове из clipboard-а као групно преузимање?',
+          bulkSummary: '{{count}} URL-ова спремно',
+          bulkIgnored: '{{count}} занемарено',
+          bulkButton: 'Групно преузимање',
           useButton: 'Користи URL',
           disableButton: 'Онемогући',
           cancelButton: 'Откажи',
@@ -444,12 +477,15 @@ const sr = {
       pullIt: 'Преузми! ↓',
       pullItTooltip: 'Покреће се одмах — ради упоредо са другим активним преузимањима',
       labelPlaylist: 'Плејлиста',
+      labelBulk: 'Групни URL-ови',
       labelPreset: 'Поставка',
       labelItems: 'Ставке',
       itemsValue_one: '{{count}} од {{total}} видеа',
       itemsValue_other: '{{count}} од {{total}} видеа',
       itemsValueAudio_one: '{{count}} од {{total}} нумере',
-      itemsValueAudio_other: '{{count}} од {{total}} нумера'
+      itemsValueAudio_other: '{{count}} од {{total}} нумера',
+      itemsValueBulk_one: '{{count}} од {{total}} URL-а',
+      itemsValueBulk_other: '{{count}} од {{total}} URL-ова'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/sw.ts
+++ b/src/shared/i18n/locales/sw.ts
@@ -1,6 +1,7 @@
 const sw = {
   common: {
     back: 'Rudi',
+    cancel: 'Ghairi',
     continue: 'Endelea',
     retry: 'Jaribu tena',
     startOver: 'Anza upya'
@@ -57,6 +58,8 @@ const sw = {
     },
     actions: {
       chooseExecutable: 'Chagua faili inayotekelezwa',
+      installWithHomebrew: 'Sakinisha kwa Homebrew',
+      installWithWinget: 'Sakinisha kwa WinGet',
       resetToDefault: 'Rejesha chaguo-msingi',
       retrySetup: 'Jaribu usanidi tena',
       cancel: 'Ghairi',
@@ -86,10 +89,17 @@ const sw = {
     },
     playlist: {
       heading: 'Vipande vya Playlist',
+      bulkHeading: 'URL nyingi',
       itemCount_one: '{{count}} video',
       itemCount_other: '{{count}} video',
       itemCountAudio_one: '{{count}} wimbo',
       itemCountAudio_other: '{{count}} nyimbo',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URL',
+      bulkMetadataResolving: 'Inaleta maelezo ya video… {{done}}/{{total}}',
+      bulkRowWaiting: 'Inasubiri',
+      bulkRowResolving: 'Inaleta maelezo',
+      bulkRowFailed: 'Maelezo hayapatikani',
       selectAll: 'Chagua yote',
       selectNone: 'Futa uchaguzi wote',
       rangeFrom: 'Kutoka',
@@ -111,6 +121,22 @@ const sw = {
       alreadyDownloaded: 'Tayari imepakuliwa',
       probeLimitAlertTitle: 'Skani ya playlist imefungwa',
       probeLimitAlertDesc: 'Arroxy imepata zaidi ya vipande {{count}}, kwa hivyo kikomo cha skani cha sasa kinaficha vilivyobaki.'
+    },
+    bulk: {
+      title: 'URL nyingi',
+      description: 'Bandika URL binafsi za video au sauti. Arroxy itaondoa zilizorudiwa na kuonyesha viungo vya playlist au channel kabla ya kupanga foleni.',
+      textareaLabel: 'Orodha ya URL',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'Tayari',
+      ignoredCount: 'Zimepuuzwa',
+      emptyPreview: 'Bandika angalau URL mbili ili kuona kundi.',
+      needsTwo: 'Ongeza angalau URL mbili zinazotumika ili kuendelea.',
+      confirm: 'Tumia URL hizi',
+      reject: {
+        duplicate: 'Imerudiwa',
+        playlist: 'Tumia mtiririko wa playlist',
+        channel: 'Tumia mtiririko wa channel'
+      }
     },
     playlistPresets: {
       heading: 'Chagua ubora wa kundi',
@@ -141,6 +167,8 @@ const sw = {
       quickProbeFailed: 'Uchunguzi umeshindikana',
       quickPrepareFailed: 'Kipengee cha foleni hakikuweza kuandaliwa',
       quickFailed: 'Haikuweza kuongeza hii: {{error}}',
+      bulkButton: 'URL nyingi',
+      bulkTooltip: 'Bandika orodha ya URL binafsi, hakiki orodha iliyosafishwa, kisha ziweke foleni kwa preset moja ya ubora.',
       features: {
         heading: 'Arroxy inaweza kupakua nini',
         youtube: {
@@ -174,6 +202,11 @@ const sw = {
         dialog: {
           title: 'YouTube URL imegunduliwa',
           body: 'Tumia kiungo hiki kutoka kwenye ubao wako wa kunakili?',
+          bulkTitle: 'URL nyingi zimegunduliwa',
+          bulkBody: 'Utumie viungo hivi vya clipboard kama upakuaji wa kundi?',
+          bulkSummary: '{{count}} URL tayari',
+          bulkIgnored: '{{count}} zimepuuzwa',
+          bulkButton: 'Pakua kundi',
           useButton: 'Tumia URL',
           disableButton: 'Zima',
           cancelButton: 'Ghairi',
@@ -443,12 +476,15 @@ const sw = {
       pullIt: 'Pakua sasa! ↓',
       pullItTooltip: 'Inaanza mara moja — inafanya kazi pamoja na vipakuzi vingine vinavyofanya kazi',
       labelPlaylist: 'Playlist',
+      labelBulk: 'URL nyingi',
       labelPreset: 'Mpangilio',
       labelItems: 'Vipande',
       itemsValue_one: '{{count}} kati ya {{total}} video',
       itemsValue_other: '{{count}} kati ya {{total}} video',
       itemsValueAudio_one: '{{count}} kati ya {{total}} wimbo',
-      itemsValueAudio_other: '{{count}} kati ya {{total}} nyimbo'
+      itemsValueAudio_other: '{{count}} kati ya {{total}} nyimbo',
+      itemsValueBulk_one: '{{count}} kati ya {{total}} URL',
+      itemsValueBulk_other: '{{count}} kati ya {{total}} URL'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/uk.ts
+++ b/src/shared/i18n/locales/uk.ts
@@ -1,6 +1,7 @@
 const uk = {
   common: {
     back: 'Назад',
+    cancel: 'Скасувати',
     continue: 'Продовжити',
     retry: 'Повторити',
     startOver: 'Почати спочатку'
@@ -57,6 +58,8 @@ const uk = {
     },
     actions: {
       chooseExecutable: 'Вибрати виконуваний файл',
+      installWithHomebrew: 'Установити через Homebrew',
+      installWithWinget: 'Установити через WinGet',
       resetToDefault: 'Скинути до стандартного',
       retrySetup: 'Повторити налаштування',
       cancel: 'Скасувати',
@@ -86,10 +89,17 @@ const uk = {
     },
     playlist: {
       heading: 'Елементи Playlist',
+      bulkHeading: 'Масові URL',
       itemCount_one: '{{count}} відео',
       itemCount_other: '{{count}} відео',
       itemCountAudio_one: '{{count}} трек',
       itemCountAudio_other: '{{count}} треків',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URL',
+      bulkMetadataResolving: 'Отримання відомостей про відео… {{done}}/{{total}}',
+      bulkRowWaiting: 'Очікування',
+      bulkRowResolving: 'Отримання відомостей',
+      bulkRowFailed: 'Відомості недоступні',
       selectAll: 'Вибрати всі',
       selectNone: 'Зняти вибір',
       rangeFrom: 'Від',
@@ -111,6 +121,22 @@ const uk = {
       alreadyDownloaded: 'Уже завантажено',
       probeLimitAlertTitle: 'Сканування плейлиста обмежено',
       probeLimitAlertDesc: 'Arroxy знайшов більше {{count}} елементів, тому поточний ліміт сканування приховує решту.'
+    },
+    bulk: {
+      title: 'Масові URL',
+      description: 'Вставте окремі URL відео або аудіо. Arroxy прибере дублікати й позначить посилання на плейлисти або канали перед додаванням у чергу.',
+      textareaLabel: 'Список URL',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'Готово',
+      ignoredCount: 'Пропущено',
+      emptyPreview: 'Вставте щонайменше два URL, щоб переглянути пакет.',
+      needsTwo: 'Додайте щонайменше два підтримувані URL, щоб продовжити.',
+      confirm: 'Використати ці URL',
+      reject: {
+        duplicate: 'Дублікат',
+        playlist: 'Використати сценарій плейлиста',
+        channel: 'Використати сценарій каналу'
+      }
     },
     playlistPresets: {
       heading: 'Вибери якість для пакетного завантаження',
@@ -142,6 +168,8 @@ const uk = {
       quickProbeFailed: 'Перевірка не вдалася',
       quickPrepareFailed: 'Не вдалося підготувати елемент черги',
       quickFailed: 'Не вдалося додати: {{error}}',
+      bulkButton: 'Масові URL',
+      bulkTooltip: 'Вставте список окремих URL, перегляньте очищений список і додайте їх у чергу зі спільним пресетом якості.',
       features: {
         heading: 'Що Arroxy вміє завантажувати',
         youtube: {
@@ -175,6 +203,11 @@ const uk = {
         dialog: {
           title: 'Знайдено посилання YouTube',
           body: 'Використати це посилання з буфера обміну?',
+          bulkTitle: 'Виявлено масові URL',
+          bulkBody: 'Використати ці посилання з буфера як масове завантаження?',
+          bulkSummary: '{{count}} URL готові',
+          bulkIgnored: '{{count}} пропущено',
+          bulkButton: 'Масове завантаження',
           useButton: 'Використати URL',
           disableButton: 'Вимкнути',
           cancelButton: 'Скасувати',
@@ -444,12 +477,15 @@ const uk = {
       pullIt: 'Качаємо! ↓',
       pullItTooltip: 'Запускається миттєво — паралельно з іншими активними завантаженнями',
       labelPlaylist: 'Плейлист',
+      labelBulk: 'Масові URL',
       labelPreset: 'Пресет',
       labelItems: 'Елементи',
       itemsValue_one: '{{count}} з {{total}} відео',
       itemsValue_other: '{{count}} з {{total}} відео',
       itemsValueAudio_one: '{{count}} з {{total}} треку',
-      itemsValueAudio_other: '{{count}} з {{total}} треків'
+      itemsValueAudio_other: '{{count}} з {{total}} треків',
+      itemsValueBulk_one: '{{count}} з {{total}} URL',
+      itemsValueBulk_other: '{{count}} з {{total}} URL'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/ur.ts
+++ b/src/shared/i18n/locales/ur.ts
@@ -1,6 +1,7 @@
 const ur = {
   common: {
     back: 'واپس',
+    cancel: 'منسوخ کریں',
     continue: 'جاری رکھیں',
     retry: 'دوبارہ کوشش کریں',
     startOver: 'دوبارہ شروع کریں'
@@ -57,6 +58,8 @@ const ur = {
     },
     actions: {
       chooseExecutable: 'فائل منتخب کریں',
+      installWithHomebrew: 'Homebrew سے انسٹال کریں',
+      installWithWinget: 'WinGet سے انسٹال کریں',
       resetToDefault: 'ڈیفالٹ پر واپس جائیں',
       retrySetup: 'سیٹ اپ دوبارہ کریں',
       cancel: 'منسوخ کریں',
@@ -86,10 +89,17 @@ const ur = {
     },
     playlist: {
       heading: 'Playlist آئٹمز',
+      bulkHeading: 'متعدد URLs',
       itemCount_one: '{{count}} ویڈیو',
       itemCount_other: '{{count}} ویڈیوز',
       itemCountAudio_one: '{{count}} ٹریک',
       itemCountAudio_other: '{{count}} ٹریکس',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URLs',
+      bulkMetadataResolving: 'ویڈیو کی تفصیلات لی جا رہی ہیں… {{done}}/{{total}}',
+      bulkRowWaiting: 'انتظار میں',
+      bulkRowResolving: 'تفصیلات لی جا رہی ہیں',
+      bulkRowFailed: 'تفصیلات دستیاب نہیں',
       selectAll: 'سب منتخب کریں',
       selectNone: 'کوئی نہیں منتخب کریں',
       rangeFrom: 'سے',
@@ -111,6 +121,22 @@ const ur = {
       alreadyDownloaded: 'پہلے سے ڈاؤن لوڈ شدہ',
       probeLimitAlertTitle: 'Playlist اسکین محدود ہے',
       probeLimitAlertDesc: 'Arroxy نے {{count}} سے زیادہ آئٹمز دریافت کیے، اس لیے موجودہ اسکین لمٹ باقی آئٹمز چھپا رہی ہے۔'
+    },
+    bulk: {
+      title: 'متعدد URLs',
+      description: 'الگ الگ ویڈیو یا آڈیو URLs پیسٹ کریں۔ Arroxy قطار میں شامل کرنے سے پہلے نقول صاف کرے گا اور playlist یا channel لنکس کو نشان زد کرے گا۔',
+      textareaLabel: 'URL فہرست',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'تیار',
+      ignoredCount: 'نظر انداز',
+      emptyPreview: 'بیچ دیکھنے کے لیے کم از کم دو URLs پیسٹ کریں۔',
+      needsTwo: 'جاری رکھنے کے لیے کم از کم دو supported URLs شامل کریں۔',
+      confirm: 'یہ URLs استعمال کریں',
+      reject: {
+        duplicate: 'نقل',
+        playlist: 'playlist فلو استعمال کریں',
+        channel: 'channel فلو استعمال کریں'
+      }
     },
     playlistPresets: {
       heading: 'بیچ کے لیے کوالٹی منتخب کریں',
@@ -142,6 +168,8 @@ const ur = {
       quickProbeFailed: 'جانچ ناکام ہوگئی',
       quickPrepareFailed: 'قطار آئٹم تیار نہیں کیا جا سکا',
       quickFailed: 'یہ شامل نہیں ہو سکا: {{error}}',
+      bulkButton: 'متعدد URLs',
+      bulkTooltip: 'الگ URLs کی فہرست پیسٹ کریں، صاف فہرست دیکھیں، پھر ایک مشترک quality preset کے ساتھ قطار میں شامل کریں۔',
       features: {
         heading: 'Arroxy کیا لا سکتا ہے',
         youtube: {
@@ -175,6 +203,11 @@ const ur = {
         dialog: {
           title: 'YouTube URL ملا',
           body: 'کلپ بورڈ سے یہ لنک استعمال کریں؟',
+          bulkTitle: 'متعدد URLs ملے',
+          bulkBody: 'کیا clipboard کے یہ لنکس bulk download کے طور پر استعمال کریں؟',
+          bulkSummary: '{{count}} URLs تیار',
+          bulkIgnored: '{{count}} نظر انداز',
+          bulkButton: 'Bulk download',
           useButton: 'URL استعمال کریں',
           disableButton: 'بند کریں',
           cancelButton: 'منسوخ کریں',
@@ -444,12 +477,15 @@ const ur = {
       pullIt: 'لے آؤ! ↓',
       pullItTooltip: 'فوراً شروع ہو گا — دوسرے ایکٹو ڈاؤن لوڈز کے ساتھ چلے گا',
       labelPlaylist: 'پلے لسٹ',
+      labelBulk: 'متعدد URLs',
       labelPreset: 'پریسیٹ',
       labelItems: 'آئٹمز',
       itemsValue_one: '{{total}} میں سے {{count}} ویڈیو',
       itemsValue_other: '{{total}} میں سے {{count}} ویڈیوز',
       itemsValueAudio_one: '{{total}} میں سے {{count}} ٹریک',
-      itemsValueAudio_other: '{{total}} میں سے {{count}} ٹریکس'
+      itemsValueAudio_other: '{{total}} میں سے {{count}} ٹریکس',
+      itemsValueBulk_one: '{{total}} میں سے {{count}} URL',
+      itemsValueBulk_other: '{{total}} میں سے {{count}} URLs'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/uz.ts
+++ b/src/shared/i18n/locales/uz.ts
@@ -1,6 +1,7 @@
 const uz = {
   common: {
     back: 'Orqaga',
+    cancel: 'Bekor qilish',
     continue: 'Davom etish',
     retry: 'Qayta urinish',
     startOver: 'Qaytadan boshlash'
@@ -57,6 +58,8 @@ const uz = {
     },
     actions: {
       chooseExecutable: 'Bajariladigan faylni tanlash',
+      installWithHomebrew: 'Homebrew bilan o‘rnatish',
+      installWithWinget: 'WinGet bilan o‘rnatish',
       resetToDefault: 'Standartga qaytarish',
       retrySetup: 'Sozlashni qayta boshlash',
       cancel: 'Bekor qilish',
@@ -86,10 +89,17 @@ const uz = {
     },
     playlist: {
       heading: 'Playlist elementlari',
+      bulkHeading: 'Ommaviy URLlar',
       itemCount_one: '{{count}} ta video',
       itemCount_other: '{{count}} ta video',
       itemCountAudio_one: '{{count}} ta trek',
       itemCountAudio_other: '{{count}} ta trek',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URL',
+      bulkMetadataResolving: 'Video tafsilotlari olinmoqda… {{done}}/{{total}}',
+      bulkRowWaiting: 'Kutilmoqda',
+      bulkRowResolving: 'Tafsilotlar olinmoqda',
+      bulkRowFailed: 'Tafsilotlar mavjud emas',
       selectAll: 'Hammasini tanlash',
       selectNone: 'Hammasini bekor qilish',
       rangeFrom: 'Dan',
@@ -111,6 +121,22 @@ const uz = {
       alreadyDownloaded: 'Allaqachon yuklab olingan',
       probeLimitAlertTitle: 'Pleylist skaneri cheklangan',
       probeLimitAlertDesc: 'Arroxy {{count}} tadan ortiq element topdi, shuning uchun joriy skaner chekovi qolganlarini yashirmoqda.'
+    },
+    bulk: {
+      title: 'Ommaviy URLlar',
+      description: 'Alohida video yoki audio URLlarini joylang. Arroxy navbatga qo‘shishdan oldin takrorlarni tozalaydi va playlist yoki kanal havolalarini belgilaydi.',
+      textareaLabel: 'URL ro‘yxati',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'Tayyor',
+      ignoredCount: 'E’tiborsiz',
+      emptyPreview: 'To‘plamni ko‘rish uchun kamida ikki URL joylang.',
+      needsTwo: 'Davom etish uchun kamida ikki qo‘llab-quvvatlanadigan URL qo‘shing.',
+      confirm: 'Bu URLlardan foydalanish',
+      reject: {
+        duplicate: 'Takror',
+        playlist: 'Playlist oqimidan foydalanish',
+        channel: 'Kanal oqimidan foydalanish'
+      }
     },
     playlistPresets: {
       heading: 'Paket uchun sifatni tanlang',
@@ -142,6 +168,8 @@ const uz = {
       quickProbeFailed: 'Tekshiruv muvaffaqiyatsiz',
       quickPrepareFailed: 'Navbat elementi tayyorlanmadi',
       quickFailed: 'Buni qo‘shib bo‘lmadi: {{error}}',
+      bulkButton: 'Ommaviy URLlar',
+      bulkTooltip: 'Alohida URLlar ro‘yxatini joylang, tozalangan ro‘yxatni ko‘ring va umumiy sifat presetida navbatga qo‘shing.',
       features: {
         heading: 'Arroxy nima yuklab olishi mumkin',
         youtube: {
@@ -175,6 +203,11 @@ const uz = {
         dialog: {
           title: 'YouTube URL aniqlandi',
           body: 'Buferingizdagi bu havoladan foydalanasizmi?',
+          bulkTitle: 'Ommaviy URLlar topildi',
+          bulkBody: 'Clipboarddagi bu havolalarni ommaviy yuklama sifatida ishlatilsinmi?',
+          bulkSummary: '{{count}} URL tayyor',
+          bulkIgnored: '{{count}} e’tiborsiz',
+          bulkButton: 'Ommaviy yuklash',
           useButton: 'URLdan foydalanish',
           disableButton: "O'chirish",
           cancelButton: 'Bekor qilish',
@@ -444,12 +477,15 @@ const uz = {
       pullIt: 'Yuklab ol! ↓',
       pullItTooltip: 'Darhol boshlanadi — boshqa faol yuklamalar bilan parallel ishlaydi',
       labelPlaylist: 'Pleylist',
+      labelBulk: 'Ommaviy URLlar',
       labelPreset: 'Sozlama',
       labelItems: 'Elementlar',
       itemsValue_one: '{{total}} ta videoning {{count}} tasi',
       itemsValue_other: '{{total}} ta videoning {{count}} tasi',
       itemsValueAudio_one: '{{total}} ta trekning {{count}} tasi',
-      itemsValueAudio_other: '{{total}} ta trekning {{count}} tasi'
+      itemsValueAudio_other: '{{total}} ta trekning {{count}} tasi',
+      itemsValueBulk_one: '{{total}} URLdan {{count}} tasi',
+      itemsValueBulk_other: '{{total}} URLdan {{count}} tasi'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/vi.ts
+++ b/src/shared/i18n/locales/vi.ts
@@ -1,6 +1,7 @@
 const vi = {
   common: {
     back: 'Quay lại',
+    cancel: 'Hủy',
     continue: 'Tiếp tục',
     retry: 'Thử lại',
     startOver: 'Bắt đầu lại'
@@ -57,6 +58,8 @@ const vi = {
     },
     actions: {
       chooseExecutable: 'Chọn tệp thực thi',
+      installWithHomebrew: 'Cài bằng Homebrew',
+      installWithWinget: 'Cài bằng WinGet',
       resetToDefault: 'Đặt lại về mặc định',
       retrySetup: 'Thử thiết lập lại',
       cancel: 'Hủy',
@@ -86,10 +89,17 @@ const vi = {
     },
     playlist: {
       heading: 'Các mục Playlist',
+      bulkHeading: 'URL hàng loạt',
       itemCount_one: '{{count}} video',
       itemCount_other: '{{count}} video',
       itemCountAudio_one: '{{count}} bản nhạc',
       itemCountAudio_other: '{{count}} bản nhạc',
+      itemCountBulk_one: '{{count}} URL',
+      itemCountBulk_other: '{{count}} URL',
+      bulkMetadataResolving: 'Đang lấy chi tiết video… {{done}}/{{total}}',
+      bulkRowWaiting: 'Đang chờ',
+      bulkRowResolving: 'Đang lấy chi tiết',
+      bulkRowFailed: 'Không có chi tiết',
       selectAll: 'Chọn tất cả',
       selectNone: 'Bỏ chọn tất cả',
       rangeFrom: 'Từ',
@@ -111,6 +121,22 @@ const vi = {
       alreadyDownloaded: 'Đã tải xuống',
       probeLimitAlertTitle: 'Quét playlist đã bị giới hạn',
       probeLimitAlertDesc: 'Arroxy tìm thấy nhiều hơn {{count}} mục, vì vậy giới hạn quét hiện tại đang ẩn phần còn lại.'
+    },
+    bulk: {
+      title: 'URL hàng loạt',
+      description: 'Dán từng URL video hoặc âm thanh. Arroxy sẽ lọc trùng và đánh dấu liên kết playlist hoặc kênh trước khi đưa vào hàng đợi.',
+      textareaLabel: 'Danh sách URL',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: 'Sẵn sàng',
+      ignoredCount: 'Bị bỏ qua',
+      emptyPreview: 'Dán ít nhất hai URL để xem trước lô.',
+      needsTwo: 'Thêm ít nhất hai URL được hỗ trợ để tiếp tục.',
+      confirm: 'Dùng các URL này',
+      reject: {
+        duplicate: 'Trùng lặp',
+        playlist: 'Dùng luồng playlist',
+        channel: 'Dùng luồng kênh'
+      }
     },
     playlistPresets: {
       heading: 'Chọn chất lượng cho lô',
@@ -142,6 +168,8 @@ const vi = {
       quickProbeFailed: 'Thăm dò thất bại',
       quickPrepareFailed: 'Không thể chuẩn bị mục hàng đợi',
       quickFailed: 'Không thể thêm mục này: {{error}}',
+      bulkButton: 'URL hàng loạt',
+      bulkTooltip: 'Dán danh sách URL riêng lẻ, xem trước danh sách đã làm sạch rồi xếp hàng với một preset chất lượng chung.',
       features: {
         heading: 'Arroxy có thể tải gì',
         youtube: {
@@ -175,6 +203,11 @@ const vi = {
         dialog: {
           title: 'Đã phát hiện YouTube URL',
           body: 'Sử dụng liên kết này từ bộ nhớ tạm của bạn?',
+          bulkTitle: 'Đã phát hiện URL hàng loạt',
+          bulkBody: 'Dùng các liên kết trong clipboard này làm tải xuống hàng loạt?',
+          bulkSummary: '{{count}} URL sẵn sàng',
+          bulkIgnored: '{{count}} bị bỏ qua',
+          bulkButton: 'Tải hàng loạt',
           useButton: 'Dùng URL',
           disableButton: 'Tắt',
           cancelButton: 'Hủy',
@@ -444,12 +477,15 @@ const vi = {
       pullIt: 'Tải về! ↓',
       pullItTooltip: 'Bắt đầu ngay lập tức — chạy song song với các tải xuống đang hoạt động',
       labelPlaylist: 'Danh sách phát',
+      labelBulk: 'URL hàng loạt',
       labelPreset: 'Cài đặt sẵn',
       labelItems: 'Mục',
       itemsValue_one: '{{count}} trong {{total}} video',
       itemsValue_other: '{{count}} trong {{total}} video',
       itemsValueAudio_one: '{{count}} trong {{total}} bản nhạc',
-      itemsValueAudio_other: '{{count}} trong {{total}} bản nhạc'
+      itemsValueAudio_other: '{{count}} trong {{total}} bản nhạc',
+      itemsValueBulk_one: '{{count}} trên {{total}} URL',
+      itemsValueBulk_other: '{{count}} trên {{total}} URL'
     }
   },
   videoCard: {

--- a/src/shared/i18n/locales/zh.ts
+++ b/src/shared/i18n/locales/zh.ts
@@ -1,6 +1,7 @@
 const zh = {
   common: {
     back: '返回',
+    cancel: '取消',
     continue: '继续',
     retry: '重试',
     startOver: '重新开始'
@@ -57,6 +58,8 @@ const zh = {
     },
     actions: {
       chooseExecutable: '选择可执行文件',
+      installWithHomebrew: '使用 Homebrew 安装',
+      installWithWinget: '使用 WinGet 安装',
       resetToDefault: '恢复默认',
       retrySetup: '重试初始化',
       cancel: '取消',
@@ -86,10 +89,17 @@ const zh = {
     },
     playlist: {
       heading: 'Playlist 视频',
+      bulkHeading: '批量 URL',
       itemCount_one: '{{count}} 个视频',
       itemCount_other: '{{count}} 个视频',
       itemCountAudio_one: '{{count}} 首曲目',
       itemCountAudio_other: '{{count}} 首曲目',
+      itemCountBulk_one: '{{count}} 个 URL',
+      itemCountBulk_other: '{{count}} 个 URL',
+      bulkMetadataResolving: '正在获取视频详情… {{done}}/{{total}}',
+      bulkRowWaiting: '等待中',
+      bulkRowResolving: '正在获取详情',
+      bulkRowFailed: '详情不可用',
       selectAll: '全选',
       selectNone: '取消全选',
       rangeFrom: '从',
@@ -111,6 +121,22 @@ const zh = {
       alreadyDownloaded: '已下载',
       probeLimitAlertTitle: '播放列表扫描已达上限',
       probeLimitAlertDesc: 'Arroxy 发现超过 {{count}} 个项目，当前扫描上限隐藏了其余内容。'
+    },
+    bulk: {
+      title: '批量 URL',
+      description: '粘贴单个视频或音频 URL。Arroxy 会清理重复项，并在加入队列前标记播放列表或频道链接。',
+      textareaLabel: 'URL 列表',
+      textareaPlaceholder: 'https://video.example/one\nhttps://video.example/two\nhttps://video.example/three',
+      acceptedCount: '就绪',
+      ignoredCount: '已忽略',
+      emptyPreview: '至少粘贴两个 URL 以预览批次。',
+      needsTwo: '至少添加两个受支持的 URL 才能继续。',
+      confirm: '使用这些 URL',
+      reject: {
+        duplicate: '重复',
+        playlist: '使用播放列表流程',
+        channel: '使用频道流程'
+      }
     },
     playlistPresets: {
       heading: '选择批量下载画质',
@@ -142,6 +168,8 @@ const zh = {
       quickProbeFailed: '探测失败',
       quickPrepareFailed: '无法准备队列项目',
       quickFailed: '无法添加此项：{{error}}',
+      bulkButton: '批量 URL',
+      bulkTooltip: '粘贴单个 URL 列表，预览清理后的列表，然后使用同一个质量预设加入队列。',
       features: {
         heading: 'Arroxy 能下载什么',
         youtube: {
@@ -175,6 +203,11 @@ const zh = {
         dialog: {
           title: '检测到 YouTube 链接',
           body: '使用剪贴板中的此链接吗?',
+          bulkTitle: '检测到批量 URL',
+          bulkBody: '将剪贴板中的这些链接作为批量下载使用？',
+          bulkSummary: '{{count}} 个 URL 就绪',
+          bulkIgnored: '已忽略 {{count}} 个',
+          bulkButton: '批量下载',
           useButton: '使用 URL',
           disableButton: '禁用',
           cancelButton: '取消',
@@ -444,12 +477,15 @@ const zh = {
       pullIt: '开始下载! ↓',
       pullItTooltip: '立即开始 — 与其他活动下载并行运行',
       labelPlaylist: '播放列表',
+      labelBulk: '批量 URL',
       labelPreset: '预设',
       labelItems: '项目',
       itemsValue_one: '{{total}} 个视频中的 {{count}} 个',
       itemsValue_other: '{{total}} 个视频中的 {{count}} 个',
       itemsValueAudio_one: '{{total}} 首曲目中的 {{count}} 首',
-      itemsValueAudio_other: '{{total}} 首曲目中的 {{count}} 首'
+      itemsValueAudio_other: '{{total}} 首曲目中的 {{count}} 首',
+      itemsValueBulk_one: '{{count}} / {{total}} 个 URL',
+      itemsValueBulk_other: '{{count}} / {{total}} 个 URL'
     }
   },
   videoCard: {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -1,6 +1,8 @@
 export const IPC_CHANNELS = {
   appWarmUp: 'app:warmUp',
   appCancelWarmup: 'app:cancelWarmup',
+  appInstallYtDlpHomebrew: 'app:installYtDlpHomebrew',
+  appInstallYtDlpWinget: 'app:installYtDlpWinget',
   downloadsStart: 'downloads:start',
   downloadsCancel: 'downloads:cancel',
   downloadsPause: 'downloads:pause',

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -356,6 +356,7 @@ const commonSettingsPatchSchema = z.object({
   lastSponsorBlockCategories: z.array(sponsorBlockCategorySchema).optional(),
   analyticsEnabled: z.boolean().optional(),
   firstRunCompleted: z.boolean().optional(),
+  launchCount: z.number().int().nonnegative().optional(),
   drawerOpen: z.boolean().optional(),
   successfulDownloadCount: z.number().int().nonnegative().optional(),
   shareInlineCardDismissed: z.boolean().optional(),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -75,6 +75,7 @@ export interface CommonSettings {
   lastSponsorBlockCategories?: SponsorBlockCategory[];
   analyticsEnabled?: boolean;
   firstRunCompleted?: boolean;
+  launchCount?: number;
   drawerOpen?: boolean;
   binaryOverrides?: BinaryOverrides;
   successfulDownloadCount?: number;

--- a/tests/renderer/feedback-nudge.test.tsx
+++ b/tests/renderer/feedback-nudge.test.tsx
@@ -11,6 +11,8 @@ const mockAppApi = {
   app: {
     warmUp: vi.fn().mockResolvedValue(ok({ completed: true, dependencies: {}, blockingFailures: [], cancelled: false })),
     cancelWarmup: vi.fn().mockResolvedValue(undefined),
+    installYtDlpWithHomebrew: vi.fn().mockResolvedValue(ok({ installedPath: '/opt/homebrew/bin/yt-dlp' })),
+    installYtDlpWithWinget: vi.fn().mockResolvedValue(ok({ installedPath: 'C:\\Users\\mock\\AppData\\Local\\Microsoft\\WinGet\\Links\\yt-dlp.exe' })),
     setLanguage: vi.fn().mockResolvedValue(undefined)
   },
   window: {

--- a/tests/renderer/footer-feedback.test.tsx
+++ b/tests/renderer/footer-feedback.test.tsx
@@ -14,6 +14,8 @@ const mockAppApi = {
   app: {
     warmUp: vi.fn().mockResolvedValue(ok({ completed: true, dependencies: {}, blockingFailures: [], cancelled: false })),
     cancelWarmup: vi.fn().mockResolvedValue(undefined),
+    installYtDlpWithHomebrew: vi.fn().mockResolvedValue(ok({ installedPath: '/opt/homebrew/bin/yt-dlp' })),
+    installYtDlpWithWinget: vi.fn().mockResolvedValue(ok({ installedPath: 'C:\\Users\\mock\\AppData\\Local\\Microsoft\\WinGet\\Links\\yt-dlp.exe' })),
     setLanguage: vi.fn().mockResolvedValue(undefined)
   },
   window: {

--- a/tests/renderer/splash-screen.test.tsx
+++ b/tests/renderer/splash-screen.test.tsx
@@ -41,11 +41,11 @@ describe('SplashScreen', () => {
   it('shows the welcome-back greeting only when requested', () => {
     const { rerender } = render(<SplashScreen initialized={false} warmupBlocking={[]} warmupDiagnostics={null} warmupProgress={null} showGreeting={false} />);
 
-    expect(screen.queryByText('Hey, welcome back!')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('splash-greeting')).not.toBeInTheDocument();
 
     rerender(<SplashScreen initialized={false} warmupBlocking={[]} warmupDiagnostics={null} warmupProgress={null} showGreeting />);
 
-    expect(screen.getByText('Hey, welcome back!')).toBeInTheDocument();
+    expect(screen.getByTestId('splash-greeting')).toBeInTheDocument();
   });
 
   it('does not show cancel during non-cancellable package-manager repair phases', () => {

--- a/tests/renderer/splash-screen.test.tsx
+++ b/tests/renderer/splash-screen.test.tsx
@@ -1,12 +1,66 @@
 // @vitest-environment jsdom
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { DependencyDiagnostic, DependencyId } from '@shared/types.js';
 import { SplashScreen } from '@renderer/components/system/SplashScreen.js';
+import { useAppStore } from '@renderer/store/useAppStore.js';
+
+const failedYtDlpDiagnostic: DependencyDiagnostic = {
+  id: 'yt-dlp',
+  state: 'failed',
+  source: { kind: 'managed', channel: 'nightly', url: 'https://example.test/yt-dlp' },
+  resolvedPath: null,
+  failure: { kind: 'download_failed', message: 'download failed' },
+  attempts: [
+    {
+      source: { kind: 'managed', channel: 'nightly', url: 'https://example.test/yt-dlp' },
+      failure: { kind: 'download_failed', message: 'download failed' }
+    }
+  ]
+};
+
+function renderBlockedSplash(): void {
+  render(<SplashScreen initialized warmupBlocking={['yt-dlp']} warmupDiagnostics={{ 'yt-dlp': failedYtDlpDiagnostic } as Record<DependencyId, DependencyDiagnostic>} warmupProgress={null} showGreeting={false} />);
+}
 
 describe('SplashScreen', () => {
+  afterEach(() => {
+    useAppStore.setState({
+      warmupRunning: false,
+      warmupCancellable: false,
+      cancelWarmup: vi.fn()
+    });
+  });
+
   it('blocks pointer events while warmup overlay is visible', () => {
-    render(<SplashScreen initialized={false} warmupBlocking={[]} warmupDiagnostics={null} warmupProgress={null} />);
+    render(<SplashScreen initialized={false} warmupBlocking={[]} warmupDiagnostics={null} warmupProgress={null} showGreeting={false} />);
 
     expect(screen.getByTestId('splash-overlay')).toHaveStyle({ pointerEvents: 'auto' });
+  });
+
+  it('shows the welcome-back greeting only when requested', () => {
+    const { rerender } = render(<SplashScreen initialized={false} warmupBlocking={[]} warmupDiagnostics={null} warmupProgress={null} showGreeting={false} />);
+
+    expect(screen.queryByText('Hey, welcome back!')).not.toBeInTheDocument();
+
+    rerender(<SplashScreen initialized={false} warmupBlocking={[]} warmupDiagnostics={null} warmupProgress={null} showGreeting />);
+
+    expect(screen.getByText('Hey, welcome back!')).toBeInTheDocument();
+  });
+
+  it('does not show cancel during non-cancellable package-manager repair phases', () => {
+    useAppStore.setState({ warmupRunning: true, warmupCancellable: false });
+
+    renderBlockedSplash();
+
+    expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument();
+  });
+
+  it('shows cancel during cancellable warmup phases', () => {
+    useAppStore.setState({ warmupRunning: true, warmupCancellable: true });
+
+    renderBlockedSplash();
+
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
   });
 });

--- a/tests/shared/mockAppApi.ts
+++ b/tests/shared/mockAppApi.ts
@@ -34,6 +34,8 @@ export function buildMockAppApi(options: BuildMockOptions = {}): AppApi {
     app: {
       warmUp: vi.fn().mockResolvedValue(ok(defaultWarmUp)),
       cancelWarmup: vi.fn().mockResolvedValue(undefined),
+      installYtDlpWithHomebrew: vi.fn().mockResolvedValue(ok({ installedPath: '/opt/homebrew/bin/yt-dlp' })),
+      installYtDlpWithWinget: vi.fn().mockResolvedValue(ok({ installedPath: 'C:\\Users\\mock\\AppData\\Local\\Microsoft\\WinGet\\Links\\yt-dlp.exe' })),
       setLanguage: vi.fn().mockResolvedValue(undefined)
     },
     window: {

--- a/tests/shared/settingsFixtures.ts
+++ b/tests/shared/settingsFixtures.ts
@@ -1,6 +1,6 @@
 import type { AppSettings } from '@shared/types.js';
 
-const COMMON_KEYS = new Set(['defaultOutputDir', 'rememberLastOutputDir', 'uiZoom', 'uiTheme', 'language', 'commonPaths', 'cookiesPath', 'cookiesMode', 'cookiesBrowser', 'cookiesEnabled', 'proxyUrl', 'clipboardWatchEnabled', 'closeBehavior', 'embedChapters', 'embedMetadata', 'embedThumbnail', 'writeDescription', 'writeThumbnail', 'lastSponsorBlockMode', 'lastSponsorBlockCategories', 'analyticsEnabled', 'firstRunCompleted', 'drawerOpen', 'lastSubfolderEnabled', 'lastSubfolder', 'includeIdInSingleFilenames']);
+const COMMON_KEYS = new Set(['defaultOutputDir', 'rememberLastOutputDir', 'uiZoom', 'uiTheme', 'language', 'commonPaths', 'cookiesPath', 'cookiesMode', 'cookiesBrowser', 'cookiesEnabled', 'proxyUrl', 'clipboardWatchEnabled', 'closeBehavior', 'embedChapters', 'embedMetadata', 'embedThumbnail', 'writeDescription', 'writeThumbnail', 'lastSponsorBlockMode', 'lastSponsorBlockCategories', 'analyticsEnabled', 'firstRunCompleted', 'launchCount', 'drawerOpen', 'lastSubfolderEnabled', 'lastSubfolder', 'includeIdInSingleFilenames']);
 
 const SINGLE_KEYS = new Set(['lastPreset', 'lastVideoResolution', 'lastSubtitleLanguages', 'lastSubtitleMode', 'lastSubtitleFormat']);
 

--- a/tests/unit/analytics-allowlist.test.ts
+++ b/tests/unit/analytics-allowlist.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { ctorMock, trackMock, identifyMock, setGlobalPropertiesMock } = vi.hoisted(() => {
+const { ctorMock, trackMock, identifyMock, setGlobalPropertiesMock, addHeaderMock } = vi.hoisted(() => {
   const trackMock = vi.fn().mockResolvedValue(undefined);
   const identifyMock = vi.fn().mockResolvedValue(undefined);
   const setGlobalPropertiesMock = vi.fn();
@@ -8,7 +8,7 @@ const { ctorMock, trackMock, identifyMock, setGlobalPropertiesMock } = vi.hoiste
   const ctorMock = vi.fn().mockImplementation(function () {
     return { track: trackMock, identify: identifyMock, setGlobalProperties: setGlobalPropertiesMock, api: { addHeader: addHeaderMock } };
   });
-  return { ctorMock, trackMock, identifyMock, setGlobalPropertiesMock };
+  return { ctorMock, trackMock, identifyMock, setGlobalPropertiesMock, addHeaderMock };
 });
 
 vi.mock('@openpanel/sdk', () => ({ OpenPanel: ctorMock }));
@@ -48,7 +48,7 @@ describe('allowlist validation', () => {
 
   it('accepts stable failure code on binary_setup_failed', () => {
     setupAnalytics(undefined, undefined, true, 'install-id-test');
-    expect(() => trackMain('binary_setup_failed', { binary: 'ffmpeg', phase: 'download_failed', code: 'ARX-001' })).not.toThrow();
+    expect(() => trackMain('binary_setup_failed', { binary: 'ffmpeg', phase: 'download_failed', code: 'ARX-001', operation: 'managed-download', setup_step: 'download', source_kind: 'managed', source_channel: 'nightly', elapsed_ms: 123 })).not.toThrow();
   });
 });
 
@@ -155,6 +155,20 @@ describe('identify + global properties', () => {
     });
     const props = setGlobalPropertiesMock.mock.calls[0][0];
     expect(props.model_name.length).toBe(64);
+  });
+
+  it('uses deviceInfo Darwin version in the browser-like User-Agent', () => {
+    setupAnalytics('client-id', 'client-secret', false, 'install-id-test', {
+      appVersion: '1.0.0',
+      platform: 'darwin',
+      architecture: 'x64',
+      systemVersion: '24.1.0',
+      modelName: 'Intel Mac',
+      osLocale: 'en-US',
+      appLocale: 'en-US'
+    });
+
+    expect(addHeaderMock).toHaveBeenCalledWith('user-agent', expect.stringContaining('Mac OS X 15_1_0'));
   });
 
   it('still calls identify (no properties) when deviceInfo is omitted', () => {

--- a/tests/unit/binary-manager-analytics.test.ts
+++ b/tests/unit/binary-manager-analytics.test.ts
@@ -34,7 +34,12 @@ describe('BinaryManager analytics', () => {
     expect(trackMain).toHaveBeenCalledWith('binary_setup_failed', {
       binary: 'ffmpeg',
       phase: 'hash_failed',
-      code: 'ARX-003'
+      code: 'ARX-003',
+      operation: 'managed-download',
+      setup_step: 'unknown',
+      source_kind: 'managed',
+      source_channel: 'default',
+      elapsed_ms: expect.any(Number)
     });
   });
 
@@ -59,7 +64,12 @@ describe('BinaryManager analytics', () => {
     expect(trackMain).toHaveBeenCalledWith('binary_setup_failed', {
       binary: 'ffmpeg',
       phase: 'timeout',
-      code: 'ARX-008'
+      code: 'ARX-008',
+      operation: 'managed-download',
+      setup_step: 'unknown',
+      source_kind: 'managed',
+      source_channel: 'default',
+      elapsed_ms: expect.any(Number)
     });
   });
 
@@ -84,7 +94,12 @@ describe('BinaryManager analytics', () => {
     expect(trackMain).toHaveBeenCalledWith('binary_setup_failed', {
       binary: 'ffmpeg',
       phase: 'download_failed',
-      code: 'ARX-001'
+      code: 'ARX-001',
+      operation: 'managed-download',
+      setup_step: 'unknown',
+      source_kind: 'managed',
+      source_channel: 'default',
+      elapsed_ms: expect.any(Number)
     });
   });
 });

--- a/tests/unit/binary-manager-platform.test.ts
+++ b/tests/unit/binary-manager-platform.test.ts
@@ -94,3 +94,27 @@ describe('denoExecutableName', () => {
     expect(binaryInternals.denoExecutableName()).toBe('deno');
   });
 });
+
+describe('fallbackPathCandidates', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('adds Homebrew bin fallbacks on macOS', () => {
+    expect(binaryInternals.fallbackPathCandidates('yt-dlp', 'darwin')).toEqual(['/opt/homebrew/bin/yt-dlp', '/usr/local/bin/yt-dlp']);
+  });
+
+  it('adds WinGet executable fallbacks on Windows', () => {
+    process.env.LOCALAPPDATA = 'C:\\Users\\me\\AppData\\Local';
+    process.env.ProgramFiles = 'C:\\Program Files';
+    process.env['ProgramFiles(x86)'] = 'C:\\Program Files (x86)';
+
+    expect(binaryInternals.fallbackPathCandidates('yt-dlp', 'win32')).toEqual(['C:\\Users\\me\\AppData\\Local/Microsoft/WindowsApps/yt-dlp.exe', 'C:\\Users\\me\\AppData\\Local/Microsoft/WinGet/Links/yt-dlp.exe', 'C:\\Program Files/WinGet/Links/yt-dlp.exe', 'C:\\Program Files (x86)/WinGet/Links/yt-dlp.exe']);
+  });
+
+  it('does not add package-manager fallbacks on Linux', () => {
+    expect(binaryInternals.fallbackPathCandidates('yt-dlp', 'linux')).toEqual([]);
+  });
+});

--- a/tests/unit/binary-manager-platform.test.ts
+++ b/tests/unit/binary-manager-platform.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { binaryInternals } from '@main/services/BinaryManager.js';
 
@@ -111,7 +112,7 @@ describe('fallbackPathCandidates', () => {
     process.env.ProgramFiles = 'C:\\Program Files';
     process.env['ProgramFiles(x86)'] = 'C:\\Program Files (x86)';
 
-    expect(binaryInternals.fallbackPathCandidates('yt-dlp', 'win32')).toEqual(['C:\\Users\\me\\AppData\\Local/Microsoft/WindowsApps/yt-dlp.exe', 'C:\\Users\\me\\AppData\\Local/Microsoft/WinGet/Links/yt-dlp.exe', 'C:\\Program Files/WinGet/Links/yt-dlp.exe', 'C:\\Program Files (x86)/WinGet/Links/yt-dlp.exe']);
+    expect(binaryInternals.fallbackPathCandidates('yt-dlp', 'win32')).toEqual([path.join('C:\\Users\\me\\AppData\\Local', 'Microsoft', 'WindowsApps', 'yt-dlp.exe'), path.join('C:\\Users\\me\\AppData\\Local', 'Microsoft', 'WinGet', 'Links', 'yt-dlp.exe'), path.join('C:\\Program Files', 'WinGet', 'Links', 'yt-dlp.exe'), path.join('C:\\Program Files (x86)', 'WinGet', 'Links', 'yt-dlp.exe')]);
   });
 
   it('does not add package-manager fallbacks on Linux', () => {

--- a/tests/unit/binary-manager-retry.test.ts
+++ b/tests/unit/binary-manager-retry.test.ts
@@ -112,6 +112,21 @@ describe('BinaryManager download retry', () => {
     expect(spy).toHaveBeenCalledOnce();
   });
 
+  it('keeps the existing yt-dlp when an update download fails', async () => {
+    const mgr = await makeMgr();
+    stubProbe(mgr);
+    const binaryPath = mgr.getYtDlpPath();
+    await fs.mkdir(path.dirname(binaryPath), { recursive: true });
+    await fs.writeFile(binaryPath, 'fake-binary');
+    if (process.platform !== 'win32') await fs.chmod(binaryPath, 0o755);
+
+    spyOnPrivate(mgr, 'getLocalYtDlpVersion').mockResolvedValue('2024.11.01');
+    spyOnPrivate(mgr, 'getRemoteYtDlpVersion').mockResolvedValue({ tag: '2025.01.15', reason: null });
+    spyOnPrivate(mgr, 'attemptDownload').mockRejectedValue(new Error('HTTP 503'));
+
+    await expect(mgr.ensureYtDlp()).resolves.toBe(binaryPath);
+  });
+
   it('re-downloads yt-dlp when local version cannot be determined', async () => {
     const mgr = await makeMgr();
     stubProbe(mgr);

--- a/tests/unit/ipc-handlers.test.ts
+++ b/tests/unit/ipc-handlers.test.ts
@@ -28,6 +28,7 @@ vi.mock('electron', () => ({
 import { registerIpcHandlers } from '@main/ipc/registerIpcHandlers.js';
 import { IPC_CHANNELS } from '@shared/ipc.js';
 import { shell } from 'electron';
+import log from 'electron-log/main.js';
 
 class FakeDownloadService extends EventEmitter {
   start = vi.fn();
@@ -84,7 +85,9 @@ function makeDeps() {
       ensureYtDlp: vi.fn(),
       ensureFFmpeg: vi.fn(),
       ensureDeno: vi.fn(),
-      ensureFFprobe: vi.fn()
+      ensureFFprobe: vi.fn(),
+      installYtDlpWithHomebrew: vi.fn().mockResolvedValue('/opt/homebrew/bin/yt-dlp'),
+      installYtDlpWithWinget: vi.fn().mockResolvedValue('C:\\Users\\mock\\AppData\\Local\\Microsoft\\WinGet\\Links\\yt-dlp.exe')
     } as never,
     tokenService: { warmUp: vi.fn() } as never,
     languageRef: languageRef as never,
@@ -253,6 +256,32 @@ describe('registerIpcHandlers', () => {
       expect(deps._raw.languageRef.current).toBe('fr');
     });
 
+    it('app:installYtDlpHomebrew invokes the binary manager repair action', async () => {
+      const deps = makeDeps();
+      registerIpcHandlers(deps);
+
+      const handler = findCall(IPC_CHANNELS.appInstallYtDlpHomebrew)!.fn;
+      const result = (await handler(null, undefined)) as {
+        ok: boolean;
+        data?: { installedPath: string };
+      };
+
+      expect(result).toEqual({ ok: true, data: { installedPath: '/opt/homebrew/bin/yt-dlp' } });
+    });
+
+    it('app:installYtDlpWinget invokes the binary manager repair action', async () => {
+      const deps = makeDeps();
+      registerIpcHandlers(deps);
+
+      const handler = findCall(IPC_CHANNELS.appInstallYtDlpWinget)!.fn;
+      const result = (await handler(null, undefined)) as {
+        ok: boolean;
+        data?: { installedPath: string };
+      };
+
+      expect(result).toEqual({ ok: true, data: { installedPath: 'C:\\Users\\mock\\AppData\\Local\\Microsoft\\WinGet\\Links\\yt-dlp.exe' } });
+    });
+
     it('queue:cmd:add rejects non-array payloads with a Result failure', async () => {
       const deps = makeDeps();
       registerIpcHandlers(deps);
@@ -374,6 +403,25 @@ describe('registerIpcHandlers', () => {
 
         expect(result.ok).toBe(true);
         expect(shell.showItemInFolder).toHaveBeenCalledWith('/tmp/logs/main.log');
+        expect(shell.openPath).not.toHaveBeenCalled();
+      } finally {
+        Object.defineProperty(process, 'platform', originalPlatform);
+      }
+    });
+
+    it.each(['/Users/monterey/Library/Application Support/arroxy/logs/main.log', '/Users/monterey/Library/Application Support/Arroxy/logs/main.log'])('logs:openDir reveals the active macOS main.log path (%s)', async (logPath) => {
+      const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+      Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+      vi.mocked(log.transports.file.getFile).mockReturnValue({ path: logPath } as ReturnType<typeof log.transports.file.getFile>);
+      try {
+        const deps = makeDeps();
+        registerIpcHandlers(deps);
+
+        const handler = findCall(IPC_CHANNELS.logsOpenDir)!.fn;
+        const result = (await handler(null, undefined)) as { ok: boolean };
+
+        expect(result.ok).toBe(true);
+        expect(shell.showItemInFolder).toHaveBeenCalledWith(logPath);
         expect(shell.openPath).not.toHaveBeenCalled();
       } finally {
         Object.defineProperty(process, 'platform', originalPlatform);

--- a/tests/unit/preload-contract.test.ts
+++ b/tests/unit/preload-contract.test.ts
@@ -43,6 +43,18 @@ describe('invoke methods → correct IPC channel', () => {
     expect(ipc.invoke).toHaveBeenCalledWith(IPC_CHANNELS.appCancelWarmup);
   });
 
+  it('app.installYtDlpWithHomebrew', () => {
+    const api = createPreloadApi(ipc.ipcRenderer);
+    void api.app.installYtDlpWithHomebrew();
+    expect(ipc.invoke).toHaveBeenCalledWith(IPC_CHANNELS.appInstallYtDlpHomebrew);
+  });
+
+  it('app.installYtDlpWithWinget', () => {
+    const api = createPreloadApi(ipc.ipcRenderer);
+    void api.app.installYtDlpWithWinget();
+    expect(ipc.invoke).toHaveBeenCalledWith(IPC_CHANNELS.appInstallYtDlpWinget);
+  });
+
   it('downloads.probe', () => {
     const api = createPreloadApi(ipc.ipcRenderer);
     const input = { url: 'https://youtube.com/watch?v=x' };

--- a/tests/unit/settings-store.test.ts
+++ b/tests/unit/settings-store.test.ts
@@ -34,6 +34,43 @@ describe('settings and recent stores', () => {
     expect(readBack.single.lastSubtitleLanguages).toEqual(['en', 'es']);
   });
 
+  it('records launch count so only the second launch is marked welcome-back eligible', async () => {
+    const userData = await fs.mkdtemp(path.join(os.tmpdir(), 'settings-store-launch-count-'));
+    const store = new SettingsStore(userData, baseDefaults);
+
+    const first = await store.recordLaunch();
+    expect(first.isFirstRun).toBe(true);
+    expect(first.launchCount).toBe(1);
+    expect(first.settings.common.firstRunCompleted).toBe(true);
+
+    const second = await store.recordLaunch();
+    expect(second.isFirstRun).toBe(false);
+    expect(second.launchCount).toBe(2);
+
+    const third = await store.recordLaunch();
+    expect(third.isFirstRun).toBe(false);
+    expect(third.launchCount).toBe(3);
+  });
+
+  it('treats existing installs without launch history as past the welcome-back launch', async () => {
+    const userData = await fs.mkdtemp(path.join(os.tmpdir(), 'settings-store-existing-launch-count-'));
+    await fs.writeFile(
+      path.join(userData, 'settings.json'),
+      JSON.stringify({
+        common: { ...baseDefaults.common, firstRunCompleted: true },
+        single: {},
+        playlist: {}
+      }),
+      'utf-8'
+    );
+    const store = new SettingsStore(userData, baseDefaults);
+
+    const launch = await store.recordLaunch();
+
+    expect(launch.isFirstRun).toBe(false);
+    expect(launch.launchCount).toBe(3);
+  });
+
   it('keeps recent jobs bounded and sorted', async () => {
     const userData = await fs.mkdtemp(path.join(os.tmpdir(), 'recent-jobs-'));
     const store = new RecentJobsStore(userData);


### PR DESCRIPTION
## Summary
- add Homebrew and WinGet repair actions for yt-dlp setup failures
- add fallback probing for Homebrew/WinGet executable locations and richer setup diagnostics
- track launch count for the welcome-back splash and keep package-manager repair cancel UI accurate
- update translations and tests

## Base branch
- [x] main

## Type
- [x] Feature
- [x] Bug fix

## Testing
- Local: bun run check
- CI: required GitHub checks on PR #60