### PR TITLE
Fix splash startup dialog timing

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -14,6 +14,7 @@ import { LanguagePicker } from './components/system/LanguagePicker.js';
 import { AboutDialog } from './components/system/AboutDialog.js';
 import { ShareDialog } from './components/system/ShareDialog.js';
 import { useUpdateChannel } from './components/system/useUpdateChannel.js';
+import { shouldShowSplashGreeting } from './components/system/splashGreeting.js';
 import { TooltipProvider } from './components/ui/tooltip.js';
 import { ScenarioGallery } from './dev/ScenarioGallery.js';
 import { cn } from './lib/utils.js';
@@ -30,7 +31,7 @@ function buildDebugInfo(): string {
 
 export function App(): JSX.Element {
   const { t } = useTranslation();
-  const { initialized, initialize, openLogs, uiZoom, setUiZoom, uiTheme, warmupBlocking, warmupDiagnostics, warmupProgress, settings, setAboutDialogOpen, openShareDialog } = useAppStore();
+  const { initialized, initialize, openLogs, uiZoom, setUiZoom, uiTheme, warmupBlocking, warmupDiagnostics, warmupProgress, settings, setSplashDismissed, setAboutDialogOpen, openShareDialog } = useAppStore();
   const update = useUpdateChannel();
   const [debugCopied, setDebugCopied] = useState(false);
   const [showNudge, setShowNudge] = useState(false);
@@ -138,7 +139,7 @@ export function App(): JSX.Element {
           </div>
         </footer>
 
-        <SplashScreen initialized={initialized} warmupBlocking={warmupBlocking} warmupDiagnostics={warmupDiagnostics} warmupProgress={warmupProgress} showGreeting={settings?.common?.launchCount === 2} />
+        <SplashScreen initialized={initialized} warmupBlocking={warmupBlocking} warmupDiagnostics={warmupDiagnostics} warmupProgress={warmupProgress} showGreeting={shouldShowSplashGreeting(settings)} onDismissed={() => setSplashDismissed(true)} />
         <AboutDialog />
         <ShareDialog />
         {SHOW_SCENARIO_GALLERY && <ScenarioGallery />}

--- a/src/renderer/src/components/system/SplashScreen.tsx
+++ b/src/renderer/src/components/system/SplashScreen.tsx
@@ -10,6 +10,7 @@ interface Props {
   warmupDiagnostics: Record<DependencyId, DependencyDiagnostic> | null;
   warmupProgress: Partial<Record<DependencyId, WarmupProgressEvent>> | null;
   showGreeting: boolean;
+  onDismissed?: () => void;
 }
 
 const MIN_MS = 3000;
@@ -19,7 +20,7 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-export function SplashScreen({ initialized, warmupBlocking, warmupDiagnostics, warmupProgress, showGreeting }: Props): JSX.Element | null {
+export function SplashScreen({ initialized, warmupBlocking, warmupDiagnostics, warmupProgress, showGreeting, onDismissed }: Props): JSX.Element | null {
   const { t } = useTranslation();
   const [minPassed, setMinPassed] = useState(false);
   const [gone, setGone] = useState(false);
@@ -51,8 +52,10 @@ export function SplashScreen({ initialized, warmupBlocking, warmupDiagnostics, w
       className="splash-overlay"
       data-testid="splash-overlay"
       style={{ opacity: fading ? 0 : 1, pointerEvents: fading ? 'none' : 'auto' }}
-      onTransitionEnd={() => {
-        if (fading) setGone(true);
+      onTransitionEnd={(event) => {
+        if (!fading || event.currentTarget !== event.target) return;
+        setGone(true);
+        onDismissed?.();
       }}
       aria-hidden={!blocked}
     >

--- a/src/renderer/src/components/system/splashGreeting.ts
+++ b/src/renderer/src/components/system/splashGreeting.ts
@@ -1,0 +1,5 @@
+import type { AppSettings } from '@shared/types.js';
+
+export function shouldShowSplashGreeting(settings: AppSettings | null): boolean {
+  return (settings?.common?.launchCount ?? 0) > 1;
+}

--- a/src/renderer/src/components/wizard/StepUrlInput.tsx
+++ b/src/renderer/src/components/wizard/StepUrlInput.tsx
@@ -42,7 +42,7 @@ const COOKIES_CHROME_URL = 'https://chromewebstore.google.com/detail/get-cookies
 
 export function StepUrlInput(): JSX.Element {
   const { t } = useTranslation();
-  const { wizardUrl, setWizardUrl, submitUrl, quickDownload, quickDownloadStatus, quickDownloadError, queue, settings, initialized, advancedAutoOpen, advancedAutoTarget, setAdvancedAutoOpen, setCookiesPath, setCookiesMode, setCookiesBrowser, setClipboardWatchEnabled, setIncludeIdInSingleFilenames, setCloseBehavior, setAnalyticsEnabled, setProxyUrl, setLimitRate, cookiesConfigDialogIssue, dismissCookiesConfigDialog, openCookiesSettings, openShareDialog, setShareInlineCardDismissed } = useAppStore();
+  const { wizardUrl, setWizardUrl, submitUrl, quickDownload, quickDownloadStatus, quickDownloadError, queue, settings, initialized, splashDismissed, advancedAutoOpen, advancedAutoTarget, setAdvancedAutoOpen, setCookiesPath, setCookiesMode, setCookiesBrowser, setClipboardWatchEnabled, setIncludeIdInSingleFilenames, setCloseBehavior, setAnalyticsEnabled, setProxyUrl, setLimitRate, cookiesConfigDialogIssue, dismissCookiesConfigDialog, openCookiesSettings, openShareDialog, setShareInlineCardDismissed } = useAppStore();
   const inputRef = useRef<HTMLInputElement>(null);
   const bulkOpenRef = useRef(false);
   const hasActiveDownloads = queue.some((i) => i.status === 'running');
@@ -440,7 +440,7 @@ export function StepUrlInput(): JSX.Element {
         </div>
       </details>
 
-      <ClipboardConfirmDialog open={pendingClipboard !== null && initialized} prompt={pendingClipboard} onUse={handleConfirmClipboard} onFetch={() => void handleFetchClipboard()} onBulk={handleBulkClipboard} onQuickDownload={() => void handleQuickDownloadClipboard()} onDisable={handleDisableClipboard} onCancel={handleCancelClipboard} quickPreparing={quickPreparing} />
+      <ClipboardConfirmDialog open={pendingClipboard !== null && initialized && splashDismissed} prompt={pendingClipboard} onUse={handleConfirmClipboard} onFetch={() => void handleFetchClipboard()} onBulk={handleBulkClipboard} onQuickDownload={() => void handleQuickDownloadClipboard()} onDisable={handleDisableClipboard} onCancel={handleCancelClipboard} quickPreparing={quickPreparing} />
       {bulkOpen ? <BulkUrlDialog open={bulkOpen} onOpenChange={setBulkOpen} initialRaw={bulkInitialRaw} /> : null}
       <IncompleteCookiesConfigDialog issue={cookiesConfigDialogIssue} onDismiss={dismissCookiesConfigDialog} onOpenSettings={openCookiesSettings} />
     </div>

--- a/src/renderer/src/store/systemSlice.ts
+++ b/src/renderer/src/store/systemSlice.ts
@@ -78,6 +78,7 @@ export function createSystemSlice(set: SetState, get: GetState): SystemSlice {
   return {
     initialized: false,
     initializing: false,
+    splashDismissed: false,
     warmupDiagnostics: null,
     warmupBlocking: [],
     warmupRunning: false,
@@ -94,7 +95,7 @@ export function createSystemSlice(set: SetState, get: GetState): SystemSlice {
 
     initialize: async () => {
       if (get().initialized || get().initializing) return;
-      set({ initializing: true });
+      set({ initializing: true, splashDismissed: false });
 
       // Detach prior queue projection bindings (defense for a future re-init flow).
       unbindQueueSnapshot?.();
@@ -208,8 +209,7 @@ export function createSystemSlice(set: SetState, get: GetState): SystemSlice {
       const settingsPromise = window.appApi.settings.get();
       const warmUpPromise = window.appApi.app.warmUp();
       const snapshotPromise = window.appApi.queue.cmd.getSnapshot();
-      const [settingsResult, warmUpResult, snapshotResult] = await Promise.all([settingsPromise, warmUpPromise, snapshotPromise]);
-      if (snapshotResult.ok) set({ queue: snapshotResult.data });
+      const settingsResult = await settingsPromise;
 
       if (settingsResult.ok) {
         const common = settingsResult.data.common ?? ({} as AppSettings['common']);
@@ -234,10 +234,17 @@ export function createSystemSlice(set: SetState, get: GetState): SystemSlice {
         });
       }
 
+      const [warmUpResult, snapshotResult] = await Promise.all([warmUpPromise, snapshotPromise]);
+      if (snapshotResult.ok) set({ queue: snapshotResult.data });
+
       const warmupDiagnostics = warmUpResult.ok ? warmUpResult.data.dependencies : null;
       const warmupBlocking = warmUpResult.ok ? warmUpResult.data.blockingFailures : [];
 
       set({ initialized: true, initializing: false, warmupRunning: false, warmupCancellable: false, warmupDiagnostics, warmupBlocking });
+    },
+
+    setSplashDismissed: (dismissed) => {
+      set({ splashDismissed: dismissed });
     },
 
     cancelWarmup: async () => {

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -214,6 +214,7 @@ export type ShareTrigger = 'footer' | 'titlebar' | 'about' | 'wizard-card' | 'mi
 export interface SystemSlice {
   initialized: boolean;
   initializing: boolean;
+  splashDismissed: boolean;
   warmupDiagnostics: Record<DependencyId, DependencyDiagnostic> | null;
   warmupBlocking: DependencyId[];
   warmupRunning: boolean;
@@ -225,6 +226,7 @@ export interface SystemSlice {
   shareDialogOpen: boolean;
   shareDialogTrigger: ShareTrigger | null;
   initialize: () => Promise<void>;
+  setSplashDismissed: (dismissed: boolean) => void;
   repairWarmup: () => Promise<void>;
   repairYtDlpWithHomebrew: () => Promise<void>;
   repairYtDlpWithWinget: () => Promise<void>;

--- a/tests/renderer/app.test.tsx
+++ b/tests/renderer/app.test.tsx
@@ -10,6 +10,7 @@ describe('App renderer', () => {
   beforeEach(() => {
     useAppStore.setState({
       initialized: false,
+      splashDismissed: false,
       settings: null,
       wizardStep: 'url',
       formatsLoading: false,
@@ -102,5 +103,17 @@ describe('App renderer', () => {
     render(<App />);
     expect(await screen.findByLabelText('Download Queue')).toBeInTheDocument();
     expect(await screen.findAllByText(/no downloads yet/i)).not.toHaveLength(0);
+  });
+
+  it('shows the welcome-back greeting while warmup is still running', async () => {
+    const pendingWarmupApi = buildMockAppApi({ settings: { common: { defaultOutputDir: '/tmp', rememberLastOutputDir: false, clipboardWatchEnabled: false, launchCount: 4 } } });
+    vi.mocked(pendingWarmupApi.app.warmUp).mockReturnValue(new Promise(() => undefined));
+    window.appApi = pendingWarmupApi;
+
+    render(<App />);
+
+    expect(await screen.findByTestId('splash-greeting')).toHaveTextContent('Hey, welcome back!');
+    expect(screen.getByTestId('splash-overlay')).toHaveTextContent('Arroxy is warming up');
+    expect(useAppStore.getState().initialized).toBe(false);
   });
 });

--- a/tests/renderer/splash-greeting.test.tsx
+++ b/tests/renderer/splash-greeting.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { shouldShowSplashGreeting } from '@renderer/components/system/splashGreeting.js';
+import { buildAppSettings } from '../shared/settingsFixtures.js';
+
+describe('splash greeting gate', () => {
+  it('hides the welcome-back greeting before settings load and on first launch', () => {
+    expect(shouldShowSplashGreeting(null)).toBe(false);
+    expect(shouldShowSplashGreeting(buildAppSettings({ launchCount: 1 }))).toBe(false);
+  });
+
+  it('shows the welcome-back greeting on every returning launch', () => {
+    expect(shouldShowSplashGreeting(buildAppSettings({ launchCount: 2 }))).toBe(true);
+    expect(shouldShowSplashGreeting(buildAppSettings({ launchCount: 7 }))).toBe(true);
+  });
+});

--- a/tests/renderer/wizard-clipboard-autofill.test.tsx
+++ b/tests/renderer/wizard-clipboard-autofill.test.tsx
@@ -14,6 +14,7 @@ function resetStore(overrides: Partial<ReturnType<typeof useAppStore.getState>> 
   useAppStore.setState({
     initialized: true,
     initializing: false,
+    splashDismissed: true,
     settings: {
       common: {
         defaultOutputDir: '/tmp',
@@ -96,6 +97,24 @@ describe('wizard clipboard confirm dialog', () => {
     });
 
     expect(screen.queryByTestId('clipboard-confirm-dialog')).not.toBeInTheDocument();
+  });
+
+  it('waits until the splash screen has finished dismissing before opening', () => {
+    resetStore({ initialized: true, splashDismissed: false });
+    render(<StepUrlInput />);
+
+    act(() => {
+      clipboardListener!(FRESH_URL);
+    });
+
+    expect(screen.queryByTestId('clipboard-confirm-dialog')).not.toBeInTheDocument();
+
+    act(() => {
+      useAppStore.getState().setSplashDismissed(true);
+    });
+
+    expect(screen.getByTestId('clipboard-confirm-dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('clipboard-confirm-url')).toHaveTextContent(FRESH_URL);
   });
 
   it('"Use URL" applies the URL and closes the dialog', () => {


### PR DESCRIPTION
## Summary
- Show the welcome-back splash greeting for returning launches and hydrate settings before warmup completes.
- Mark the splash as dismissed after its fade-out transition finishes.
- Defer clipboard watcher prompts until the splash has fully dismissed.

## Base branch

- [x] This PR targets `dev`, or it is a maintainer release-candidate PR targeting `main`.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling
- [ ] Docs

## Checks

Run from the repo root and confirm clean:

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run knip`
- [x] `bun run test` (if your change touches code under test)

## Testing

- `bun run check`
- Focused renderer coverage for splash greeting timing and clipboard prompt gating.
- PR checks: CI, E2E cold start, Windows installer smoke, and CodeRabbit.

## Notes for the reviewer

Clipboard watcher events are still retained while the splash is visible; the dialog opens only after the splash overlay transition completes.