### PR TITLE
Refine renderer UI with shadcn components

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -15,6 +15,8 @@ import { AboutDialog } from './components/system/AboutDialog.js';
 import { ShareDialog } from './components/system/ShareDialog.js';
 import { useUpdateChannel } from './components/system/useUpdateChannel.js';
 import { shouldShowSplashGreeting } from './components/system/splashGreeting.js';
+import { Button } from './components/ui/button.js';
+import { ButtonGroup } from './components/ui/button-group.js';
 import { TooltipProvider } from './components/ui/tooltip.js';
 import { ScenarioGallery } from './dev/ScenarioGallery.js';
 import { cn } from './lib/utils.js';
@@ -98,38 +100,42 @@ export function App(): JSX.Element {
 
         <footer className="shrink-0 flex items-center justify-between border-t border-border px-4 h-7">
           <div className="flex items-center gap-1">
-            <button type="button" onClick={() => setUiZoom(uiZoom - ZOOM_STEP)} disabled={uiZoom <= ZOOM_MIN} className="w-4 h-4 flex items-center justify-center text-muted-foreground hover:text-foreground/80 disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-base leading-none" aria-label={t('app.zoomOut')}>
-              −
-            </button>
-            <span className="text-[13px] text-muted-foreground w-8 text-center tabular-nums">{Math.round(uiZoom * 100)}%</span>
-            <button type="button" onClick={() => setUiZoom(uiZoom + ZOOM_STEP)} disabled={uiZoom >= ZOOM_MAX} className="w-4 h-4 flex items-center justify-center text-muted-foreground hover:text-foreground/80 disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-base leading-none" aria-label={t('app.zoomIn')}>
-              +
-            </button>
-            <div className="w-px h-3 bg-border mx-1" aria-hidden />
+            <ButtonGroup>
+              <Button type="button" variant="ghost" size="icon-xs" onClick={() => setUiZoom(uiZoom - ZOOM_STEP)} disabled={uiZoom <= ZOOM_MIN} className="size-5 text-base leading-none text-muted-foreground" aria-label={t('app.zoomOut')}>
+                −
+              </Button>
+              <Button type="button" variant="ghost" size="icon-xs" onClick={() => setUiZoom(uiZoom + ZOOM_STEP)} disabled={uiZoom >= ZOOM_MAX} className="size-5 text-base leading-none text-muted-foreground" aria-label={t('app.zoomIn')}>
+                +
+              </Button>
+            </ButtonGroup>
+            <span className="w-8 text-center text-[13px] text-muted-foreground tabular-nums">{Math.round(uiZoom * 100)}%</span>
+            <div className="mx-1 h-3 w-px bg-border" aria-hidden />
             <ThemeToggle />
-            <div className="w-px h-3 bg-border mx-1" aria-hidden />
+            <div className="mx-1 h-3 w-px bg-border" aria-hidden />
             <LanguagePicker />
           </div>
           <div className="flex items-center gap-3">
-            <button type="button" className="inline-flex items-center h-5 leading-none text-[11px] text-muted-foreground/50 tabular-nums select-none hover:text-foreground/80 transition-colors" onClick={() => setAboutDialogOpen(true)} title={t('about.openTitle')} data-testid="btn-about-version">
+            <Button type="button" variant="ghost" size="xs" className="h-5 px-0 text-[11px] text-muted-foreground/50 tabular-nums" onClick={() => setAboutDialogOpen(true)} title={t('about.openTitle')} data-testid="btn-about-version">
               v{window.appVersion}
-            </button>
-            <button type="button" className="inline-flex items-center h-5 leading-none gap-1.5 text-[13px] text-muted-foreground hover:text-foreground/80 transition-colors" onClick={() => setAboutDialogOpen(true)} title={t('about.openTitle')} data-testid="btn-about">
-              <Info size={14} />
+            </Button>
+            <Button type="button" variant="ghost" size="xs" className="h-5 px-0 text-[13px] text-muted-foreground" onClick={() => setAboutDialogOpen(true)} title={t('about.openTitle')} data-testid="btn-about">
+              <Info data-icon="inline-start" aria-hidden />
               {t('about.button')}
-            </button>
-            <button type="button" className="inline-flex items-center justify-center w-5 h-5 leading-none text-muted-foreground hover:text-foreground/80 transition-colors" onClick={copyDebugInfo} title={debugCopied ? t('app.debugCopied') : t('app.debugCopyTitle')} data-testid="btn-debug">
-              <Bug size={14} />
-            </button>
-            <button type="button" className="inline-flex items-center h-5 leading-none gap-1.5 text-[13px] text-muted-foreground hover:text-foreground/80 transition-colors" onClick={() => openShareDialog('footer')} title={t('share.footerTooltip')} data-testid="btn-share">
-              <Share2 size={14} />
+            </Button>
+            <Button type="button" variant="ghost" size="icon-xs" className="size-5 text-muted-foreground" onClick={copyDebugInfo} title={debugCopied ? t('app.debugCopied') : t('app.debugCopyTitle')} data-testid="btn-debug">
+              <Bug aria-hidden />
+            </Button>
+            <Button type="button" variant="ghost" size="xs" className="h-5 px-0 text-[13px] text-muted-foreground" onClick={() => openShareDialog('footer')} title={t('share.footerTooltip')} data-testid="btn-share">
+              <Share2 data-icon="inline-start" aria-hidden />
               {t('share.footerLabel')}
-            </button>
+            </Button>
             <div className="relative inline-flex items-center h-5">
               <FeedbackNudge visible={showNudge} message={t('app.feedbackNudge')} />
-              <button
+              <Button
                 type="button"
-                className={cn('inline-flex items-center h-5 leading-none text-[13px] transition-colors', showNudge ? 'feedback-btn-nudging' : 'text-muted-foreground hover:text-foreground/80')}
+                variant="ghost"
+                size="xs"
+                className={cn('h-5 px-0 text-[13px]', showNudge ? 'feedback-btn-nudging' : 'text-muted-foreground')}
                 onClick={() => {
                   setShowNudge(false);
                   void window.appApi.shell.openExternal(FEEDBACK_URL);
@@ -137,11 +143,11 @@ export function App(): JSX.Element {
                 data-testid="btn-feedback"
               >
                 {t('app.feedback')}
-              </button>
+              </Button>
             </div>
-            <button type="button" className="inline-flex items-center h-5 leading-none text-[13px] text-muted-foreground hover:text-foreground/80 transition-colors" onClick={() => void openLogs()} data-testid="btn-logs">
+            <Button type="button" variant="ghost" size="xs" className="h-5 px-0 text-[13px] text-muted-foreground" onClick={() => void openLogs()} data-testid="btn-logs">
               {t('app.logs')}
-            </button>
+            </Button>
           </div>
         </footer>
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -122,7 +122,7 @@ export function App(): JSX.Element {
               <Info data-icon="inline-start" aria-hidden />
               {t('about.button')}
             </Button>
-            <Button type="button" variant="ghost" size="icon-xs" className="size-5 text-muted-foreground" onClick={copyDebugInfo} title={debugCopied ? t('app.debugCopied') : t('app.debugCopyTitle')} data-testid="btn-debug">
+            <Button type="button" variant="ghost" size="icon-xs" className="size-5 text-muted-foreground" onClick={copyDebugInfo} title={debugCopied ? t('app.debugCopied') : t('app.debugCopyTitle')} aria-label={debugCopied ? t('app.debugCopied') : t('app.debugCopyTitle')} data-testid="btn-debug">
               <Bug aria-hidden />
             </Button>
             <Button type="button" variant="ghost" size="xs" className="h-5 px-0 text-[13px] text-muted-foreground" onClick={() => openShareDialog('footer')} title={t('share.footerTooltip')} data-testid="btn-share">

--- a/src/renderer/src/components/shared/LimitRatePicker.tsx
+++ b/src/renderer/src/components/shared/LimitRatePicker.tsx
@@ -4,8 +4,9 @@ import { useTranslation } from 'react-i18next';
 import { AlertTriangle } from 'lucide-react';
 import { limitRateSchema } from '@shared/schemas.js';
 import { useAppStore } from '../../store/useAppStore.js';
+import { Alert, AlertDescription } from '../ui/alert.js';
 import { Input } from '../ui/input.js';
-import { RadioOption } from '../ui/radio-option.js';
+import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group.js';
 import { LIMIT_RATE_PRESETS, formatLimitRateLabel, isLimitRatePreset } from './limitRateFormat.js';
 
 interface Props {
@@ -40,6 +41,7 @@ export function LimitRatePicker({ value, onChange }: Props): JSX.Element {
   const customMode = editingCustom || !valueIsPreset;
   const trimmedDraft = customDraft.trim();
   const customError = customMode && trimmedDraft !== '' && !limitRateSchema.safeParse(trimmedDraft).success;
+  const selectedToggleValue = customMode ? 'custom' : (value ?? 'off');
 
   const pickPreset = (preset: string | undefined): void => {
     setEditingCustom(false);
@@ -62,18 +64,38 @@ export function LimitRatePicker({ value, onChange }: Props): JSX.Element {
   return (
     <div className="flex flex-col gap-2" data-testid="limit-rate-picker">
       {hasActiveDownloads && (
-        <p className="flex items-start gap-1.5 text-[11px] text-amber-500" data-testid="limit-rate-active-warning">
-          <AlertTriangle size={12} className="mt-0.5 shrink-0" />
-          <span>{t('wizard.url.limitRate.activeWarning')}</span>
-        </p>
+        <Alert variant="warning" data-testid="limit-rate-active-warning">
+          <AlertTriangle />
+          <AlertDescription className="text-[11px]">{t('wizard.url.limitRate.activeWarning')}</AlertDescription>
+        </Alert>
       )}
-      <div className="grid grid-cols-2 gap-0.5" role="radiogroup" aria-label={t('wizard.url.limitRate.label')}>
-        <RadioOption label={t('wizard.url.limitRate.off')} checked={!customMode && value === undefined} onClick={() => pickPreset(undefined)} />
+      <ToggleGroup
+        value={[selectedToggleValue]}
+        onValueChange={(values) => {
+          const next = values[0];
+          if (!next) return;
+          if (next === 'custom') {
+            setEditingCustom(true);
+            return;
+          }
+          pickPreset(next === 'off' ? undefined : next);
+        }}
+        aria-label={t('wizard.url.limitRate.label')}
+        spacing={1}
+        className="grid w-full grid-cols-2 items-stretch"
+      >
+        <ToggleGroupItem value="off" className="h-7 justify-start px-2 text-[12px] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]">
+          {t('wizard.url.limitRate.off')}
+        </ToggleGroupItem>
         {LIMIT_RATE_PRESETS.map((preset) => (
-          <RadioOption key={preset} label={formatLimitRateLabel(preset)} checked={!customMode && value === preset} onClick={() => pickPreset(preset)} />
+          <ToggleGroupItem key={preset} value={preset} className="h-7 justify-start px-2 text-[12px] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]">
+            {formatLimitRateLabel(preset)}
+          </ToggleGroupItem>
         ))}
-        <RadioOption label={t('wizard.url.limitRate.custom')} checked={customMode} onClick={() => setEditingCustom(true)} />
-      </div>
+        <ToggleGroupItem value="custom" className="h-7 justify-start px-2 text-[12px] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]">
+          {t('wizard.url.limitRate.custom')}
+        </ToggleGroupItem>
+      </ToggleGroup>
       {customMode && (
         <div className="flex flex-col gap-1">
           <Input type="text" value={customDraft} onChange={(e) => handleCustomChange(e.target.value)} placeholder={t('wizard.url.limitRate.customPlaceholder')} className="h-8 text-[12px] font-mono" aria-invalid={customError} data-testid="limit-rate-custom-input" />

--- a/src/renderer/src/components/shared/LimitRatePicker.tsx
+++ b/src/renderer/src/components/shared/LimitRatePicker.tsx
@@ -84,15 +84,15 @@ export function LimitRatePicker({ value, onChange }: Props): JSX.Element {
         spacing={1}
         className="grid w-full grid-cols-2 items-stretch"
       >
-        <ToggleGroupItem value="off" className="h-7 justify-start px-2 text-[12px] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]">
+        <ToggleGroupItem value="off" className="h-7 justify-start px-2 text-[12px] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)] aria-pressed:shadow-[0_0_0_2px_var(--brand-dim)]">
           {t('wizard.url.limitRate.off')}
         </ToggleGroupItem>
         {LIMIT_RATE_PRESETS.map((preset) => (
-          <ToggleGroupItem key={preset} value={preset} className="h-7 justify-start px-2 text-[12px] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]">
+          <ToggleGroupItem key={preset} value={preset} className="h-7 justify-start px-2 text-[12px] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)] aria-pressed:shadow-[0_0_0_2px_var(--brand-dim)]">
             {formatLimitRateLabel(preset)}
           </ToggleGroupItem>
         ))}
-        <ToggleGroupItem value="custom" className="h-7 justify-start px-2 text-[12px] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]">
+        <ToggleGroupItem value="custom" className="h-7 justify-start px-2 text-[12px] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)] aria-pressed:shadow-[0_0_0_2px_var(--brand-dim)]">
           {t('wizard.url.limitRate.custom')}
         </ToggleGroupItem>
       </ToggleGroup>

--- a/src/renderer/src/components/system/UpdateBanner.tsx
+++ b/src/renderer/src/components/system/UpdateBanner.tsx
@@ -1,8 +1,13 @@
 import { useState, type JSX } from 'react';
-import { Copy, CopyCheck } from 'lucide-react';
+import { Copy, CopyCheck, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { UpdateAvailablePayload } from '@shared/types.js';
+import { Button, buttonVariants } from '../ui/button.js';
+import { ButtonGroup } from '../ui/button-group.js';
+import { Spinner } from '../ui/spinner.js';
 import { resolveAction } from './updateBannerAction.js';
+
+const DOWNLOAD_URL = 'https://arroxy.orionus.dev/';
 
 interface Props {
   info: UpdateAvailablePayload;
@@ -12,8 +17,6 @@ interface Props {
   onDownload: () => void;
   onDismiss: () => void;
 }
-
-const DOWNLOAD_URL = 'https://arroxy.orionus.dev/';
 
 export function UpdateBanner({ info, installing, installError, onInstall, onDownload, onDismiss }: Props): JSX.Element {
   const { t } = useTranslation();
@@ -27,7 +30,7 @@ export function UpdateBanner({ info, installing, installError, onInstall, onDown
   }
 
   return (
-    <div className="banner-slide-in shrink-0 flex items-center justify-between gap-3 px-4 h-9 border-b border-border" style={{ background: 'var(--brand-dim)' }} data-testid="update-banner">
+    <div className="banner-slide-in flex h-9 shrink-0 items-center justify-between gap-3 border-b border-border bg-[var(--brand-dim)] px-4" data-testid="update-banner">
       <span className="text-[13px] text-foreground/80 truncate" data-testid="update-banner-message">
         {installError ? (
           <span className="text-destructive font-medium">
@@ -35,31 +38,28 @@ export function UpdateBanner({ info, installing, installError, onInstall, onDown
           </span>
         ) : (
           <>
-            <span className="font-semibold" style={{ color: 'var(--brand)' }}>
-              {t('update.appVersion', { version: info.version })}
-            </span>{' '}
-            {t('update.isAvailable')} <span className="text-muted-foreground">{t('update.youHave', { currentVersion: info.currentVersion })}</span>
+            <span className="font-semibold text-[var(--brand)]">{t('update.appVersion', { version: info.version })}</span> {t('update.isAvailable')} <span className="text-muted-foreground">{t('update.youHave', { currentVersion: info.currentVersion })}</span>
           </>
         )}
       </span>
 
-      <div className="flex items-center gap-2 shrink-0">
+      <ButtonGroup className="shrink-0">
         {action.kind === 'install' && (
-          <button type="button" onClick={onInstall} disabled={installing} className="flex items-center gap-1.5 text-[13px] font-medium px-2.5 py-1 rounded-md transition-colors disabled:opacity-60" style={{ background: 'var(--brand)', color: '#fff' }}>
-            {installing && <span className="inline-block w-3 h-3 rounded-full border border-white/30 border-t-white animate-spin" aria-hidden />}
+          <Button type="button" onClick={onInstall} disabled={installing} size="sm" className="bg-[var(--brand)] text-white hover:bg-[var(--brand)]/90">
+            {installing ? <Spinner data-icon="inline-start" /> : null}
             {installing ? t('update.downloading') : installError ? t('update.retry') : t('update.install')}
-          </button>
+          </Button>
         )}
 
         {action.kind === 'download' && (
           <a
             href={DOWNLOAD_URL}
+            data-slot="button"
+            className={buttonVariants({ size: 'sm', className: 'bg-[var(--brand)] text-white hover:bg-[var(--brand)]/90' })}
             onClick={(e) => {
               e.preventDefault();
               onDownload();
             }}
-            className="text-[13px] font-medium px-2.5 py-1 rounded-md transition-colors"
-            style={{ background: 'var(--brand)', color: '#fff' }}
           >
             {t('update.download')}
           </a>
@@ -70,16 +70,16 @@ export function UpdateBanner({ info, installing, installError, onInstall, onDown
             <code className="font-mono text-[12px] px-1.5 py-0.5 rounded bg-muted text-foreground" data-testid="update-command">
               {action.cmd}
             </code>
-            <button type="button" onClick={() => void handleCopy(action.cmd)} className="w-5 h-5 flex items-center justify-center text-muted-foreground hover:text-foreground/80 transition-colors" aria-label={copied ? t('update.copied') : t('update.copy')}>
-              {copied ? <CopyCheck size={14} /> : <Copy size={14} />}
-            </button>
+            <Button type="button" variant="ghost" size="icon-xs" onClick={() => void handleCopy(action.cmd)} aria-label={copied ? t('update.copied') : t('update.copy')}>
+              {copied ? <CopyCheck aria-hidden /> : <Copy aria-hidden />}
+            </Button>
           </>
         )}
 
-        <button type="button" onClick={onDismiss} className="w-5 h-5 flex items-center justify-center text-muted-foreground hover:text-foreground/80 transition-colors text-base leading-none" aria-label={t('update.dismiss')}>
-          ×
-        </button>
-      </div>
+        <Button type="button" variant="ghost" size="icon-xs" onClick={onDismiss} aria-label={t('update.dismiss')}>
+          <X aria-hidden />
+        </Button>
+      </ButtonGroup>
     </div>
   );
 }

--- a/src/renderer/src/components/ui/empty.tsx
+++ b/src/renderer/src/components/ui/empty.tsx
@@ -1,0 +1,42 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import type * as React from 'react';
+
+import { cn } from '@renderer/lib/utils.js';
+
+function Empty({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="empty" className={cn('flex w-full min-w-0 flex-1 flex-col items-center justify-center gap-4 rounded-xl border-dashed p-6 text-center text-balance', className)} {...props} />;
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="empty-header" className={cn('flex max-w-sm flex-col items-center gap-2', className)} {...props} />;
+}
+
+const emptyMediaVariants = cva('mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0', {
+  variants: {
+    variant: {
+      default: 'bg-transparent',
+      icon: "flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-4"
+    }
+  },
+  defaultVariants: {
+    variant: 'default'
+  }
+});
+
+function EmptyMedia({ className, variant = 'default', ...props }: React.ComponentProps<'div'> & VariantProps<typeof emptyMediaVariants>) {
+  return <div data-slot="empty-icon" data-variant={variant} className={cn(emptyMediaVariants({ variant, className }))} {...props} />;
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="empty-title" className={cn('font-heading text-sm font-medium tracking-tight', className)} {...props} />;
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<'p'>) {
+  return <div data-slot="empty-description" className={cn('text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary', className)} {...props} />;
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="empty-content" className={cn('flex w-full max-w-sm min-w-0 flex-col items-center gap-2.5 text-sm text-balance', className)} {...props} />;
+}
+
+export { Empty, EmptyHeader, EmptyTitle, EmptyDescription, EmptyContent, EmptyMedia };

--- a/src/renderer/src/components/ui/empty.tsx
+++ b/src/renderer/src/components/ui/empty.tsx
@@ -32,7 +32,7 @@ function EmptyTitle({ className, ...props }: React.ComponentProps<'div'>) {
 }
 
 function EmptyDescription({ className, ...props }: React.ComponentProps<'p'>) {
-  return <div data-slot="empty-description" className={cn('text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary', className)} {...props} />;
+  return <p data-slot="empty-description" className={cn('text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary', className)} {...props} />;
 }
 
 function EmptyContent({ className, ...props }: React.ComponentProps<'div'>) {

--- a/src/renderer/src/components/ui/radio-option.tsx
+++ b/src/renderer/src/components/ui/radio-option.tsx
@@ -1,5 +1,6 @@
 import type { JSX, ReactNode, KeyboardEvent } from 'react';
 import { cn } from '@renderer/lib/utils.js';
+import { Item, ItemActions, ItemContent, ItemMedia, ItemTitle } from './item.js';
 import { RadioDot } from './radio-dot.js';
 
 interface Props {
@@ -22,11 +23,15 @@ export function RadioOption({ label, checked, onClick, disabled, adornment, meta
   const effectiveChecked = checked && !disabled;
 
   return (
-    <div role="radio" aria-checked={effectiveChecked} aria-disabled={disabled ?? undefined} tabIndex={disabled ? -1 : 0} onClick={disabled ? undefined : onClick} onKeyDown={handleKeyDown} className={cn('flex items-center gap-[7px] py-[5px] px-[8px] rounded-[6px] transition-colors', disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer', effectiveChecked ? 'bg-[var(--brand-dim)]' : !disabled && 'hover:bg-accent', className)}>
-      <RadioDot checked={effectiveChecked} />
-      {adornment}
-      <span className={cn('text-[13px]', effectiveChecked ? 'font-semibold text-[var(--brand)]' : 'font-medium text-muted-foreground', labelClassName)}>{label}</span>
-      {meta}
-    </div>
+    <Item role="radio" aria-checked={effectiveChecked} aria-disabled={disabled ?? undefined} tabIndex={disabled ? -1 : 0} onClick={disabled ? undefined : onClick} onKeyDown={handleKeyDown} size="xs" className={cn('flex-nowrap rounded-md border-transparent px-2 py-[5px]', disabled ? 'cursor-not-allowed opacity-40' : 'cursor-pointer', effectiveChecked ? 'bg-[var(--brand-dim)]' : !disabled && 'hover:bg-accent', className)}>
+      <ItemMedia className="gap-[7px]">
+        <RadioDot checked={effectiveChecked} />
+        {adornment}
+      </ItemMedia>
+      <ItemContent className="min-w-0 flex-none">
+        <ItemTitle className={cn('text-[13px]', effectiveChecked ? 'font-semibold text-[var(--brand)]' : 'font-medium text-muted-foreground', labelClassName)}>{label}</ItemTitle>
+      </ItemContent>
+      {meta ? <ItemActions className="ms-auto min-w-0">{meta}</ItemActions> : null}
+    </Item>
   );
 }

--- a/src/renderer/src/components/ui/radio-option.tsx
+++ b/src/renderer/src/components/ui/radio-option.tsx
@@ -23,7 +23,7 @@ export function RadioOption({ label, checked, onClick, disabled, adornment, meta
   const effectiveChecked = checked && !disabled;
 
   return (
-    <Item role="radio" aria-checked={effectiveChecked} aria-disabled={disabled ?? undefined} tabIndex={disabled ? -1 : 0} onClick={disabled ? undefined : onClick} onKeyDown={handleKeyDown} size="xs" className={cn('flex-nowrap rounded-md border-transparent px-2 py-[5px]', disabled ? 'cursor-not-allowed opacity-40' : 'cursor-pointer', effectiveChecked ? 'bg-[var(--brand-dim)]' : !disabled && 'hover:bg-accent', className)}>
+    <Item role="radio" aria-checked={effectiveChecked} aria-disabled={disabled ?? undefined} tabIndex={disabled ? -1 : 0} onClick={disabled ? undefined : onClick} onKeyDown={handleKeyDown} size="xs" className={cn('flex-nowrap rounded-md border-transparent px-2 py-[5px]', disabled ? 'cursor-not-allowed opacity-40' : 'cursor-pointer', effectiveChecked ? 'bg-[var(--brand-dim)] shadow-[0_0_0_2px_var(--brand-dim)]' : !disabled && 'hover:bg-accent', className)}>
       <ItemMedia className="gap-[7px]">
         <RadioDot checked={effectiveChecked} />
         {adornment}

--- a/src/renderer/src/components/ui/spinner.tsx
+++ b/src/renderer/src/components/ui/spinner.tsx
@@ -1,0 +1,10 @@
+import { Loader2Icon } from 'lucide-react';
+import type * as React from 'react';
+
+import { cn } from '@renderer/lib/utils.js';
+
+function Spinner({ className, ...props }: React.ComponentProps<'svg'>) {
+  return <Loader2Icon role="status" aria-label="Loading" className={cn('size-4 animate-spin', className)} {...props} />;
+}
+
+export { Spinner };

--- a/src/renderer/src/components/ui/table.tsx
+++ b/src/renderer/src/components/ui/table.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import type * as React from 'react';
+
+import { cn } from '@renderer/lib/utils.js';
+
+function Table({ className, ...props }: React.ComponentProps<'table'>) {
+  return (
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
+      <table data-slot="table" className={cn('w-full caption-bottom text-sm', className)} {...props} />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+  return <thead data-slot="table-header" className={cn('[&_tr]:border-b', className)} {...props} />;
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
+  return <tbody data-slot="table-body" className={cn('[&_tr:last-child]:border-0', className)} {...props} />;
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
+  return <tfoot data-slot="table-footer" className={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0', className)} {...props} />;
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+  return <tr data-slot="table-row" className={cn('border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted', className)} {...props} />;
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
+  return <th data-slot="table-head" className={cn('h-10 px-2 text-start align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pe-0', className)} {...props} />;
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+  return <td data-slot="table-cell" className={cn('p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pe-0', className)} {...props} />;
+}
+
+function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) {
+  return <caption data-slot="table-caption" className={cn('mt-4 text-sm text-muted-foreground', className)} {...props} />;
+}
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/src/renderer/src/components/ui/tabs.tsx
+++ b/src/renderer/src/components/ui/tabs.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@renderer/lib/utils.js';
 
 function Tabs({ className, orientation = 'horizontal', ...props }: TabsPrimitive.Root.Props) {
-  return <TabsPrimitive.Root data-slot="tabs" data-orientation={orientation} className={cn('group/tabs flex gap-2 data-horizontal:flex-col', className)} {...props} />;
+  return <TabsPrimitive.Root data-slot="tabs" orientation={orientation} data-orientation={orientation} className={cn('group/tabs flex gap-2 data-horizontal:flex-col', className)} {...props} />;
 }
 
 const tabsListVariants = cva('group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none', {

--- a/src/renderer/src/components/ui/tabs.tsx
+++ b/src/renderer/src/components/ui/tabs.tsx
@@ -1,0 +1,34 @@
+import { Tabs as TabsPrimitive } from '@base-ui/react/tabs';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@renderer/lib/utils.js';
+
+function Tabs({ className, orientation = 'horizontal', ...props }: TabsPrimitive.Root.Props) {
+  return <TabsPrimitive.Root data-slot="tabs" data-orientation={orientation} className={cn('group/tabs flex gap-2 data-horizontal:flex-col', className)} {...props} />;
+}
+
+const tabsListVariants = cva('group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none', {
+  variants: {
+    variant: {
+      default: 'bg-muted',
+      line: 'gap-1 bg-transparent'
+    }
+  },
+  defaultVariants: {
+    variant: 'default'
+  }
+});
+
+function TabsList({ className, variant = 'default', ...props }: TabsPrimitive.List.Props & VariantProps<typeof tabsListVariants>) {
+  return <TabsPrimitive.List data-slot="tabs-list" data-variant={variant} className={cn(tabsListVariants({ variant }), className)} {...props} />;
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return <TabsPrimitive.Tab data-slot="tabs-trigger" className={cn("relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pe-1 has-data-[icon=inline-start]:ps-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4", 'group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent', 'data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground', 'after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-end-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100', className)} {...props} />;
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return <TabsPrimitive.Panel data-slot="tabs-content" className={cn('flex-1 text-sm outline-none', className)} {...props} />;
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };

--- a/src/renderer/src/components/wizard/BulkUrlDialog.tsx
+++ b/src/renderer/src/components/wizard/BulkUrlDialog.tsx
@@ -5,8 +5,13 @@ import { parseBulkUrls } from '@shared/bulkUrls.js';
 import type { BulkUrlRejectReason } from '@shared/types.js';
 import { bulkLogger } from '@renderer/lib/bulkLogger.js';
 import { cn } from '@renderer/lib/utils.js';
+import { Badge } from '../ui/badge.js';
 import { Button } from '../ui/button.js';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog.js';
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '../ui/empty.js';
+import { Field, FieldLabel } from '../ui/field.js';
+import { Item, ItemActions, ItemContent, ItemGroup, ItemMedia, ItemTitle } from '../ui/item.js';
+import { Textarea } from '../ui/textarea.js';
 import { useAppStore } from '../../store/useAppStore.js';
 
 export interface BulkUrlDialogActionState {
@@ -82,12 +87,12 @@ export function BulkUrlDialog({ open, onOpenChange, initialRaw = '', renderActio
           <DialogDescription>{t('wizard.bulk.description')}</DialogDescription>
         </DialogHeader>
 
-        <div className="flex flex-col gap-2">
-          <label htmlFor="bulk-url-textarea" className="text-[11px] font-bold uppercase tracking-[0.12em] text-[var(--text-subtle)]">
+        <Field className="gap-2">
+          <FieldLabel htmlFor="bulk-url-textarea" className="text-[11px] font-bold uppercase tracking-[0.12em] text-[var(--text-subtle)]">
             {t('wizard.bulk.textareaLabel')}
-          </label>
-          <textarea ref={textareaRef} id="bulk-url-textarea" data-testid="bulk-url-textarea" value={raw} onChange={(event) => setRaw(event.target.value)} placeholder={t('wizard.bulk.textareaPlaceholder')} spellCheck={false} className="min-h-32 w-full resize-y rounded-lg border border-input bg-transparent px-2.5 py-2 text-sm outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30" />
-        </div>
+          </FieldLabel>
+          <Textarea ref={textareaRef} id="bulk-url-textarea" data-testid="bulk-url-textarea" value={raw} onChange={(event) => setRaw(event.target.value)} placeholder={t('wizard.bulk.textareaPlaceholder')} spellCheck={false} className="min-h-32 resize-y text-sm" />
+        </Field>
 
         <div className="flex items-center gap-3 text-xs text-muted-foreground">
           <span>
@@ -105,25 +110,42 @@ export function BulkUrlDialog({ open, onOpenChange, initialRaw = '', renderActio
 
         <div className="max-h-48 overflow-y-auto rounded-md border border-border bg-secondary/50" data-testid="bulk-url-preview">
           {parsed.accepted.length === 0 && parsed.rejected.length === 0 ? (
-            <p className="px-3 py-4 text-center text-xs text-muted-foreground">{t('wizard.bulk.emptyPreview')}</p>
+            <Empty className="min-h-28 rounded-none border-0 p-4">
+              <EmptyHeader>
+                <EmptyTitle>{t('wizard.bulk.emptyPreview')}</EmptyTitle>
+                <EmptyDescription>{t('wizard.bulk.needsAtLeastOne')}</EmptyDescription>
+              </EmptyHeader>
+            </Empty>
           ) : (
-            <div className="divide-y divide-border">
+            <ItemGroup className="gap-0 divide-y divide-border" data-size="xs">
               {parsed.accepted.map((item, index) => (
-                <div key={item.url} className="flex items-center gap-2 px-3 py-2 text-xs">
-                  <Link2 size={13} className="shrink-0 text-[var(--brand)]" />
-                  <span className="shrink-0 font-mono text-muted-foreground">{index + 1}</span>
-                  <span className="min-w-0 flex-1 truncate font-mono text-foreground/80">{item.url}</span>
-                  <span className="shrink-0 rounded-full border border-border px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] text-muted-foreground">{item.kind}</span>
-                </div>
+                <Item key={item.url} size="xs" className="rounded-none border-0 px-3 py-2">
+                  <ItemMedia variant="icon" className="text-[var(--brand)]">
+                    <Link2 />
+                  </ItemMedia>
+                  <span className="shrink-0 font-mono text-xs text-muted-foreground">{index + 1}</span>
+                  <ItemContent className="min-w-0">
+                    <ItemTitle className="block w-full truncate font-mono text-xs font-normal text-foreground/80">{item.url}</ItemTitle>
+                  </ItemContent>
+                  <ItemActions>
+                    <Badge variant="outline" className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
+                      {item.kind}
+                    </Badge>
+                  </ItemActions>
+                </Item>
               ))}
               {parsed.rejected.map((item) => (
-                <div key={item.id} className="flex items-center gap-2 px-3 py-2 text-xs text-amber-500">
-                  <AlertTriangle size={13} className="shrink-0" />
-                  <span className="min-w-0 flex-1 truncate font-mono">{item.url}</span>
-                  <span className="shrink-0">{t(REJECT_I18N[item.reason])}</span>
-                </div>
+                <Item key={item.id} size="xs" className="rounded-none border-0 px-3 py-2 text-[var(--color-status-paused)]">
+                  <ItemMedia variant="icon">
+                    <AlertTriangle />
+                  </ItemMedia>
+                  <ItemContent className="min-w-0">
+                    <ItemTitle className="block w-full truncate font-mono text-xs font-normal">{item.url}</ItemTitle>
+                  </ItemContent>
+                  <ItemActions className="text-xs">{t(REJECT_I18N[item.reason])}</ItemActions>
+                </Item>
               ))}
-            </div>
+            </ItemGroup>
           )}
         </div>
 
@@ -138,11 +160,11 @@ export function BulkUrlDialog({ open, onOpenChange, initialRaw = '', renderActio
                 {t('common.cancel')}
               </Button>
               <Button type="button" onClick={() => void confirmQuick()} disabled={!canConfirm || quickPreparing} data-testid="bulk-url-quick-confirm" className="shadow-[0_4px_14px_var(--brand-glow)] disabled:shadow-none">
-                <Download size={16} />
+                <Download data-icon="inline-start" />
                 {quickPreparing ? t('wizard.url.quickPreparing') : 'Quick Download'}
               </Button>
               <Button type="button" variant="outline" onClick={confirm} disabled={!canConfirm} data-testid="bulk-url-confirm">
-                <WandSparkles size={16} />
+                <WandSparkles data-icon="inline-start" />
                 Interactive Download
               </Button>
             </>

--- a/src/renderer/src/components/wizard/BulkUrlDialog.tsx
+++ b/src/renderer/src/components/wizard/BulkUrlDialog.tsx
@@ -88,7 +88,7 @@ export function BulkUrlDialog({ open, onOpenChange, initialRaw = '', renderActio
         </DialogHeader>
 
         <Field className="gap-2">
-          <FieldLabel htmlFor="bulk-url-textarea" className="text-[11px] font-bold uppercase tracking-[0.12em] text-[var(--text-subtle)]">
+          <FieldLabel htmlFor="bulk-url-textarea" className="text-[9px] font-bold uppercase tracking-[0.12em] text-[var(--text-subtle)]">
             {t('wizard.bulk.textareaLabel')}
           </FieldLabel>
           <Textarea ref={textareaRef} id="bulk-url-textarea" data-testid="bulk-url-textarea" value={raw} onChange={(event) => setRaw(event.target.value)} placeholder={t('wizard.bulk.textareaPlaceholder')} spellCheck={false} className="min-h-32 resize-y text-sm" />

--- a/src/renderer/src/components/wizard/DownloadProfileEditor.tsx
+++ b/src/renderer/src/components/wizard/DownloadProfileEditor.tsx
@@ -5,8 +5,10 @@ import { DEFAULT_AUDIO_BITRATE, DOWNLOAD_PROFILE_ICONS } from '@shared/schemas.j
 import type { DownloadProfile, DownloadProfileIcon } from '@shared/types.js';
 import { isValidSubfolder, safeFolderName } from '@shared/subfolder.js';
 import { cn } from '@renderer/lib/utils.js';
+import { Alert, AlertDescription } from '../ui/alert.js';
 import { Badge } from '../ui/badge.js';
 import { Button } from '../ui/button.js';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card.js';
 import { Checkbox } from '../ui/checkbox.js';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog.js';
 import { Field, FieldContent, FieldDescription, FieldGroup, FieldLabel, FieldTitle } from '../ui/field.js';
@@ -189,13 +191,13 @@ function defaultProfileSubfolderName(name: string): string {
 
 function ProfilePanel({ title, description, children, className }: { title: string; description?: string; children: ReactNode; className?: string }): JSX.Element {
   return (
-    <section className={cn('rounded-lg border border-[var(--border-strong)] bg-card/40 p-3', className)}>
-      <div className="mb-3">
-        <h3 className="text-sm font-semibold leading-tight">{title}</h3>
-        {description ? <p className="mt-1 text-[12px] leading-snug text-[var(--text-subtle)]">{description}</p> : null}
-      </div>
-      {children}
-    </section>
+    <Card size="sm" className={cn('gap-3 rounded-lg border-[var(--border-strong)] bg-card/40 py-3', className)}>
+      <CardHeader className="gap-1 px-3">
+        <CardTitle className="text-sm font-semibold leading-tight">{title}</CardTitle>
+        {description ? <CardDescription className="text-[12px] leading-snug text-[var(--text-subtle)]">{description}</CardDescription> : null}
+      </CardHeader>
+      <CardContent className="px-3">{children}</CardContent>
+    </Card>
   );
 }
 
@@ -236,9 +238,9 @@ function ProfileHelpTooltip({ label, children }: { label: string; children: Reac
     <Tooltip>
       <TooltipTrigger
         render={(props) => (
-          <button type="button" {...props} aria-label={`${label} help`} className="inline-flex size-5 items-center justify-center rounded text-[var(--text-subtle)] hover:bg-muted hover:text-foreground">
-            <Info className="size-3.5" aria-hidden />
-          </button>
+          <Button {...props} type="button" variant="ghost" size="icon-xs" aria-label={`${label} help`} className="text-[var(--text-subtle)] hover:text-foreground">
+            <Info aria-hidden />
+          </Button>
         )}
       />
       <TooltipContent className="max-w-[18rem] leading-snug">{children}</TooltipContent>
@@ -392,30 +394,29 @@ export function DownloadProfileEditor({ initialProfile = null, open, onOpenChang
                         />
                       </InputGroupAddon>
                       <PopoverContent align="start" sideOffset={6} className="w-40" data-testid="profiles-editor-icon-menu">
-                        <div className="grid grid-cols-3 gap-1.5" role="radiogroup" aria-label="Profile icon">
+                        <ToggleGroup
+                          variant="outline"
+                          value={[profileIcon]}
+                          onValueChange={(value) => {
+                            const next = value[0] as DownloadProfileIcon | undefined;
+                            if (!next) return;
+                            setProfileIcon(next);
+                            setProfileIconPickerOpen(false);
+                          }}
+                          spacing={1}
+                          className="grid w-full grid-cols-3 gap-1.5"
+                          aria-label="Profile icon"
+                        >
                           {PROFILE_ICON_OPTIONS.map((option) => {
                             const Icon = option.icon;
-                            const selected = profileIcon === option.value;
                             return (
-                              <button
-                                key={option.value}
-                                type="button"
-                                role="radio"
-                                aria-checked={selected}
-                                title={option.label}
-                                onClick={() => {
-                                  setProfileIcon(option.value);
-                                  setProfileIconPickerOpen(false);
-                                }}
-                                className={cn('grid h-10 place-items-center rounded-lg border bg-background/25 text-[var(--text-subtle)] transition-colors hover:border-[var(--border-strong)] hover:text-foreground', selected ? 'border-[var(--brand)] bg-[var(--brand-dim)] text-[var(--brand)] shadow-[0_0_0_2px_var(--brand-dim)]' : 'border-border')}
-                                data-testid={`profiles-editor-icon-${option.value}`}
-                              >
+                              <ToggleGroupItem key={option.value} value={option.value} title={option.label} className="grid h-10 place-items-center rounded-lg border bg-background/25 p-0 text-[var(--text-subtle)] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)] hover:border-[var(--border-strong)] hover:text-foreground" data-testid={`profiles-editor-icon-${option.value}`}>
                                 <Icon aria-hidden />
                                 <span className="sr-only">{option.label}</span>
-                              </button>
+                              </ToggleGroupItem>
                             );
                           })}
-                        </div>
+                        </ToggleGroup>
                       </PopoverContent>
                     </Popover>
                     <InputGroupInput id="profile-name" value={profileName} onChange={(event) => changeProfileName(event.target.value)} data-testid="profiles-editor-name" />
@@ -471,7 +472,11 @@ export function DownloadProfileEditor({ initialProfile = null, open, onOpenChang
                 ) : null}
               </div>
 
-              {subtitlesOnly ? <div className="rounded-md border border-[var(--brand)]/40 bg-[var(--brand-dim)] px-3 py-2 text-[12px] text-[var(--text-subtle)]">This profile queues subtitle files only. Video, audio, SponsorBlock, and media conversion are skipped.</div> : null}
+              {subtitlesOnly ? (
+                <Alert variant="info" className="py-2 text-[12px]">
+                  <AlertDescription className="text-[12px]">This profile queues subtitle files only. Video, audio, SponsorBlock, and media conversion are skipped.</AlertDescription>
+                </Alert>
+              ) : null}
 
               <ProfilePanel title="Subtitles">
                 <FieldGroup className="gap-3">
@@ -503,7 +508,9 @@ export function DownloadProfileEditor({ initialProfile = null, open, onOpenChang
                   </Field>
 
                   {!effectiveSubtitleEnabled ? (
-                    <div className="rounded-md border border-border bg-background/25 px-3 py-2 text-[12px] leading-snug text-[var(--text-subtle)]">No subtitle files or embedded subtitle tracks will be requested for this profile.</div>
+                    <Alert variant="info" className="py-2 text-[12px]">
+                      <AlertDescription className="text-[12px]">No subtitle files or embedded subtitle tracks will be requested for this profile.</AlertDescription>
+                    </Alert>
                   ) : (
                     <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.65fr)]">
                       <Field className="gap-1.5">
@@ -513,10 +520,12 @@ export function DownloadProfileEditor({ initialProfile = null, open, onOpenChang
                         <div className="flex min-h-8 flex-wrap items-center gap-1.5 rounded-lg border border-input bg-background/30 px-2 py-1">
                           {subtitleLanguages.length > 0 ? (
                             subtitleLanguages.map((code) => (
-                              <button key={code} type="button" onClick={() => removeSubtitleLanguage(code)} className="inline-flex h-6 items-center gap-1 rounded-full bg-secondary px-2 text-[11px] font-semibold text-secondary-foreground hover:bg-muted" aria-label={`Remove ${code}`}>
+                              <Badge key={code} variant="secondary" className="h-6 gap-1 px-2 text-[11px] font-semibold">
                                 <span>{code}</span>
-                                <X className="size-3" aria-hidden />
-                              </button>
+                                <Button type="button" variant="ghost" size="icon-xs" onClick={() => removeSubtitleLanguage(code)} className="-me-1 size-4 rounded-full p-0" aria-label={`Remove ${code}`}>
+                                  <X data-icon="inline-start" aria-hidden />
+                                </Button>
+                              </Badge>
                             ))
                           ) : (
                             <span className="px-1 text-[11px] italic text-[var(--text-subtle)]">No languages selected</span>
@@ -632,7 +641,7 @@ export function DownloadProfileEditor({ initialProfile = null, open, onOpenChang
                   {subfolderInvalid ? <FieldDescription className="text-[12px] text-destructive">Use a valid folder name without / \ : * ? &quot; &lt; &gt; |.</FieldDescription> : null}
                 </Field>
 
-                <section className="rounded-lg border border-border bg-background/25 p-3">
+                <Card size="sm" className="rounded-lg bg-background/25 px-3 py-3">
                   <div className="mb-2 flex items-center justify-between gap-3">
                     <h4 className="text-sm font-semibold">Output options</h4>
                     <Badge variant="outline">{outputEnabledCount} enabled</Badge>
@@ -643,9 +652,9 @@ export function DownloadProfileEditor({ initialProfile = null, open, onOpenChang
                     <ProfileSwitchRow id="profile-output-description" label="Save description" description={OUTPUT_OPTION_DESCRIPTIONS.description} checked={saveDescription} onCheckedChange={setSaveDescription} />
                     <ProfileSwitchRow id="profile-output-thumbnail" label="Save thumbnail" description={OUTPUT_OPTION_DESCRIPTIONS.thumbnail} checked={saveThumbnail} onCheckedChange={setSaveThumbnail} />
                   </div>
-                </section>
+                </Card>
 
-                <section className="rounded-lg border border-border bg-background/25 p-3">
+                <Card size="sm" className="rounded-lg bg-background/25 px-3 py-3">
                   <div className="mb-2 flex items-center justify-between gap-3">
                     <h4 className="text-sm font-semibold">SponsorBlock</h4>
                     <Badge variant="outline">{showVideo ? optionLabel(SPONSOR_BLOCK_OPTIONS, sponsorBlockMode) : 'Skipped'}</Badge>
@@ -666,9 +675,11 @@ export function DownloadProfileEditor({ initialProfile = null, open, onOpenChang
                       ))}
                     </ToggleGroup>
                   ) : (
-                    <p className="text-[12px] leading-snug text-[var(--text-subtle)]">Skipped for this output type.</p>
+                    <Alert variant="info" className="py-2 text-[12px]">
+                      <AlertDescription className="text-[12px]">Skipped for this output type.</AlertDescription>
+                    </Alert>
                   )}
-                </section>
+                </Card>
 
                 <ProfileSelect label="Playlist probe cap" value={playlistCap} options={PLAYLIST_CAP_OPTIONS} onValueChange={setPlaylistCap} testId="profiles-editor-playlist-cap" />
               </FieldGroup>

--- a/src/renderer/src/components/wizard/DownloadProfilesHome.tsx
+++ b/src/renderer/src/components/wizard/DownloadProfilesHome.tsx
@@ -8,11 +8,14 @@ import { bulkLogger } from '@renderer/lib/bulkLogger.js';
 import { notify } from '@renderer/lib/notify.js';
 import { cn } from '@renderer/lib/utils.js';
 import { useAppStore } from '../../store/useAppStore.js';
+import { Alert, AlertDescription } from '../ui/alert.js';
 import { Badge } from '../ui/badge.js';
 import { Button } from '../ui/button.js';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card.js';
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from '../ui/input-group.js';
 import { Popover, PopoverContent, PopoverDescription, PopoverHeader, PopoverTitle, PopoverTrigger } from '../ui/popover.js';
 import { Separator } from '../ui/separator.js';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs.js';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js';
 import { BulkUrlDialog } from './BulkUrlDialog.js';
 import { DownloadProfileEditor } from './DownloadProfileEditor.js';
@@ -23,6 +26,7 @@ import downloadingImg from '../../assets/Downloading.png';
 
 type ProfilesTab = 'download' | 'profiles' | 'settings';
 type DownloadInputType = 'Single URL' | 'Playlist URL' | 'Channel URL' | 'Search URL' | 'URL' | 'Unknown URL';
+const PROFILE_TABS = ['download', 'profiles', 'settings'] as const satisfies readonly ProfilesTab[];
 
 const ICONS: Record<DownloadProfileIcon, LucideIcon> = {
   archive: Archive,
@@ -41,6 +45,10 @@ function tabFromHash(hash = window.location.hash): ProfilesTab {
   if (value === 'profile' || value === 'profiles') return 'profiles';
   if (value === 'setting' || value === 'settings') return 'settings';
   return 'download';
+}
+
+function isProfilesTab(value: unknown): value is ProfilesTab {
+  return typeof value === 'string' && PROFILE_TABS.includes(value as ProfilesTab);
 }
 
 function tabHash(tab: ProfilesTab): string {
@@ -234,88 +242,108 @@ export function DownloadProfilesHome(): JSX.Element {
 
   return (
     <div className="wizard-step mx-auto flex w-full max-w-6xl flex-col gap-4 pb-5" data-testid="download-profiles-home">
-      <nav className="flex flex-wrap items-center gap-5 border-b border-border/80" aria-label="Download profile navigation" data-testid="profiles-tabs">
-        <TabButton active={activeTab === 'download'} icon={Download} label="Download" onClick={() => selectTab('download')} />
-        <TabButton active={activeTab === 'profiles'} icon={Users} label="Profiles" onClick={() => selectTab('profiles')} />
-        <TabButton active={activeTab === 'settings'} icon={Settings} label="Settings" onClick={() => selectTab('settings')} />
-      </nav>
+      <Tabs
+        value={activeTab}
+        onValueChange={(value) => {
+          if (isProfilesTab(value)) selectTab(value);
+        }}
+        className="gap-4"
+      >
+        <TabsList variant="line" className="flex h-11 w-full justify-start gap-5 border-b border-border/80 p-0" aria-label="Download profile navigation" data-testid="profiles-tabs">
+          <TabsTrigger value="download" className="h-11 flex-none rounded-none border-b-2 px-1 data-active:border-[var(--brand)]">
+            <Download data-icon="inline-start" aria-hidden />
+            Download
+          </TabsTrigger>
+          <TabsTrigger value="profiles" className="h-11 flex-none rounded-none border-b-2 px-1 data-active:border-[var(--brand)]">
+            <Users data-icon="inline-start" aria-hidden />
+            Profiles
+          </TabsTrigger>
+          <TabsTrigger value="settings" className="h-11 flex-none rounded-none border-b-2 px-1 data-active:border-[var(--brand)]">
+            <Settings data-icon="inline-start" aria-hidden />
+            Settings
+          </TabsTrigger>
+        </TabsList>
 
-      {activeTab === 'download' ? (
-        <>
-          <section className="rounded-lg border border-[var(--border-strong)] bg-card/40 p-4" data-testid="profiles-download-panel">
-            <div className="flex items-center gap-3">
+        <TabsContent value="download" className="flex flex-col gap-4">
+          <Card className="rounded-lg border-[var(--border-strong)] bg-card/40" data-testid="profiles-download-panel">
+            <CardHeader className="flex-row items-center gap-3">
               <div className="grid size-12 shrink-0 place-items-center rounded-lg border border-[var(--brand)]/40 bg-[var(--brand-dim)] text-[var(--brand)]">
                 <Download aria-hidden />
               </div>
               <div className="min-w-0">
-                <h2 className="text-xl font-semibold leading-tight">Download input</h2>
-                <p className="mt-1 text-[12px] text-[var(--text-subtle)]">Enter a URL to start your download.</p>
+                <CardTitle className="text-xl font-semibold leading-tight">Download input</CardTitle>
+                <CardDescription className="mt-1 text-[12px] text-[var(--text-subtle)]">Enter a URL to start your download.</CardDescription>
               </div>
-            </div>
-
-            <InputGroup className="mt-5 h-12 border-[var(--border-strong)] bg-background/35">
-              <InputGroupAddon align="inline-start">
-                <Link2 aria-hidden />
-              </InputGroupAddon>
-              <InputGroupInput ref={inputRef} type="url" value={wizardUrl} onChange={(event) => setWizardUrl(event.target.value)} onKeyDown={handleKeyDown} onPaste={handlePaste} placeholder="Paste a URL..." spellCheck={false} data-testid="profiles-main-input" className="text-[13px]" />
-              {hasInput ? (
-                <InputGroupAddon align="inline-end">
-                  <InputGroupButton type="button" size="icon-sm" aria-label="Clear URL" onClick={handleClearUrl} data-testid="url-clear">
-                    <X aria-hidden />
-                  </InputGroupButton>
+            </CardHeader>
+            <CardContent>
+              <InputGroup className="mt-5 h-12 border-[var(--border-strong)] bg-background/35">
+                <InputGroupAddon align="inline-start">
+                  <Link2 aria-hidden />
                 </InputGroupAddon>
-              ) : null}
-            </InputGroup>
+                <InputGroupInput ref={inputRef} type="url" value={wizardUrl} onChange={(event) => setWizardUrl(event.target.value)} onKeyDown={handleKeyDown} onPaste={handlePaste} placeholder="Paste a URL..." spellCheck={false} data-testid="profiles-main-input" className="text-[13px]" />
+                {hasInput ? (
+                  <InputGroupAddon align="inline-end">
+                    <InputGroupButton type="button" size="icon-sm" aria-label="Clear URL" onClick={handleClearUrl} data-testid="url-clear">
+                      <X aria-hidden />
+                    </InputGroupButton>
+                  </InputGroupAddon>
+                ) : null}
+              </InputGroup>
 
-            <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-subtle)]">
-              <Badge variant={hasInput ? 'secondary' : 'outline'} className={cn(!hasInput && 'text-[var(--text-subtle)]')}>
-                {hasInput ? 'URL entered' : 'Waiting for URL'}
-              </Badge>
-              {inputType ? (
-                <Badge variant="outline" className="border-[var(--brand)]/40 bg-[var(--brand-dim)] text-[var(--brand)]">
-                  {inputType}
+              <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-subtle)]">
+                <Badge variant={hasInput ? 'secondary' : 'outline'} className={cn(!hasInput && 'text-[var(--text-subtle)]')}>
+                  {hasInput ? 'URL entered' : 'Waiting for URL'}
                 </Badge>
+                {inputType ? (
+                  <Badge variant="outline" className="border-[var(--brand)]/40 bg-[var(--brand-dim)] text-[var(--brand)]">
+                    {inputType}
+                  </Badge>
+                ) : null}
+              </div>
+
+              <Separator className="my-5" />
+
+              <QuickProfileCard
+                activeProfile={activeProfile}
+                disabled={!hasInput || quickPreparing}
+                menuOpen={profileMenuOpen}
+                onDownload={() => void quickDownload()}
+                onEditProfile={() => openEditor(activeProfile)}
+                onManageProfiles={() => {
+                  setProfileMenuOpen(false);
+                  selectTab('profiles');
+                }}
+                onMenuOpenChange={setProfileMenuOpen}
+                onNewProfile={() => {
+                  setProfileMenuOpen(false);
+                  openEditor(null);
+                }}
+                onPickProfile={activateProfile}
+                profiles={profiles}
+              />
+
+              {quickDownloadStatus === 'error' ? (
+                <Alert variant="warning" className="mt-2 py-2" data-testid="quick-download-feedback">
+                  <AlertDescription className="text-[11px]">Quick Download failed: {quickErrorText}</AlertDescription>
+                </Alert>
               ) : null}
-            </div>
 
-            <Separator className="my-5" />
-
-            <QuickProfileCard
-              activeProfile={activeProfile}
-              disabled={!hasInput || quickPreparing}
-              menuOpen={profileMenuOpen}
-              onDownload={() => void quickDownload()}
-              onEditProfile={() => openEditor(activeProfile)}
-              onManageProfiles={() => {
-                setProfileMenuOpen(false);
-                selectTab('profiles');
-              }}
-              onMenuOpenChange={setProfileMenuOpen}
-              onNewProfile={() => {
-                setProfileMenuOpen(false);
-                openEditor(null);
-              }}
-              onPickProfile={activateProfile}
-              profiles={profiles}
-            />
-
-            {quickDownloadStatus === 'error' ? (
-              <p className="mt-2 text-[11px] text-amber-500" data-testid="quick-download-feedback">
-                Quick Download failed: {quickErrorText}
-              </p>
-            ) : null}
-
-            <div className="mt-3 grid gap-2">
-              <ActionRow disabled={!hasInput || quickPreparing} icon={Wand2} title="Interactive Download" description="Review and customize options before downloading." onClick={() => void submitUrl()} testId="profiles-interactive-download" />
-              <ActionRow icon={ListPlus} title="Bulk URLs" description="Choose Quick or Interactive for batch downloads." onClick={() => setBulkOpen(true)} testId="profiles-bulk-urls" />
-            </div>
-          </section>
+              <div className="mt-3 grid gap-2">
+                <ActionRow disabled={!hasInput || quickPreparing} icon={Wand2} title="Interactive Download" description="Review and customize options before downloading." onClick={() => void submitUrl()} testId="profiles-interactive-download" />
+                <ActionRow icon={ListPlus} title="Bulk URLs" description="Choose Quick or Interactive for batch downloads." onClick={() => setBulkOpen(true)} testId="profiles-bulk-urls" />
+              </div>
+            </CardContent>
+          </Card>
           {showMascotHelp ? <DownloadMascotHelpCard help={mascotHelp} onDismiss={() => setDismissedMascotKey(mascotHelp.key)} /> : null}
-        </>
-      ) : null}
+        </TabsContent>
 
-      {activeTab === 'profiles' ? <ProfilesTab activeProfile={activeProfile} onEdit={openEditor} onPick={activateProfile} onRemove={(profile) => void removeDownloadProfile(profile.id)} profiles={profiles} profilesPrefs={profilesPrefs} /> : null}
-      {activeTab === 'settings' ? <DownloadProfilesSettingsTab /> : null}
+        <TabsContent value="profiles">
+          <ProfilesTab activeProfile={activeProfile} onEdit={openEditor} onPick={activateProfile} onRemove={(profile) => void removeDownloadProfile(profile.id)} profiles={profiles} profilesPrefs={profilesPrefs} />
+        </TabsContent>
+        <TabsContent value="settings">
+          <DownloadProfilesSettingsTab />
+        </TabsContent>
+      </Tabs>
 
       {bulkOpen ? <BulkUrlDialog open={bulkOpen} onOpenChange={setBulkOpen} initialRaw="" /> : null}
       <DownloadProfileEditor key={editorSessionId} initialProfile={editingProfile} open={editorOpen} onOpenChange={setEditorOpen} onSave={(profile) => saveDownloadProfile(profile)} />
@@ -326,7 +354,7 @@ export function DownloadProfilesHome(): JSX.Element {
 
 function DownloadMascotHelpCard({ help, onDismiss }: { help: ReturnType<typeof downloadMascotHelp>; onDismiss: () => void }): JSX.Element {
   return (
-    <aside className="flex w-full max-w-[34rem] items-center gap-4 rounded-lg border border-[var(--border-strong)] bg-background/30 px-4 py-3" data-testid="profiles-mascot-help">
+    <Card className="flex w-full max-w-[34rem] flex-row items-center gap-4 rounded-lg border-[var(--border-strong)] bg-background/30 px-4 py-3" data-testid="profiles-mascot-help">
       <img src={help.image} alt="" aria-hidden className="size-20 shrink-0 object-contain" />
       <div className="min-w-0 flex-1">
         <p className="text-sm font-semibold text-foreground">{help.title}</p>
@@ -342,16 +370,7 @@ function DownloadMascotHelpCard({ help, onDismiss }: { help: ReturnType<typeof d
       <Button type="button" variant="ghost" size="sm" onClick={onDismiss} className="shrink-0 text-[var(--brand)] hover:text-[var(--brand)]" data-testid="profiles-mascot-dismiss">
         Got it
       </Button>
-    </aside>
-  );
-}
-
-function TabButton({ active, icon: Icon, label, onClick }: { active: boolean; icon: LucideIcon; label: string; onClick: () => void }): JSX.Element {
-  return (
-    <button type="button" aria-current={active ? 'page' : undefined} className={cn('inline-flex h-11 items-center gap-2 border-b-2 px-1 text-sm transition-colors', active ? 'border-[var(--brand)] font-semibold text-foreground' : 'border-transparent font-medium text-[var(--text-subtle)] hover:text-foreground')} onClick={onClick}>
-      <Icon data-icon="inline-start" aria-hidden />
-      {label}
-    </button>
+    </Card>
   );
 }
 
@@ -467,18 +486,18 @@ function ActionRow({ description, disabled = false, icon: Icon, onClick, testId,
 
 function ProfilesTab({ activeProfile, onEdit, onPick, onRemove, profiles, profilesPrefs }: { activeProfile: DownloadProfile; onEdit: (profile: DownloadProfile | null) => void; onPick: (profile: DownloadProfile) => void; onRemove: (profile: DownloadProfile) => void; profiles: DownloadProfile[]; profilesPrefs: DownloadProfilesPrefs | undefined }): JSX.Element {
   return (
-    <section className="rounded-lg border border-[var(--border-strong)] bg-card/40 p-4" data-testid="profiles-manage-tab">
-      <div className="flex flex-wrap items-center justify-between gap-3">
+    <Card className="rounded-lg border-[var(--border-strong)] bg-card/40" data-testid="profiles-manage-tab">
+      <CardHeader className="flex-row flex-wrap items-center justify-between gap-3">
         <div>
-          <h2 className="text-xl font-semibold leading-tight">Download Profiles</h2>
-          <p className="mt-1 text-[12px] text-[var(--text-subtle)]">Create, select, edit, or remove reusable download setups.</p>
+          <CardTitle className="text-xl font-semibold leading-tight">Download Profiles</CardTitle>
+          <CardDescription className="mt-1 text-[12px] text-[var(--text-subtle)]">Create, select, edit, or remove reusable download setups.</CardDescription>
         </div>
         <Button type="button" onClick={() => onEdit(null)} className="shadow-[0_4px_14px_var(--brand-glow)]">
           <Plus data-icon="inline-start" />
           New profile
         </Button>
-      </div>
-      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+      </CardHeader>
+      <CardContent className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
         {profiles.map((profile) => {
           const Icon = ICONS[profile.icon];
           const active = activeProfile.id === profile.id;
@@ -514,7 +533,7 @@ function ProfilesTab({ activeProfile, onEdit, onPick, onRemove, profiles, profil
             </article>
           );
         })}
-      </div>
-    </section>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/renderer/src/components/wizard/DownloadProfilesSettingsTab.tsx
+++ b/src/renderer/src/components/wizard/DownloadProfilesSettingsTab.tsx
@@ -4,7 +4,9 @@ import { DEFAULTS } from '@shared/constants.js';
 import type { CookiesBrowser, CookiesMode } from '@shared/types.js';
 import { formatHomeRelativePath } from '@renderer/lib/utils.js';
 import { useAppStore } from '../../store/useAppStore.js';
+import { Alert, AlertDescription } from '../ui/alert.js';
 import { Button } from '../ui/button.js';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card.js';
 import { Field, FieldContent, FieldDescription, FieldGroup, FieldLabel, FieldTitle } from '../ui/field.js';
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from '../ui/input-group.js';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover.js';
@@ -31,13 +33,13 @@ const COOKIES_CHROME_URL = 'https://chromewebstore.google.com/detail/get-cookies
 
 function SettingsPanel({ title, description, children }: { title: string; description?: string; children: ReactNode }): JSX.Element {
   return (
-    <section className="rounded-lg border border-[var(--border-strong)] bg-card/40 p-3">
-      <div className="mb-3">
-        <h3 className="text-sm font-semibold leading-tight">{title}</h3>
-        {description ? <p className="mt-1 text-[12px] leading-snug text-[var(--text-subtle)]">{description}</p> : null}
-      </div>
-      {children}
-    </section>
+    <Card size="sm" className="gap-3 rounded-lg border-[var(--border-strong)] bg-card/40 py-3">
+      <CardHeader className="gap-1 px-3">
+        <CardTitle className="text-sm font-semibold leading-tight">{title}</CardTitle>
+        {description ? <CardDescription className="text-[12px] leading-snug text-[var(--text-subtle)]">{description}</CardDescription> : null}
+      </CardHeader>
+      <CardContent className="px-3">{children}</CardContent>
+    </Card>
   );
 }
 
@@ -240,9 +242,9 @@ export function DownloadProfilesSettingsTab(): JSX.Element {
 
 function WarningText({ text }: { text: string }): JSX.Element {
   return (
-    <p className="flex items-center gap-1.5 text-[11px] text-amber-500">
-      <AlertTriangle size={12} />
-      {text}
-    </p>
+    <Alert variant="warning" className="py-1.5">
+      <AlertTriangle aria-hidden />
+      <AlertDescription className="text-[11px]">{text}</AlertDescription>
+    </Alert>
   );
 }

--- a/src/renderer/src/components/wizard/NetworkPacingSettings.tsx
+++ b/src/renderer/src/components/wizard/NetworkPacingSettings.tsx
@@ -5,6 +5,7 @@ import { NETWORK_PACING_PRESET_VALUES } from '@shared/constants.js';
 import { pacingConcurrentFragmentsSchema, pacingSleepSecondsSchema } from '@shared/schemas.js';
 import type { NetworkPacingPreset } from '@shared/types.js';
 import { useAppStore } from '../../store/useAppStore.js';
+import { Button } from '../ui/button.js';
 import { Field, FieldContent, FieldDescription, FieldGroup, FieldLabel, FieldTitle } from '../ui/field.js';
 import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from '../ui/input-group.js';
 import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group.js';
@@ -25,9 +26,9 @@ function HelpTooltip({ children, testId, label }: { children: ReactNode; testId:
     <Tooltip>
       <TooltipTrigger
         render={(props) => (
-          <button {...props} type="button" aria-label={label} className="inline-flex h-5 w-5 items-center justify-center rounded text-[var(--text-subtle)] hover:bg-muted hover:text-foreground" data-testid={testId}>
-            <Info size={13} />
-          </button>
+          <Button {...props} type="button" variant="ghost" size="icon-xs" aria-label={label} className="text-[var(--text-subtle)] hover:text-foreground" data-testid={testId}>
+            <Info aria-hidden />
+          </Button>
         )}
       />
       <TooltipContent className="max-w-[18rem] leading-snug">{children}</TooltipContent>

--- a/src/renderer/src/components/wizard/PlaylistProbeLimitSelector.tsx
+++ b/src/renderer/src/components/wizard/PlaylistProbeLimitSelector.tsx
@@ -108,7 +108,7 @@ export function PlaylistProbeLimitSelector({ testId = 'playlist-probe-limit', cl
                 {formatOptionLabel(preset)}
               </SelectItem>
             ))}
-            <SelectItem value={CUSTOM_VALUE} onClick={openCustomDialogAfterSelectClose} data-testid={`${testId}-option-custom`}>
+            <SelectItem value={CUSTOM_VALUE} onClick={() => handleValueChange(CUSTOM_VALUE)} data-testid={`${testId}-option-custom`}>
               {t('wizard.url.playlistProbeLimit.custom')}
             </SelectItem>
           </SelectGroup>

--- a/src/renderer/src/components/wizard/PlaylistScopeControl.tsx
+++ b/src/renderer/src/components/wizard/PlaylistScopeControl.tsx
@@ -15,6 +15,10 @@ import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group.js';
 
 type ItemMode = PlaylistScope['items']['kind'];
 
+function isItemMode(value: string | undefined): value is ItemMode {
+  return value === 'app-limit' || value === 'first' || value === 'range';
+}
+
 interface PlaylistScopeControlProps {
   onApplyScope?: (scope: PlaylistScope) => Promise<void> | void;
   applyLabel?: string;
@@ -130,8 +134,8 @@ export function PlaylistScopeControl({ onApplyScope, applyLabel, pendingLabel, d
               <ToggleGroup
                 value={[mode]}
                 onValueChange={(values) => {
-                  const next = values[0] as ItemMode | undefined;
-                  if (next) setMode(next);
+                  const next = values[0];
+                  if (isItemMode(next)) setMode(next);
                 }}
                 aria-label={copy(t, 'wizard.url.playlistScope.itemsLabel', 'Items to load')}
                 orientation="vertical"

--- a/src/renderer/src/components/wizard/PlaylistScopeControl.tsx
+++ b/src/renderer/src/components/wizard/PlaylistScopeControl.tsx
@@ -6,10 +6,12 @@ import { playlistScopeSchema, PLAYLIST_PROBE_LIMIT_MAX, PLAYLIST_PROBE_LIMIT_MIN
 import type { PlaylistScope } from '@shared/types.js';
 import { resolvePlaylistProbeLimit } from '@shared/networkPacing.js';
 import { useAppStore } from '../../store/useAppStore.js';
+import { Alert, AlertDescription } from '../ui/alert.js';
 import { Button } from '../ui/button.js';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog.js';
+import { Field, FieldLabel } from '../ui/field.js';
 import { Input } from '../ui/input.js';
-import { RadioOption } from '../ui/radio-option.js';
+import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group.js';
 
 type ItemMode = PlaylistScope['items']['kind'];
 
@@ -103,7 +105,6 @@ export function PlaylistScopeControl({ onApplyScope, applyLabel, pendingLabel, d
           type="button"
           size="sm"
           variant="outline"
-          className="gap-1.5"
           onClick={() => {
             syncDraftsFromScope();
             setOpen(true);
@@ -111,7 +112,7 @@ export function PlaylistScopeControl({ onApplyScope, applyLabel, pendingLabel, d
           data-testid="playlist-scope-change"
           disabled={disabled || applying}
         >
-          <SlidersHorizontal size={14} />
+          <SlidersHorizontal data-icon="inline-start" />
           {copy(t, 'wizard.url.playlistScope.change', 'Change')}
         </Button>
       </div>
@@ -124,13 +125,29 @@ export function PlaylistScopeControl({ onApplyScope, applyLabel, pendingLabel, d
           </DialogHeader>
 
           <div className="flex flex-col gap-3">
-            <div className="flex flex-col gap-1.5">
-              <span className="text-[11px] font-medium text-[var(--text-subtle)]">{copy(t, 'wizard.url.playlistScope.itemsLabel', 'Items to load')}</span>
-              <div className="grid gap-1" role="radiogroup" aria-label={copy(t, 'wizard.url.playlistScope.itemsLabel', 'Items to load')}>
-                <RadioOption label={copy(t, 'wizard.url.playlistScope.appLimit', 'Use app limit: {{count}}', { count: appLimit })} checked={mode === 'app-limit'} onClick={() => setMode('app-limit')} />
-                <RadioOption label={copy(t, 'wizard.url.playlistScope.first', 'First')} checked={mode === 'first'} onClick={() => setMode('first')} />
+            <Field className="gap-1.5">
+              <FieldLabel className="text-[11px] font-medium text-[var(--text-subtle)]">{copy(t, 'wizard.url.playlistScope.itemsLabel', 'Items to load')}</FieldLabel>
+              <ToggleGroup
+                value={[mode]}
+                onValueChange={(values) => {
+                  const next = values[0] as ItemMode | undefined;
+                  if (next) setMode(next);
+                }}
+                aria-label={copy(t, 'wizard.url.playlistScope.itemsLabel', 'Items to load')}
+                orientation="vertical"
+                spacing={1}
+                className="grid w-full items-stretch"
+              >
+                <ToggleGroupItem value="app-limit" className="h-7 justify-start px-2 text-[12px] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]">
+                  {copy(t, 'wizard.url.playlistScope.appLimit', 'Use app limit: {{count}}', { count: appLimit })}
+                </ToggleGroupItem>
+                <ToggleGroupItem value="first" className="h-7 justify-start px-2 text-[12px] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]">
+                  {copy(t, 'wizard.url.playlistScope.first', 'First')}
+                </ToggleGroupItem>
                 {mode === 'first' && <Input type="number" min={PLAYLIST_PROBE_LIMIT_MIN} max={PLAYLIST_PROBE_LIMIT_MAX} value={firstDraft} onChange={(event) => setFirstDraft(event.target.value)} className="h-8 font-mono" data-testid="playlist-scope-first-input" />}
-                <RadioOption label={copy(t, 'wizard.url.playlistScope.range', 'Range')} checked={mode === 'range'} onClick={() => setMode('range')} />
+                <ToggleGroupItem value="range" className="h-7 justify-start px-2 text-[12px] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]">
+                  {copy(t, 'wizard.url.playlistScope.range', 'Range')}
+                </ToggleGroupItem>
                 {mode === 'range' && (
                   <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
                     <Input type="number" min={PLAYLIST_PROBE_LIMIT_MIN} max={PLAYLIST_PROBE_LIMIT_MAX} value={fromDraft} onChange={(event) => setFromDraft(event.target.value)} className="h-8 font-mono" data-testid="playlist-scope-range-from" />
@@ -138,13 +155,17 @@ export function PlaylistScopeControl({ onApplyScope, applyLabel, pendingLabel, d
                     <Input type="number" min={PLAYLIST_PROBE_LIMIT_MIN} max={PLAYLIST_PROBE_LIMIT_MAX} value={toDraft} onChange={(event) => setToDraft(event.target.value)} className="h-8 font-mono" data-testid="playlist-scope-range-to" />
                   </div>
                 )}
-              </div>
-            </div>
-            {!parsedScope && <p className="text-[11px] text-amber-500">{copy(t, 'wizard.url.playlistScope.invalid', 'Use whole item numbers from 1 to 5000, with the start no higher than the end.')}</p>}
+              </ToggleGroup>
+            </Field>
+            {!parsedScope && (
+              <Alert variant="warning">
+                <AlertDescription className="text-[11px]">{copy(t, 'wizard.url.playlistScope.invalid', 'Use whole item numbers from 1 to 5000, with the start no higher than the end.')}</AlertDescription>
+              </Alert>
+            )}
             {applyError ? (
-              <p className="text-[11px] text-amber-500" data-testid="playlist-scope-apply-error">
-                {applyError}
-              </p>
+              <Alert variant="warning" data-testid="playlist-scope-apply-error">
+                <AlertDescription className="text-[11px]">{applyError}</AlertDescription>
+              </Alert>
             ) : null}
           </div>
 

--- a/src/renderer/src/components/wizard/StepConfirm.tsx
+++ b/src/renderer/src/components/wizard/StepConfirm.tsx
@@ -122,7 +122,7 @@ export function StepConfirm(): JSX.Element {
           <TableBody>
             {summaryRows.map((row) => (
               <TableRow key={row.key} className="hover:bg-transparent">
-                <TableCell className="w-16 px-4 py-2 text-[11px] font-bold uppercase tracking-[0.12em] text-[var(--text-subtle)]">{row.label}</TableCell>
+                <TableCell className="w-16 px-4 py-2 text-[9px] font-bold uppercase tracking-[0.12em] text-[var(--text-subtle)]">{row.label}</TableCell>
                 <TableCell className="max-w-xs px-4 py-2 font-mono text-xs text-foreground/80" data-testid={`confirm-${row.key}`}>
                   <span className="block truncate">{row.value}</span>
                 </TableCell>

--- a/src/renderer/src/components/wizard/StepConfirm.tsx
+++ b/src/renderer/src/components/wizard/StepConfirm.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from 'react';
+import { AlertTriangle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { humanSize } from '@shared/format.js';
 import { useAppStore, presetLabel, resolveAudioLabel, resolveVideoResolution } from '../../store/useAppStore.js';
@@ -7,7 +8,9 @@ import { effectiveOutputDir } from '@renderer/lib/path.js';
 import { resolveSubtitleLabel, SUBTITLE_MODE_I18N_KEYS } from '../../lib/subtitleLabel.js';
 import { sanitizeJobOptions } from '@shared/sanitizeJobOptions.js';
 import { resolveOutputContainer } from '../../store/wizard/resolveContainer.js';
+import { Alert, AlertDescription } from '../ui/alert.js';
 import { Button } from '../ui/button.js';
+import { Table, TableBody, TableCell, TableRow } from '../ui/table.js';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../ui/tooltip.js';
 import { WizardFooter } from './WizardFooter.js';
 import { VideoSummaryCard } from '../shared/VideoSummaryCard.js';
@@ -104,7 +107,7 @@ export function StepConfirm(): JSX.Element {
 
       {/* Mascot banner */}
       <div className="flex items-center gap-4 p-4 rounded-lg border border-[hsla(220,100%,56%,0.15)] bg-[var(--brand-dim)] shrink-0">
-        <img src={loveImg} alt="" aria-hidden className="w-16 h-16 object-contain shrink-0" />
+        <img src={loveImg} alt="" aria-hidden className="size-16 shrink-0 object-contain" />
         <div>
           <p className="text-sm font-semibold text-foreground">{t('wizard.confirm.readyHeadline')}</p>
           <p className="text-xs text-muted-foreground mt-1">
@@ -114,36 +117,38 @@ export function StepConfirm(): JSX.Element {
       </div>
 
       {/* Summary table */}
-      <div className="rounded-lg border border-border bg-secondary overflow-hidden" data-testid="confirm-preview">
-        <table className="w-full">
-          <tbody>
+      <div className="overflow-hidden rounded-lg border border-border bg-secondary" data-testid="confirm-preview">
+        <Table>
+          <TableBody>
             {summaryRows.map((row) => (
-              <tr key={row.key} className="border-b border-border last:border-b-0">
-                <td className="px-4 py-2 text-[11px] font-bold uppercase tracking-[0.12em] text-[var(--text-subtle)] w-16 whitespace-nowrap">{row.label}</td>
-                <td className="px-4 py-2 text-xs text-foreground/80 font-mono truncate max-w-xs" data-testid={`confirm-${row.key}`}>
-                  {row.value}
-                </td>
-              </tr>
+              <TableRow key={row.key} className="hover:bg-transparent">
+                <TableCell className="w-16 px-4 py-2 text-[11px] font-bold uppercase tracking-[0.12em] text-[var(--text-subtle)]">{row.label}</TableCell>
+                <TableCell className="max-w-xs px-4 py-2 font-mono text-xs text-foreground/80" data-testid={`confirm-${row.key}`}>
+                  <span className="block truncate">{row.value}</span>
+                </TableCell>
+              </TableRow>
             ))}
-          </tbody>
-        </table>
+          </TableBody>
+        </Table>
       </div>
 
       {conflicts.length > 0 && (
-        <ul className="space-y-1" data-testid="confirm-conflicts">
-          {conflicts.map((c) => (
-            <li key={c.code} className="flex items-start gap-1.5 text-xs text-amber-500 dark:text-amber-400/90 px-1">
-              <span className="shrink-0 mt-px">⚠</span>
-              <span>{CONFLICT_LABELS[c.code]}</span>
-            </li>
-          ))}
-        </ul>
+        <Alert variant="warning" data-testid="confirm-conflicts">
+          <AlertTriangle />
+          <AlertDescription>
+            <ul className="flex flex-col gap-1">
+              {conflicts.map((c) => (
+                <li key={c.code}>{CONFLICT_LABELS[c.code]}</li>
+              ))}
+            </ul>
+          </AlertDescription>
+        </Alert>
       )}
 
       {hasNothingSelected && (
-        <p className="text-xs text-muted-foreground text-center px-2" data-testid="nothing-to-download-note">
-          {t('wizard.confirm.nothingToDownload')}
-        </p>
+        <Alert variant="info" data-testid="nothing-to-download-note">
+          <AlertDescription>{t('wizard.confirm.nothingToDownload')}</AlertDescription>
+        </Alert>
       )}
 
       <WizardFooter>

--- a/src/renderer/src/components/wizard/StepFolderConfirm.tsx
+++ b/src/renderer/src/components/wizard/StepFolderConfirm.tsx
@@ -3,9 +3,10 @@ import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../../store/useAppStore.js';
 import { Button } from '../ui/button.js';
 import { WizardFooter } from './WizardFooter.js';
-import { RadioOption } from '../ui/radio-option.js';
+import { Field, FieldError, FieldGroup, FieldLabel } from '../ui/field.js';
 import { Switch } from '../ui/switch.js';
 import { Input } from '../ui/input.js';
+import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group.js';
 import { formatHomeRelativePath } from '@renderer/lib/utils.js';
 import { isValidSubfolder } from '@renderer/lib/path.js';
 import { VideoSummaryCard } from '../shared/VideoSummaryCard.js';
@@ -97,24 +98,16 @@ export function StepFolderConfirm(): JSX.Element {
     return formatHomeRelativePath(loc.path, commonPaths);
   };
 
-  const renderRadio = (loc: Location, full: boolean): JSX.Element => {
-    const isSelected = selectedId === loc.id;
+  const renderLocation = (loc: Location, full: boolean): JSX.Element => {
     const path = displayPath(loc);
     return (
-      <RadioOption
-        key={loc.id}
-        checked={isSelected}
-        onClick={() => void handleSelect(loc)}
-        className={full ? 'col-span-2 gap-3' : 'gap-3'}
-        labelClassName="flex-1 truncate"
-        adornment={
-          <span className="text-base leading-none" aria-hidden>
-            {loc.icon}
-          </span>
-        }
-        label={loc.label}
-        meta={path && <code className="font-mono text-[12px] text-[var(--text-subtle)] truncate max-w-[140px]">{path}</code>}
-      />
+      <ToggleGroupItem key={loc.id} value={loc.id} className={full ? 'col-span-2 h-auto min-h-9 justify-start gap-3 px-2 aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]' : 'h-auto min-h-9 justify-start gap-3 px-2 aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]'}>
+        <span className="text-base leading-none" aria-hidden>
+          {loc.icon}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-start">{loc.label}</span>
+        {path ? <code className="max-w-[140px] truncate font-mono text-[12px] text-[var(--text-subtle)]">{path}</code> : null}
+      </ToggleGroupItem>
     );
   };
 
@@ -124,20 +117,30 @@ export function StepFolderConfirm(): JSX.Element {
 
       <div className="flex flex-col gap-1.5">
         <p className="text-[11px] font-bold uppercase tracking-[0.12em] text-[var(--text-subtle)]">{t('wizard.folder.heading')}</p>
-        <div className="grid grid-cols-2 gap-1.5">
-          {presets.map((loc) => renderRadio(loc, false))}
-          {renderRadio(custom, true)}
-        </div>
+        <ToggleGroup
+          value={[selectedId]}
+          onValueChange={(values) => {
+            const next = values[0];
+            const loc = locations.find((location) => location.id === next);
+            if (loc) void handleSelect(loc);
+          }}
+          spacing={1}
+          className="grid w-full grid-cols-2 items-stretch"
+          aria-label={t('wizard.folder.heading')}
+        >
+          {presets.map((loc) => renderLocation(loc, false))}
+          {renderLocation(custom, true)}
+        </ToggleGroup>
       </div>
 
-      <div className="flex flex-col gap-2">
-        <label className="flex items-center gap-2.5 cursor-pointer">
+      <FieldGroup className="gap-2">
+        <Field orientation="horizontal" className="items-center gap-2.5">
           <Switch checked={wizardSubfolderEnabled} onCheckedChange={setWizardSubfolderEnabled} aria-label={t('wizard.folder.subfolder.toggle')} />
-          <span className="text-[13px] font-medium text-foreground">{t('wizard.folder.subfolder.toggle')}</span>
-        </label>
-        <Input type="text" value={wizardSubfolderName} onChange={(e) => setWizardSubfolderName(e.target.value)} disabled={!wizardSubfolderEnabled} placeholder={t('wizard.folder.subfolder.placeholder')} maxLength={64} aria-invalid={wizardSubfolderEnabled && wizardSubfolderName.trim() !== '' && !isValidSubfolder(wizardSubfolderName)} className="ml-[42px] w-[calc(100%-42px)]" />
-        {wizardSubfolderEnabled && wizardSubfolderName.trim() !== '' && !isValidSubfolder(wizardSubfolderName) && <p className="ml-[42px] text-[12px] text-destructive">{t('wizard.folder.subfolder.invalid')}</p>}
-      </div>
+          <FieldLabel className="text-[13px] font-medium text-foreground">{t('wizard.folder.subfolder.toggle')}</FieldLabel>
+        </Field>
+        <Input type="text" value={wizardSubfolderName} onChange={(e) => setWizardSubfolderName(e.target.value)} disabled={!wizardSubfolderEnabled} placeholder={t('wizard.folder.subfolder.placeholder')} maxLength={64} aria-invalid={wizardSubfolderEnabled && wizardSubfolderName.trim() !== '' && !isValidSubfolder(wizardSubfolderName)} className="ms-[42px] w-[calc(100%-42px)]" />
+        {wizardSubfolderEnabled && wizardSubfolderName.trim() !== '' && !isValidSubfolder(wizardSubfolderName) ? <FieldError className="ms-[42px] text-[12px]">{t('wizard.folder.subfolder.invalid')}</FieldError> : null}
+      </FieldGroup>
 
       <WizardFooter>
         <Button variant="ghost" type="button" onClick={back} className="border-[1.5px] border-[var(--border-strong)] text-muted-foreground hover:text-foreground">

--- a/src/renderer/src/components/wizard/StepFolderConfirm.tsx
+++ b/src/renderer/src/components/wizard/StepFolderConfirm.tsx
@@ -7,7 +7,7 @@ import { Field, FieldError, FieldGroup, FieldLabel } from '../ui/field.js';
 import { Switch } from '../ui/switch.js';
 import { Input } from '../ui/input.js';
 import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group.js';
-import { formatHomeRelativePath } from '@renderer/lib/utils.js';
+import { cn, formatHomeRelativePath } from '@renderer/lib/utils.js';
 import { isValidSubfolder } from '@renderer/lib/path.js';
 import { VideoSummaryCard } from '../shared/VideoSummaryCard.js';
 
@@ -101,7 +101,7 @@ export function StepFolderConfirm(): JSX.Element {
   const renderLocation = (loc: Location, full: boolean): JSX.Element => {
     const path = displayPath(loc);
     return (
-      <ToggleGroupItem key={loc.id} value={loc.id} className={full ? 'col-span-2 h-auto min-h-9 justify-start gap-3 px-2 aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]' : 'h-auto min-h-9 justify-start gap-3 px-2 aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]'}>
+      <ToggleGroupItem key={loc.id} value={loc.id} className={cn('h-auto min-h-9 justify-start gap-3 px-2 aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]', full && 'col-span-2')}>
         <span className="text-base leading-none" aria-hidden>
           {loc.icon}
         </span>

--- a/src/renderer/src/components/wizard/StepFormatSelect.tsx
+++ b/src/renderer/src/components/wizard/StepFormatSelect.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useAppStore } from '../../store/useAppStore.js';
 import { useFormatSelectionView } from '../../store/formatSelectionView.js';
 import { VideoSummaryCard } from '../shared/VideoSummaryCard.js';
+import { Spinner } from '../ui/spinner.js';
 import downloadingImg from '../../assets/Downloading.png';
 import { PresetStrip } from './format/PresetStrip.js';
 import { VideoColumn } from './format/VideoColumn.js';
@@ -19,7 +20,7 @@ export function StepFormatSelect(): JSX.Element {
     return (
       <div className="wizard-step flex flex-col items-center gap-4 py-8">
         <div className="rounded-2xl bg-[var(--brand-dim)] p-4 shadow-[0_0_28px_var(--brand-glow)]">
-          <img src={downloadingImg} alt="" aria-hidden className="w-28 h-28 object-contain" />
+          <img src={downloadingImg} alt="" aria-hidden className="size-28 object-contain" />
         </div>
         <div className="relative rounded-xl border border-border bg-secondary px-4 py-2.5 text-sm text-muted-foreground leading-relaxed shadow-sm text-center max-w-[260px]">
           <span
@@ -43,7 +44,7 @@ export function StepFormatSelect(): JSX.Element {
           {t('wizard.formats.sniffing')}
         </div>
         <div className="flex items-center gap-2 text-xs text-[var(--text-subtle)]">
-          <div className="spinner" aria-label={t('wizard.formats.loadingAria')} />
+          <Spinner aria-label={t('wizard.formats.loadingAria')} />
           <span>{t('wizard.formats.loadingHint')}</span>
         </div>
       </div>

--- a/src/renderer/src/components/wizard/StepSponsorBlock.tsx
+++ b/src/renderer/src/components/wizard/StepSponsorBlock.tsx
@@ -4,7 +4,7 @@ import { useAppStore } from '../../store/useAppStore.js';
 import { Checkbox } from '../ui/checkbox.js';
 import { Separator } from '../ui/separator.js';
 import { WizardStepFooterActions } from './WizardStepFooterActions.js';
-import { RadioOption } from '../ui/radio-option.js';
+import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group.js';
 import { SPONSORBLOCK_CATEGORIES, SPONSORBLOCK_MODES } from '@shared/schemas.js';
 import type { SponsorBlockMode } from '@shared/types.js';
 
@@ -31,11 +31,22 @@ export function StepSponsorBlock(): JSX.Element {
       {/* ── Mode ───────────────────────────────────────── */}
       <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-2.5 items-center -mx-1">
         <span className="text-[10px] font-bold uppercase tracking-widest text-[var(--text-subtle)] px-1 shrink-0">{t('wizard.sponsorblock.modeHeading')}</span>
-        <div role="radiogroup" aria-label={t('wizard.sponsorblock.modeHeading')} className="flex flex-row flex-wrap gap-1">
+        <ToggleGroup
+          value={[wizardSponsorBlockMode]}
+          onValueChange={(values) => {
+            const next = values[0] as SponsorBlockMode | undefined;
+            if (next) setSponsorBlockMode(next);
+          }}
+          aria-label={t('wizard.sponsorblock.modeHeading')}
+          spacing={1}
+          className="flex-wrap"
+        >
           {SPONSORBLOCK_MODES.map((mode) => (
-            <RadioOption key={mode} label={t(SB_MODE_LABEL_KEYS[mode])} checked={wizardSponsorBlockMode === mode} onClick={() => setSponsorBlockMode(mode)} className="py-0.5" />
+            <ToggleGroupItem key={mode} value={mode} className="h-7 px-2 text-[12px] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]">
+              {t(SB_MODE_LABEL_KEYS[mode])}
+            </ToggleGroupItem>
           ))}
-        </div>
+        </ToggleGroup>
 
         <span />
         <p className="text-[11px] text-[var(--text-subtle)] leading-snug">{t(SB_MODE_HINT_KEYS[wizardSponsorBlockMode])}</p>

--- a/src/renderer/src/components/wizard/StepSponsorBlock.tsx
+++ b/src/renderer/src/components/wizard/StepSponsorBlock.tsx
@@ -20,6 +20,10 @@ const SB_MODE_HINT_KEYS = {
   remove: 'wizard.sponsorblock.modeHint.remove'
 } as const satisfies Record<SponsorBlockMode, string>;
 
+function isSponsorBlockMode(value: string | undefined): value is SponsorBlockMode {
+  return value !== undefined && (SPONSORBLOCK_MODES as readonly string[]).includes(value);
+}
+
 export function StepSponsorBlock(): JSX.Element {
   const { t } = useTranslation();
   const { wizardSponsorBlockMode, wizardSponsorBlockCategories, setSponsorBlockMode, toggleSponsorBlockCategory, advance, back } = useAppStore();
@@ -34,8 +38,8 @@ export function StepSponsorBlock(): JSX.Element {
         <ToggleGroup
           value={[wizardSponsorBlockMode]}
           onValueChange={(values) => {
-            const next = values[0] as SponsorBlockMode | undefined;
-            if (next) setSponsorBlockMode(next);
+            const next = values[0];
+            if (isSponsorBlockMode(next)) setSponsorBlockMode(next);
           }}
           aria-label={t('wizard.sponsorblock.modeHeading')}
           spacing={1}

--- a/src/renderer/src/components/wizard/StepSubtitles.tsx
+++ b/src/renderer/src/components/wizard/StepSubtitles.tsx
@@ -1,11 +1,15 @@
 import { type JSX, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Search, Check, X } from 'lucide-react';
+import { Search, X } from 'lucide-react';
 import { useAppStore } from '../../store/useAppStore.js';
+import { Badge } from '../ui/badge.js';
 import { Button } from '../ui/button.js';
+import { Checkbox } from '../ui/checkbox.js';
+import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from '../ui/empty.js';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group.js';
 import { Separator } from '../ui/separator.js';
 import { WizardFooter } from './WizardFooter.js';
-import { RadioOption } from '../ui/radio-option.js';
+import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group.js';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../ui/tooltip.js';
 import { MascotBubble } from '../shared/MascotBubble.js';
 import { buildSubtitleList, SUBTITLE_MODE_I18N_KEYS } from '../../lib/subtitleLabel.js';
@@ -49,11 +53,22 @@ export function StepSubtitles(): JSX.Element {
       {hasLangs && (
         <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-2.5 items-center -mx-1">
           <span className="text-[10px] font-bold uppercase tracking-widest text-[var(--text-subtle)] px-1 shrink-0">{t('wizard.subtitles.saveMode.heading')}</span>
-          <div role="radiogroup" aria-label={t('wizard.subtitles.saveMode.heading')} className="flex flex-row flex-wrap gap-1">
+          <ToggleGroup
+            value={[wizardSubtitleMode]}
+            onValueChange={(values) => {
+              const next = values[0] as (typeof SUBTITLE_MODES)[number] | undefined;
+              if (next) setSubtitleMode(next);
+            }}
+            aria-label={t('wizard.subtitles.saveMode.heading')}
+            spacing={1}
+            className="flex-wrap"
+          >
             {saveModes.map(({ mode, label }) => (
-              <RadioOption key={mode} label={label} checked={wizardSubtitleMode === mode} onClick={() => setSubtitleMode(mode)} className="py-0.5" />
+              <ToggleGroupItem key={mode} value={mode} className="h-7 px-2 text-[12px] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]">
+                {label}
+              </ToggleGroupItem>
             ))}
-          </div>
+          </ToggleGroup>
 
           {wizardSubtitleMode === 'embed' ? (
             <>
@@ -65,13 +80,22 @@ export function StepSubtitles(): JSX.Element {
           ) : (
             <>
               <span className="text-[10px] font-bold uppercase tracking-widest text-[var(--text-subtle)] px-1 shrink-0">{t('wizard.subtitles.format.heading')}</span>
-              <div className="flex items-center gap-1.5">
+              <ToggleGroup
+                value={[wizardSubtitleFormat]}
+                onValueChange={(values) => {
+                  const next = values[0] as (typeof SUBTITLE_FORMATS)[number] | undefined;
+                  if (next) setSubtitleFormat(next);
+                }}
+                aria-label={t('wizard.subtitles.format.heading')}
+                spacing={1}
+                className="flex-wrap"
+              >
                 {SUBTITLE_FORMATS.map((fmt) => (
-                  <button key={fmt} type="button" aria-pressed={wizardSubtitleFormat === fmt} onClick={() => setSubtitleFormat(fmt)} className="h-6 px-2 rounded text-[11px] font-semibold uppercase border border-[var(--border-strong)] transition-colors aria-pressed:bg-[var(--brand-dim)] aria-pressed:border-[var(--brand)] aria-pressed:text-[var(--brand)] hover:bg-accent/60">
+                  <ToggleGroupItem key={fmt} value={fmt} className="h-6 px-2 text-[11px] font-semibold uppercase aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]">
                     {fmt.toUpperCase()}
-                  </button>
+                  </ToggleGroupItem>
                 ))}
-              </div>
+              </ToggleGroup>
             </>
           )}
 
@@ -90,9 +114,11 @@ export function StepSubtitles(): JSX.Element {
 
       {/* ── Languages ───────────────────────────────────── */}
       {!hasLangs ? (
-        <div className="flex flex-col items-center gap-3 py-6 text-center">
-          <p className="text-sm text-muted-foreground">{t('wizard.subtitles.noLanguages')}</p>
-        </div>
+        <Empty className="py-6">
+          <EmptyHeader>
+            <EmptyTitle>{t('wizard.subtitles.noLanguages')}</EmptyTitle>
+          </EmptyHeader>
+        </Empty>
       ) : (
         <>
           {/* Selected chips row */}
@@ -102,50 +128,59 @@ export function StepSubtitles(): JSX.Element {
                 <span className="text-[11px] italic text-[var(--text-subtle)]">{t('wizard.subtitles.noSelected')}</span>
               ) : (
                 selectedItems.map(({ code, displayName }) => (
-                  <span key={code} className="flex items-center gap-1 h-6 ps-2.5 pe-1.5 rounded-full text-[11px] font-semibold bg-[var(--brand)] text-white">
+                  <Badge key={code} className="h-6 gap-1 bg-[var(--brand)] ps-2.5 pe-1.5 text-[11px] text-white">
                     {displayName}
-                    <button
+                    <Button
                       type="button"
                       aria-label={`Remove ${displayName}`}
                       onClick={() => {
                         toggleSubtitleLanguage(code);
                       }}
-                      className="flex items-center justify-center w-3.5 h-3.5 rounded-full hover:bg-white/20 transition-colors"
+                      variant="ghost"
+                      size="icon-xs"
+                      className="size-4 rounded-full p-0 text-white hover:bg-white/20 hover:text-white"
                     >
-                      <X size={9} strokeWidth={3} />
-                    </button>
-                  </span>
+                      <X data-icon="inline-start" strokeWidth={3} />
+                    </Button>
+                  </Badge>
                 ))
               )}
             </div>
             <div className="flex items-center gap-2 shrink-0">
               {selectedCount > 0 && <span className="text-[11px] text-[var(--text-subtle)]">{selectedCount}</span>}
               {selectedCount > 0 && (
-                <button type="button" onClick={clearAll} className="text-[11px] text-[var(--brand)] hover:underline cursor-pointer">
+                <Button type="button" variant="link" size="xs" onClick={clearAll} className="h-auto px-0 text-[11px]">
                   {t('wizard.subtitles.clearAll')}
-                </button>
+                </Button>
               )}
             </div>
           </div>
 
           {/* Search input */}
-          <div className="relative">
-            <Search size={13} className="absolute start-2.5 top-1/2 -translate-y-1/2 text-[var(--text-subtle)] pointer-events-none" />
-            <input
+          <InputGroup>
+            <InputGroupAddon>
+              <Search />
+            </InputGroupAddon>
+            <InputGroupInput
               type="text"
               value={query}
               onChange={(e) => {
                 setQuery(e.target.value);
               }}
               placeholder={t('wizard.subtitles.searchPlaceholder')}
-              className="w-full h-8 ps-7 pe-3 rounded-md border border-[var(--border-strong)] bg-secondary/60 text-sm text-foreground placeholder:text-[var(--text-subtle)] focus:outline-none focus:ring-1 focus:ring-[var(--brand)] focus:border-[var(--brand)] transition-colors"
+              className="text-sm"
             />
-          </div>
+          </InputGroup>
 
           {/* Language list */}
           <div className="flex flex-col -mx-1 px-1">
             {noMatches ? (
-              <p className="py-4 text-center text-sm text-[var(--text-subtle)]">{t('wizard.subtitles.noMatches')}</p>
+              <Empty className="py-4">
+                <EmptyHeader>
+                  <EmptyTitle>{t('wizard.subtitles.noMatches')}</EmptyTitle>
+                  <EmptyDescription>{query}</EmptyDescription>
+                </EmptyHeader>
+              </Empty>
             ) : (
               <>
                 <LangSection label={t('wizard.subtitles.sectionManual')} items={manualLangs} selected={wizardSubtitleLanguages} onToggle={toggleSubtitleLanguage} autoBadge={t('wizard.subtitles.autoBadge')} />
@@ -213,22 +248,15 @@ function LangSection({ label, items, selected, onToggle, autoBadge }: LangSectio
         {items.map(({ code, displayName, isAuto }) => {
           const isChecked = selected.includes(code);
           return (
-            <button
-              key={code}
-              type="button"
-              role="checkbox"
-              aria-checked={isChecked}
-              onClick={() => {
-                onToggle(code);
-              }}
-              className="flex w-full items-center gap-2 h-7 px-2 rounded-md text-sm font-medium transition-colors cursor-pointer aria-checked:bg-[var(--brand-dim)] aria-checked:border-s-2 aria-checked:border-[var(--brand)] aria-checked:text-[var(--brand)] hover:bg-accent/60"
-            >
-              <span aria-hidden="true" className="flex h-4 w-4 shrink-0 items-center justify-center rounded border border-[var(--border-strong)] transition-colors" style={isChecked ? { borderColor: 'var(--brand)' } : undefined}>
-                {isChecked && <Check size={10} strokeWidth={3} className="text-[var(--brand)]" />}
-              </span>
+            <label key={code} className="flex h-7 w-full cursor-pointer items-center gap-2 rounded-md px-2 text-sm font-medium transition-colors hover:bg-accent/60 has-[[data-checked]]:border-s-2 has-[[data-checked]]:border-[var(--brand)] has-[[data-checked]]:bg-[var(--brand-dim)] has-[[data-checked]]:text-[var(--brand)]">
+              <Checkbox checked={isChecked} onCheckedChange={() => onToggle(code)} className="border-[var(--border-strong)] data-checked:border-[var(--brand)] data-checked:bg-[var(--brand)] data-checked:text-white" />
               <span className="flex-1 text-start truncate">{displayName}</span>
-              {isAuto && <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-[var(--brand-dim)] text-[var(--brand)] shrink-0">{autoBadge}</span>}
-            </button>
+              {isAuto && (
+                <Badge variant="secondary" className="text-[10px] font-semibold text-[var(--brand)]">
+                  {autoBadge}
+                </Badge>
+              )}
+            </label>
           );
         })}
       </div>

--- a/src/renderer/src/components/wizard/format/BotWallNotice.tsx
+++ b/src/renderer/src/components/wizard/format/BotWallNotice.tsx
@@ -2,6 +2,7 @@ import type { JSX } from 'react';
 import { AlertTriangle, RefreshCw, ShieldCheck } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '@renderer/store/useAppStore.js';
+import { Alert, AlertDescription, AlertTitle } from '@renderer/components/ui/alert.js';
 import { Button } from '@renderer/components/ui/button.js';
 
 interface Props {
@@ -29,26 +30,22 @@ export function BotWallNotice({ forceShow = false }: Props): JSX.Element | null 
   const body = variant === 'unconfigured' ? t('wizard.formats.botWall.bodyUnconfigured') : variant === 'disabled' ? t('wizard.formats.botWall.bodyDisabled') : t('wizard.formats.botWall.bodyEnabled');
 
   return (
-    <div role="status" data-testid="bot-wall-notice" data-variant={variant} className="flex flex-col gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[12px] text-amber-900 dark:text-amber-100">
-      <div className="flex items-start gap-2">
-        <AlertTriangle size={14} className="mt-0.5 shrink-0 text-amber-500" />
-        <div className="flex flex-col gap-0.5">
-          <span className="font-semibold">{t('wizard.formats.botWall.heading')}</span>
-          <span className="leading-snug">{body}</span>
-        </div>
-      </div>
-      <div className="flex flex-wrap gap-2 ps-6">
+    <Alert role="status" variant="warning" data-testid="bot-wall-notice" data-variant={variant} className="text-[12px]">
+      <AlertTriangle />
+      <AlertTitle className="text-[12px]">{t('wizard.formats.botWall.heading')}</AlertTitle>
+      <AlertDescription className="text-[12px] text-current">{body}</AlertDescription>
+      <div className="col-start-2 flex flex-wrap gap-2">
         {variant === 'disabled' ? (
-          <Button type="button" size="sm" variant="default" onClick={() => void retryProbeWithCookies()} className="gap-1.5" data-testid="bot-wall-enable-cta">
-            <ShieldCheck size={12} />
+          <Button type="button" size="sm" variant="default" onClick={() => void retryProbeWithCookies()} data-testid="bot-wall-enable-cta">
+            <ShieldCheck data-icon="inline-start" />
             {t('wizard.formats.botWall.enableRetryCta')}
           </Button>
         ) : null}
-        <Button type="button" size="sm" variant="outline" onClick={() => void retryFormatProbe()} className="gap-1.5" data-testid="bot-wall-retry-cta">
-          <RefreshCw size={12} />
+        <Button type="button" size="sm" variant="outline" onClick={() => void retryFormatProbe()} data-testid="bot-wall-retry-cta">
+          <RefreshCw data-icon="inline-start" />
           {t('wizard.formats.botWall.retryCta')}
         </Button>
       </div>
-    </div>
+    </Alert>
   );
 }

--- a/src/renderer/src/components/wizard/format/CookiesErrorAlert.tsx
+++ b/src/renderer/src/components/wizard/format/CookiesErrorAlert.tsx
@@ -2,6 +2,7 @@ import type { JSX, ReactNode } from 'react';
 import { AlertTriangle, ExternalLink } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAppStore } from '@renderer/store/useAppStore.js';
+import { Alert, AlertDescription } from '@renderer/components/ui/alert.js';
 import { Button } from '@renderer/components/ui/button.js';
 
 const DPAPI_DOCS_URL = 'https://github.com/yt-dlp/yt-dlp/issues/10927';
@@ -20,13 +21,11 @@ interface CookiesAlertShellProps {
 
 function CookiesAlertShell({ mode, variant, body, footer }: CookiesAlertShellProps): JSX.Element {
   return (
-    <div role="status" data-testid="cookies-error-alert" data-mode={mode} {...(variant ? { 'data-variant': variant } : {})} className="flex flex-col gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[12px] text-amber-900 dark:text-amber-100">
-      <div className="flex items-start gap-2">
-        <AlertTriangle size={14} className="mt-0.5 shrink-0 text-amber-500" />
-        <div className="flex flex-col gap-1">{body}</div>
-      </div>
-      {footer}
-    </div>
+    <Alert role="status" variant="warning" data-testid="cookies-error-alert" data-mode={mode} {...(variant ? { 'data-variant': variant } : {})} className="text-[12px]">
+      <AlertTriangle />
+      <AlertDescription className="flex flex-col gap-1 text-[12px] text-current">{body}</AlertDescription>
+      <div className="col-start-2 flex flex-col gap-2">{footer}</div>
+    </Alert>
   );
 }
 
@@ -34,9 +33,9 @@ function OpenCookiesSettingsButton(): JSX.Element {
   const { t } = useTranslation();
   const { openCookiesSettings } = useAppStore();
   return (
-    <div className="flex flex-wrap gap-2 ps-6">
-      <Button type="button" size="sm" variant="outline" onClick={() => openCookiesSettings()} className="gap-1.5" data-testid="cookies-error-open-settings-cta">
-        <ExternalLink size={12} />
+    <div className="flex flex-wrap gap-2">
+      <Button type="button" size="sm" variant="outline" onClick={() => openCookiesSettings()} data-testid="cookies-error-open-settings-cta">
+        <ExternalLink data-icon="inline-start" />
         {t('wizard.formats.cookiesError.openSettingsCta')}
       </Button>
     </div>
@@ -89,7 +88,7 @@ export function CookiesErrorAlert({ forceShowCookiesOff = false }: CookiesErrorA
         }
         footer={
           <>
-            <ol className="flex flex-col gap-1.5 ps-9 list-decimal marker:text-amber-700/80 dark:marker:text-amber-200/70">
+            <ol className="flex list-decimal flex-col gap-1.5 ps-4 marker:text-amber-700/80 dark:marker:text-amber-200/70">
               <li>
                 <span className="font-medium">{t('wizard.formats.cookiesError.dpapi.fixFirefoxLabel')}.</span> <span className="leading-snug">{t('wizard.formats.cookiesError.dpapi.fixFirefoxBody')}</span>
               </li>
@@ -98,9 +97,10 @@ export function CookiesErrorAlert({ forceShowCookiesOff = false }: CookiesErrorA
               </li>
               <li>
                 <span className="font-medium">{t('wizard.formats.cookiesError.dpapi.fixUnsafeLabel')}.</span> <span className="leading-snug">{t('wizard.formats.cookiesError.dpapi.fixUnsafeBody')}</span>{' '}
-                <button type="button" className="underline hover:text-foreground" onClick={() => void window.appApi.shell.openExternal(DPAPI_DOCS_URL)} data-testid="cookies-error-dpapi-docs-link">
-                  {t('wizard.formats.cookiesError.dpapi.docsLinkLabel')} ↗
-                </button>
+                <Button type="button" variant="link" size="xs" className="h-auto px-0 align-baseline text-[12px]" onClick={() => void window.appApi.shell.openExternal(DPAPI_DOCS_URL)} data-testid="cookies-error-dpapi-docs-link">
+                  {t('wizard.formats.cookiesError.dpapi.docsLinkLabel')}
+                  <ExternalLink data-icon="inline-end" />
+                </Button>
               </li>
             </ol>
             <OpenCookiesSettingsButton />

--- a/tests/renderer/update-banner.test.tsx
+++ b/tests/renderer/update-banner.test.tsx
@@ -85,7 +85,8 @@ describe('UpdateBanner', () => {
   it('shows Download ↗ for direct channel on darwin', () => {
     window.platform = 'darwin';
     render(<UpdateBanner info={makeInfo({ installChannel: 'direct' })} installing={false} installError={null} onInstall={vi.fn()} onDownload={vi.fn()} onDismiss={vi.fn()} />);
-    expect(screen.getByText('Download ↗')).toBeInTheDocument();
+    const downloadLink = screen.getByRole('link', { name: 'Download ↗' });
+    expect(downloadLink).toHaveAttribute('href', 'https://arroxy.orionus.dev/');
     expect(screen.queryByRole('button', { name: 'Install & Restart' })).not.toBeInTheDocument();
   });
 
@@ -161,7 +162,7 @@ describe('UpdateBanner', () => {
     window.platform = 'darwin';
     const onDownload = vi.fn();
     render(<UpdateBanner info={makeInfo({ installChannel: 'direct' })} installing={false} installError={null} onInstall={vi.fn()} onDownload={onDownload} onDismiss={vi.fn()} />);
-    fireEvent.click(screen.getByText('Download ↗'));
+    fireEvent.click(screen.getByRole('link', { name: 'Download ↗' }));
     expect(onDownload).toHaveBeenCalledOnce();
   });
 

--- a/tests/renderer/wizard-cookies-config.test.tsx
+++ b/tests/renderer/wizard-cookies-config.test.tsx
@@ -93,7 +93,7 @@ beforeEach(() => {
 });
 
 function openSettingsTab(): void {
-  fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+  fireEvent.click(screen.getByRole('tab', { name: 'Settings' }));
 }
 
 function enterUrlAndStartInteractiveDownload(): void {


### PR DESCRIPTION
## Summary
- Replace several custom renderer controls and panels with shadcn/base-nova components
- Add shadcn Empty, Spinner, Table, and Tabs components
- Preserve update download link semantics and restore warning color for rejected bulk URL rows

## Verification
- bunx vitest run --project jsdom tests/renderer/update-banner.test.tsx
- bun run check
- Browser-mock visual smoke for update download banner and duplicate bulk URL rejected row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## User-Facing Changes

- Refined UI styling and consistency across wizard steps, dialogs, and renderer panels through adoption of shadcn/base-nova component library
- New visual components: Empty state displays, spinner indicators, table layouts, and tabbed navigation
- Restored warning color styling for rejected bulk URL entries
- Improved button and control styling in footer zoom controls, update banner, and various wizard dialogs

## Internal/Refactor Changes

- Added new UI component modules: `empty.tsx`, `spinner.tsx`, `table.tsx`, `tabs.tsx` with variant support (Empty/EmptyMedia, TabsList variants)
- Systematically replaced custom HTML markup and custom control components with shared UI primitives:
  - RadioOption replaced with ToggleGroup/ToggleGroupItem in SponsorBlock, Folder Confirm, Subtitles, and Format Select steps
  - Raw buttons/divs replaced with Button, ButtonGroup, Card, Alert components throughout
  - Dialog layouts refactored to use Field, FieldGroup, FieldLabel, FieldError, and Textarea components
  - Inline warning/alert text replaced with Alert/AlertDescription components
  - List/item rendering refactored to use ItemGroup/Item/ItemMedia/ItemContent/ItemActions
- Refactored tabbed navigation in DownloadProfilesHome from custom conditional rendering to Tabs-based layout
- Updated button sizing utilities (e.g., `w-28 h-28` → `size-28`)
- Reorganized component layouts in UpdateBanner, BulkUrlDialog, DownloadProfileEditor, and related wizard panels

## Risk Areas

- **Update download link preservation**: Download button link behavior in UpdateBanner refactored to use buttonVariants while preserving href semantics; test coverage updated and should be verified
- **Visual regression surface**: Significant markup restructuring across multiple panels and dialogs; manual smoke testing for layout and spacing recommended
- **Test selector changes**: Tests updated to use semantic role queries (tab role, link role) rather than text/button matching; verify new selectors target intended elements
- **Component integration**: New tabbed layout in DownloadProfilesHome changes tab activation/routing behavior; verify URL hash syncing and state persistence

## Tests and Checks to Run

- Unit tests: `bunx vitest run --project jsdom tests/renderer/update-banner.test.tsx`
- Type and lint checks: `bun run check`
- Manual/browser-mock visual smoke tests:
  - Update download banner rendering and link functionality
  - Rejected bulk URL row warning color display
  - Wizard step layouts (folder selection, subtitle controls, sponsorblock mode)
  - Settings panel and advanced options rendering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->