### PR TITLE
Clarify profile compatibility labels

### DIFF
--- a/src/renderer/src/components/wizard/DownloadProfileEditor.tsx
+++ b/src/renderer/src/components/wizard/DownloadProfileEditor.tsx
@@ -55,9 +55,9 @@ const PROFILE_ICON_META: Record<DownloadProfileIcon, { label: string; icon: Luci
 
 const PROFILE_ICON_OPTIONS = DOWNLOAD_PROFILE_ICONS.map((value) => ({ value, ...PROFILE_ICON_META[value] }));
 
-const CODEC_OPTIONS: SelectOption<ProfileCodec>[] = [
-  { value: 'best', label: 'Best codec' },
-  { value: 'mp4', label: 'MP4 (H.264)' }
+const VIDEO_COMPATIBILITY_OPTIONS: SelectOption<ProfileCodec>[] = [
+  { value: 'best', label: 'Best native' },
+  { value: 'mp4', label: 'MP4 / Smart TV' }
 ];
 
 const RESOLUTION_OPTIONS: SelectOption<ProfileResolution>[] = [
@@ -79,8 +79,8 @@ const AUDIO_FORMAT_OPTIONS: SelectOption<ProfileAudioFormat>[] = [
 ];
 
 const VIDEO_AUDIO_FORMAT_OPTIONS: SelectOption<Extract<ProfileAudioFormat, 'best' | 'm4a'>>[] = [
-  { value: 'best', label: 'Best' },
-  { value: 'm4a', label: 'M4A' }
+  { value: 'best', label: 'Best native' },
+  { value: 'm4a', label: 'M4A / AAC' }
 ];
 
 const AUDIO_QUALITY_OPTIONS: SelectOption<ProfileAudioQuality>[] = [
@@ -315,6 +315,9 @@ export function DownloadProfileEditor({ initialProfile = null, open, onOpenChang
 
   function setProfileCodec(nextCodec: ProfileCodec): void {
     setCodec(nextCodec);
+    if (mediaMode === 'video-audio') {
+      setAudioFormat(nextCodec === 'mp4' ? 'm4a' : 'best');
+    }
   }
 
   function addSubtitleLanguages(): void {
@@ -449,7 +452,7 @@ export function DownloadProfileEditor({ initialProfile = null, open, onOpenChang
                 {showVideo ? (
                   <ProfilePanel title="Video">
                     <FieldGroup className="gap-3">
-                      <ProfileSelect label="Codec" value={codec} options={CODEC_OPTIONS} onValueChange={setProfileCodec} testId="profiles-editor-video-codec" />
+                      <ProfileSelect label="Compatibility" value={codec} options={VIDEO_COMPATIBILITY_OPTIONS} onValueChange={setProfileCodec} testId="profiles-editor-video-codec" />
                       <ProfileSelect label="Resolution" value={resolution} options={RESOLUTION_OPTIONS} onValueChange={setResolution} testId="profiles-editor-video-resolution" />
                     </FieldGroup>
                   </ProfilePanel>

--- a/src/renderer/src/components/wizard/StepConfirm.tsx
+++ b/src/renderer/src/components/wizard/StepConfirm.tsx
@@ -55,7 +55,7 @@ export function StepConfirm(): JSX.Element {
       return t('playlistPresets.audioFormatBitrate', { format: playlistSelection.format.toUpperCase(), kbps: playlistSelection.bitrateKbps ?? 192 });
     }
     const tierLabel = t(`playlistPresets.tier.${playlistSelection.tier}`);
-    return playlistSelection.codec === 'mp4' ? `MP4 · ${tierLabel}` : tierLabel;
+    return playlistSelection.codec === 'mp4' ? `MP4 / Smart TV · ${tierLabel}` : tierLabel;
   })();
   // "videos" vs "tracks" — pick the unit that matches the actual content.
   // Audio-only extractors (Bandcamp, QQMusic, etc.) and audio playlist

--- a/src/renderer/src/components/wizard/StepPlaylistPresets.tsx
+++ b/src/renderer/src/components/wizard/StepPlaylistPresets.tsx
@@ -109,9 +109,9 @@ export function StepPlaylistPresets(): JSX.Element {
 
           {currentKind === 'video' && (
             <>
-              {/* Codec / format toggle */}
+              {/* Compatibility toggle */}
               <div>
-                <p className={SECTION_LABEL}>{t('playlistPresets.videoFormat.best')}</p>
+                <p className={SECTION_LABEL}>{t('playlistPresets.type.video')}</p>
                 <ItemGroup className="grid grid-cols-2 gap-2">
                   {(['best', 'mp4'] as const).map((codec) => {
                     const selected = currentCodec === codec;

--- a/src/renderer/src/store/queueSlice.ts
+++ b/src/renderer/src/store/queueSlice.ts
@@ -229,7 +229,7 @@ function resolvePlaylistFormatLabel(s: PlaylistSelection): string {
     return i18next.t('playlistPresets.audioFormatBitrate', { format: s.format.toUpperCase(), kbps: s.bitrateKbps ?? 192 });
   }
   const tierLabel = i18next.t(`playlistPresets.tier.${s.tier}` as const);
-  if (s.codec === 'mp4') return `MP4 · ${tierLabel}`;
+  if (s.codec === 'mp4') return `MP4 / Smart TV · ${tierLabel}`;
   return tierLabel;
 }
 

--- a/src/shared/downloadProfiles.ts
+++ b/src/shared/downloadProfiles.ts
@@ -48,6 +48,19 @@ function baseProfile(id: string, name: string, media: DownloadProfile['media'], 
   };
 }
 
+function videoCompatibilityLabel(codec: 'best' | 'mp4'): string {
+  return codec === 'mp4' ? 'MP4 / Smart TV' : 'Best native';
+}
+
+function videoTierLabel(tiers: readonly PlaylistVideoTier[]): string {
+  const tier = tiers[0] ?? 'best';
+  return tier === 'best' ? 'best available' : `up to ${tier}p`;
+}
+
+function videoAudioLabel(format: 'best' | 'm4a'): string {
+  return format === 'm4a' ? 'AAC audio' : 'best native audio';
+}
+
 export const BUILTIN_DOWNLOAD_PROFILES: readonly DownloadProfile[] = [baseProfile('best-quality', 'Best quality', videoAudio('best', ['best']), 'video'), baseProfile('best-2160', '2160p', videoAudio('best', ['2160']), 'video'), baseProfile('best-1440', '1440p', videoAudio('best', ['1440']), 'video'), baseProfile('hd-1080', 'HD 1080p', videoAudio('best', ['1080']), 'video'), baseProfile('balanced', 'Balanced', videoAudio('best', ['720']), 'download'), baseProfile('small-file', 'Small file', videoAudio('best', ['480', '360']), 'clip'), baseProfile('mp4-2160', 'MP4 2160p', videoAudio('mp4', ['2160']), 'video'), baseProfile('mp4-1440', 'MP4 1440p', videoAudio('mp4', ['1440']), 'video'), baseProfile('mp4-1080', 'MP4 1080p', videoAudio('mp4', ['1080']), 'video'), baseProfile('audio-only', 'Audio only', { kind: 'audio-only', audio: { format: 'best' } }, 'audio')] as const;
 
 export const DEFAULT_DOWNLOAD_PROFILE_REF: DownloadProfileRef = { kind: 'builtin', id: 'balanced' };
@@ -197,9 +210,9 @@ export function resolveDownloadProfile(profile: DownloadProfile, ref: DownloadPr
 export function downloadProfileLabel(profile: DownloadProfile): string {
   switch (profile.media.kind) {
     case 'video-audio':
-      return `Video + audio · ${profile.media.codec === 'mp4' ? 'MP4' : 'best codec'} · ${profile.media.tiers.join('/')} · ${profile.media.audio.format === 'm4a' ? 'M4A audio' : 'best audio'}`;
+      return `Video + audio · ${videoCompatibilityLabel(profile.media.codec)} · ${videoTierLabel(profile.media.tiers)} · ${videoAudioLabel(profile.media.audio.format)}`;
     case 'video-only':
-      return `Video, no audio · ${profile.media.codec === 'mp4' ? 'MP4' : 'best codec'} · ${profile.media.tiers.join('/')}`;
+      return `Video, no audio · ${videoCompatibilityLabel(profile.media.codec)} · ${videoTierLabel(profile.media.tiers)}`;
     case 'audio-only':
       if (profile.media.audio.format === 'best') return 'Audio only · best';
       if (profile.media.audio.format === 'wav') return 'Audio only · WAV';

--- a/src/shared/i18n/locales/en.ts
+++ b/src/shared/i18n/locales/en.ts
@@ -611,12 +611,12 @@ const en = {
   playlistPresets: {
     type: { video: 'Video', audio: 'Audio' },
     videoFormat: {
-      best: 'Best codec',
-      mp4: 'MP4 (H.264)'
+      best: 'Best native',
+      mp4: 'MP4 / Smart TV'
     },
     videoFormatDesc: {
-      best: 'Highest available codec per item',
-      mp4: 'H.264 + AAC preferred, MP4 container · best-effort'
+      best: 'Best available container and codecs per item',
+      mp4: 'Prefer H.264 video + AAC audio in MP4 when possible'
     },
     tier: {
       best: 'Best quality',

--- a/tests/renderer/download-profile-editor.test.tsx
+++ b/tests/renderer/download-profile-editor.test.tsx
@@ -6,26 +6,43 @@ import { BUILTIN_DOWNLOAD_PROFILES } from '@shared/downloadProfiles.js';
 import type { DownloadProfile } from '@shared/types.js';
 
 describe('DownloadProfileEditor', () => {
-  it('shows best audio for best-codec video profiles', async () => {
+  it('shows best native audio for best native video profiles', async () => {
     const profile = BUILTIN_DOWNLOAD_PROFILES.find((item) => item.id === 'best-1440');
     expect(profile).toBeDefined();
 
     render(<DownloadProfileEditor initialProfile={profile} open onOpenChange={() => undefined} />);
 
-    expect(await screen.findByTestId('profiles-editor-audio-format')).toHaveTextContent('Best');
+    expect(await screen.findByTestId('profiles-editor-video-codec')).toHaveTextContent('Best native');
+    expect(await screen.findByTestId('profiles-editor-audio-format')).toHaveTextContent('Best native');
     expect(screen.getByTestId('profiles-editor-audio-format')).not.toBeDisabled();
     expect(screen.queryByTestId('profiles-editor-audio-quality')).not.toBeInTheDocument();
   });
 
-  it('shows M4A audio preference for MP4 video profiles', async () => {
+  it('shows M4A/AAC audio preference for MP4/Smart TV video profiles', async () => {
     const profile = BUILTIN_DOWNLOAD_PROFILES.find((item) => item.id === 'mp4-1440');
     expect(profile).toBeDefined();
 
     render(<DownloadProfileEditor initialProfile={profile} open onOpenChange={() => undefined} />);
 
-    expect(await screen.findByTestId('profiles-editor-audio-format')).toHaveTextContent('M4A');
+    expect(await screen.findByTestId('profiles-editor-video-codec')).toHaveTextContent('MP4 / Smart TV');
+    expect(await screen.findByTestId('profiles-editor-audio-format')).toHaveTextContent('M4A / AAC');
     expect(screen.getByTestId('profiles-editor-audio-format')).not.toBeDisabled();
     expect(screen.queryByTestId('profiles-editor-audio-quality')).not.toBeInTheDocument();
+  });
+
+  it('pairs video compatibility with the matching native audio default', async () => {
+    const profile = BUILTIN_DOWNLOAD_PROFILES.find((item) => item.id === 'best-1440');
+    expect(profile).toBeDefined();
+
+    render(<DownloadProfileEditor initialProfile={profile} open onOpenChange={() => undefined} />);
+
+    fireEvent.click(await screen.findByTestId('profiles-editor-video-codec'));
+    fireEvent.click(await screen.findByTestId('profiles-editor-video-codec-option-mp4'));
+    expect(screen.getByTestId('profiles-editor-audio-format')).toHaveTextContent('M4A / AAC');
+
+    fireEvent.click(screen.getByTestId('profiles-editor-video-codec'));
+    fireEvent.click(await screen.findByTestId('profiles-editor-video-codec-option-best'));
+    expect(screen.getByTestId('profiles-editor-audio-format')).toHaveTextContent('Best native');
   });
 
   it('saves the selected video-audio audio preference', async () => {

--- a/tests/renderer/probe-orchestrator.test.tsx
+++ b/tests/renderer/probe-orchestrator.test.tsx
@@ -191,7 +191,7 @@ describe('quickDownload', () => {
     const queued = vi.mocked(api.queue.cmd.add).mock.calls[0]?.[0]?.[0];
     expect(queued).toMatchObject({
       outputDir: '/tmp/first-launch-downloads/Balanced',
-      formatLabel: 'Video + audio · best codec · 720 · best audio',
+      formatLabel: 'Video + audio · Best native · up to 720p · best native audio',
       job: expect.objectContaining({
         kind: 'ranged-format',
         intent: { kind: 'video-audio', codec: 'best', tiers: ['720'], audio: { format: 'best' } }

--- a/tests/unit/download-profiles.test.ts
+++ b/tests/unit/download-profiles.test.ts
@@ -146,7 +146,7 @@ describe('download profiles', () => {
     expect(resolved.subtitles).toEqual({ languages: ['en', 'uk'], mode: 'sidecar', format: 'srt', writeAuto: true });
     expect(resolved.sponsorBlock).toEqual({ mode: 'remove', categories: ['sponsor'] });
     expect(resolved.embed).toEqual({ chapters: true, metadata: true, thumbnail: false, description: true, thumbnailSidecar: true });
-    expect(downloadProfileLabel(profile)).toBe('Video + audio · MP4 · 1080/720 · M4A audio');
+    expect(downloadProfileLabel(profile)).toBe('Video + audio · MP4 / Smart TV · up to 1080p · AAC audio');
   });
 
   it('treats subtitles-only profiles as non-media jobs with sanitized embed and SponsorBlock options', () => {


### PR DESCRIPTION
## Summary
- Rename profile video selection from codec wording to compatibility wording.
- Pair MP4 / Smart TV selection with M4A / AAC audio for video+audio profiles.
- Update profile, playlist, queue, and confirm summaries to use Smart TV compatibility copy.

## Base branch confirmation
- Base branch: `main`.

## Type
- [x] Refactor / UX copy cleanup
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation

## Checks completion
- [x] Focused unit and renderer tests passed.
- [x] `rtk bun run check` passed locally.
- [x] GitHub CI checks passed.
- [x] CodeRabbit produced no actionable review comments.

## Validation
- `rtk bunx vitest run --project jsdom tests/renderer/download-profile-editor.test.tsx tests/renderer/probe-orchestrator.test.tsx tests/renderer/playlist-presets-order.test.tsx --project node tests/unit/download-profiles.test.ts tests/unit/playlist-presets.test.ts tests/unit/ytdlp-playlist-args.test.ts`
- `rtk bun run check`

## User-facing changes
- Renamed video selection labels from codec-focused to compatibility-focused terminology: `Best native` and `MP4 / Smart TV`.
- Audio format automatically pairs with video selection: MP4 / Smart TV now pairs with M4A / AAC audio; Best native pairs with Best native audio.
- Updated label formatting across UI surfaces: playlist presets, profile editor, queue, and confirmation summaries now display MP4 / Smart TV terminology instead of MP4 (H.264).

## Risk areas
- Low. Label changes are localized to UI rendering and human-readable profile descriptions. No IPC, security, build, or dependency impacts.