### PR TITLE
Polish download profiles home

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -84,7 +84,7 @@ export function App(): JSX.Element {
 
 	return (
 		<TooltipProvider>
-			<div className="relative flex flex-col h-screen w-screen bg-background overflow-hidden" data-testid="app-root">
+			<div className="relative flex flex-col h-screen w-screen overflow-hidden" data-testid="app-root">
 				<TitleBar />
 
 				{update.info && <UpdateBanner info={update.info} installing={update.installing} installError={update.error} onInstall={update.install} onDownload={update.download} onDismiss={update.dismiss} />}
@@ -98,7 +98,7 @@ export function App(): JSX.Element {
 					</div>
 				</div>
 
-				<footer className="shrink-0 flex items-center justify-between border-t border-border px-4 h-7">
+				<footer className="chrome-glass shrink-0 flex h-8 items-center justify-between border-t border-border px-4">
 					<div className="flex items-center gap-1">
 						<ButtonGroup>
 							<Button type="button" variant="ghost" size="icon-xs" onClick={() => setUiZoom(uiZoom - ZOOM_STEP)} disabled={uiZoom <= ZOOM_MIN} className="size-5 text-base leading-none text-muted-foreground" aria-label={t('app.zoomOut')}>

--- a/src/renderer/src/components/layout/SmartDrawer.tsx
+++ b/src/renderer/src/components/layout/SmartDrawer.tsx
@@ -110,7 +110,7 @@ export function SmartDrawer(): JSX.Element {
 	}
 
 	return (
-		<section className="relative shrink-0 border-t border-border bg-background" data-testid="smart-drawer">
+		<section className="chrome-glass relative shrink-0 border-t border-border" data-testid="smart-drawer">
 			<QueueTipNudge visible={showQueueTip} onDismiss={dismissQueueTip} />
 			<div
 				role="button"
@@ -123,7 +123,7 @@ export function SmartDrawer(): JSX.Element {
 						setDrawerOpen(!drawerOpen)
 					}
 				}}
-				className="relative overflow-hidden w-full flex items-center justify-between px-4 h-9 hover:bg-accent transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				className="relative flex h-9 w-full cursor-pointer items-center justify-between overflow-hidden px-4 transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 				data-testid="drawer-toggle"
 				title={t('queue.toggleTitle')}
 			>

--- a/src/renderer/src/components/layout/TitleBar.tsx
+++ b/src/renderer/src/components/layout/TitleBar.tsx
@@ -71,7 +71,7 @@ export function TitleBar(): JSX.Element {
 	}, [])
 
 	return (
-		<div className={cn('flex items-center h-9 border-b border-border select-none shrink-0', isMac ? 'pl-3 pr-2' : 'pl-4 pr-0')} style={drag} data-testid="title-bar">
+		<div className={cn('chrome-glass flex h-9 shrink-0 select-none items-center border-b border-border', isMac ? 'pl-3 pr-2' : 'pl-4 pr-0')} style={drag} data-testid="title-bar">
 			{isMac && <MacControls isMaximized={isMaximized} />}
 
 			<span className={cn('flex-1 flex items-center gap-1.5 text-xs font-medium text-muted-foreground tracking-wide', isMac ? 'justify-center' : 'pl-1')}>

--- a/src/renderer/src/components/system/FeedbackNudge.tsx
+++ b/src/renderer/src/components/system/FeedbackNudge.tsx
@@ -23,16 +23,12 @@ export function FeedbackNudge({visible, message}: Props): JSX.Element | null {
 	if (!rendered) return null
 
 	return (
-		<div className="absolute bottom-full end-0 mb-1.5 pointer-events-none" data-testid="feedback-nudge">
-			<div className={cn(cls, 'flex items-end gap-2 pointer-events-auto')}>
-				{/* Mascot */}
-				<img src={loveImg} alt="" aria-hidden draggable={false} className="w-9 h-9 object-contain shrink-0" />
-				{/* Speech bubble */}
-				<div className="relative bg-secondary border border-border rounded-xl px-3 py-2 text-xs text-foreground/80 leading-relaxed whitespace-nowrap shadow-lg">
+		<div className="pointer-events-none absolute bottom-full end-0 mb-2" data-testid="feedback-nudge">
+			<div className={cn(cls, 'pointer-events-auto flex items-end gap-2')}>
+				<img src={loveImg} alt="" aria-hidden draggable={false} className="h-10 w-10 shrink-0 object-contain drop-shadow-[0_0_14px_var(--brand-glow)]" />
+				<div className="glow-tile relative whitespace-nowrap rounded-2xl border-transparent px-4 py-2.5 text-xs leading-relaxed text-foreground/85">
 					{message}
-					{/* Downward caret pointing toward the Feedback button */}
-					<span aria-hidden className="absolute -bottom-[7px] end-3 w-0 h-0" style={{borderLeft: '6px solid transparent', borderRight: '6px solid transparent', borderTop: '7px solid var(--border)'}} />
-					<span aria-hidden className="absolute -bottom-[5px] end-3 w-0 h-0" style={{borderLeft: '6px solid transparent', borderRight: '6px solid transparent', borderTop: '6px solid var(--secondary)'}} />
+					<span aria-hidden className="absolute -bottom-[7px] end-4 h-3 w-3 rotate-45 border-b border-r border-[var(--glow-border)] bg-[var(--card)]" />
 				</div>
 			</div>
 		</div>

--- a/src/renderer/src/components/wizard/BulkUrlDialog.tsx
+++ b/src/renderer/src/components/wizard/BulkUrlDialog.tsx
@@ -151,11 +151,11 @@ export function BulkUrlDialog({open, onOpenChange, initialRaw = '', renderAction
 							</Button>
 							<Button type="button" onClick={() => void confirmQuick()} disabled={!canConfirm || quickPreparing} data-testid="bulk-url-quick-confirm" className="shadow-[0_4px_14px_var(--brand-glow)] disabled:shadow-none">
 								<Download data-icon="inline-start" />
-								{quickPreparing ? t('wizard.url.quickPreparing') : 'Quick Download'}
+								{quickPreparing ? t('wizard.url.quickPreparing') : t('wizard.url.quickDownload')}
 							</Button>
 							<Button type="button" variant="outline" onClick={confirm} disabled={!canConfirm} data-testid="bulk-url-confirm">
 								<WandSparkles data-icon="inline-start" />
-								Interactive Download
+								{t('wizard.url.interactiveDownload')}
 							</Button>
 						</>
 					)}

--- a/src/renderer/src/components/wizard/DownloadProfileEditor.tsx
+++ b/src/renderer/src/components/wizard/DownloadProfileEditor.tsx
@@ -1,5 +1,5 @@
 import {useId, useState, type JSX, type ReactNode} from 'react'
-import {Archive, BookOpen, Captions, ChevronDown, Clapperboard, Download, FileAudio, Film, Folder, Headphones, Info, Music, Plus, Scissors, X, type LucideIcon} from 'lucide-react'
+import {Archive, BookOpen, Captions, ChevronDown, Clapperboard, Download, FileAudio, Film, Folder, Headphones, Info, Music, Plus, Scissors, SlidersHorizontal, X, type LucideIcon} from 'lucide-react'
 import {DEFAULTS} from '@shared/constants.js'
 import {DEFAULT_AUDIO_BITRATE, DOWNLOAD_PROFILE_ICONS} from '@shared/schemas.js'
 import type {DownloadProfile, DownloadProfileIcon} from '@shared/types.js'
@@ -44,6 +44,7 @@ const MEDIA_MODES: {value: ProfileMediaMode; label: string; description: string;
 ]
 
 const PROFILE_ICON_META: Record<DownloadProfileIcon, {label: string; icon: LucideIcon}> = {
+	controls: {label: 'Controls', icon: SlidersHorizontal},
 	download: {label: 'Download', icon: Download},
 	video: {label: 'Video', icon: Clapperboard},
 	captions: {label: 'Captions', icon: Captions},

--- a/src/renderer/src/components/wizard/DownloadProfilesHome.tsx
+++ b/src/renderer/src/components/wizard/DownloadProfilesHome.tsx
@@ -1,5 +1,7 @@
 import {useEffect, useMemo, useRef, useState, type ClipboardEvent, type JSX, type KeyboardEvent} from 'react'
-import {Archive, BookOpen, Captions, Check, ChevronDown, ChevronRight, Clapperboard, Download, FileAudio, Headphones, Link2, ListPlus, Music, PenLine, Plus, Scissors, Settings, Users, Wand2, X, type LucideIcon} from 'lucide-react'
+import type {TFunction} from 'i18next'
+import {useTranslation} from 'react-i18next'
+import {Archive, BookOpen, Captions, Check, ChevronDown, ChevronRight, Clapperboard, Clock3, Download, FileAudio, Globe2, Headphones, Link2, ListPlus, Loader2, Music, PenLine, Plus, Scissors, Settings, SlidersHorizontal, Sparkles, Users, Wand2, X, type LucideIcon} from 'lucide-react'
 import {allDownloadProfiles, downloadProfileLabel, downloadProfileOrigin, downloadProfileRefFor, resolveActiveDownloadProfile} from '@shared/downloadProfiles.js'
 import {cleanUrl} from '@shared/cleanUrl.js'
 import type {DownloadProfile, DownloadProfileIcon, DownloadProfilesPrefs} from '@shared/types.js'
@@ -28,13 +30,27 @@ type ProfilesTab = 'download' | 'profiles' | 'settings'
 type DownloadInputType = 'Single URL' | 'Playlist URL' | 'Channel URL' | 'Search URL' | 'URL' | 'Unknown URL'
 const PROFILE_TABS = ['download', 'profiles', 'settings'] as const satisfies readonly ProfilesTab[]
 
-const ICONS: Record<DownloadProfileIcon, LucideIcon> = {archive: Archive, audio: FileAudio, captions: Captions, classes: BookOpen, clip: Scissors, download: Download, music: Music, podcast: Headphones, video: Clapperboard}
+const ICONS: Record<DownloadProfileIcon, LucideIcon> = {archive: Archive, audio: FileAudio, captions: Captions, classes: BookOpen, clip: Scissors, controls: SlidersHorizontal, download: Download, music: Music, podcast: Headphones, video: Clapperboard}
+const FEATURE_GROUPS = [
+	{heading: 'wizard.url.features.youtube.heading', icon: Clapperboard, items: ['wizard.url.features.youtube.video', 'wizard.url.features.youtube.channel', 'wizard.url.features.youtube.playlist', 'wizard.url.features.youtube.short', 'wizard.url.features.youtube.music', 'wizard.url.features.youtube.podcast']},
+	{heading: 'wizard.url.features.anySite.heading', icon: Globe2, items: ['wizard.url.features.anySite.video', 'wizard.url.features.anySite.videoPlaylist', 'wizard.url.features.anySite.musicPlaylist']},
+	{heading: 'wizard.url.features.always.heading', icon: Clock3, items: ['wizard.url.features.always.audioOnly', 'wizard.url.features.always.subtitles']}
+] as const
 
 function tabFromHash(hash = window.location.hash): ProfilesTab {
 	const value = hash.replace(/^#/, '').toLowerCase()
 	if (value === 'profile' || value === 'profiles') return 'profiles'
 	if (value === 'setting' || value === 'settings') return 'settings'
 	return 'download'
+}
+
+function browserMockScenarioId(): string | null {
+	if (import.meta.env.MODE !== 'browser-mock') return null
+	try {
+		return new URLSearchParams(window.location.search).get('scenario')
+	} catch {
+		return null
+	}
 }
 
 function isProfilesTab(value: unknown): value is ProfilesTab {
@@ -47,10 +63,10 @@ function tabHash(tab: ProfilesTab): string {
 	return '#download'
 }
 
-function profileDetail(profile: DownloadProfile): string {
-	const subs = profile.subtitles.enabled || profile.media.kind === 'subtitles-only' ? `${profile.subtitles.languages.join(', ') || 'selected'} subtitles` : 'no subtitles'
-	const output = profile.output.kind === 'fixed' ? profile.output.dir : 'default folder'
-	const artifacts = [profile.embed.metadata ? 'metadata' : null, profile.embed.thumbnailSidecar ? 'thumbnail' : null, profile.embed.description ? 'description' : null].filter(Boolean).join(' · ')
+function profileDetail(profile: DownloadProfile, t: TFunction): string {
+	const subs = profile.subtitles.enabled || profile.media.kind === 'subtitles-only' ? `${profile.subtitles.languages.join(', ') || 'selected'} ${t('wizard.confirm.labelSubtitles').toLowerCase()}` : t('wizard.subtitles.noSelected')
+	const output = profile.output.kind === 'fixed' ? profile.output.dir : t('wizard.folder.downloads')
+	const artifacts = [profile.embed.metadata ? t('wizard.output.embedMetadata.label') : null, profile.embed.thumbnailSidecar ? t('wizard.output.writeThumbnail.label') : null, profile.embed.description ? t('wizard.output.writeDescription.label') : null].filter(Boolean).join(' · ')
 	return `${subs} · ${output}${artifacts ? ` · ${artifacts}` : ''}`
 }
 
@@ -58,7 +74,9 @@ function detectUrlType(value: string): DownloadInputType | null {
 	const trimmed = value.trim()
 	if (!trimmed) return null
 	try {
-		const kind = classifyBulkUrlKind(cleanUrl(trimmed))
+		const cleaned = cleanUrl(trimmed)
+		new URL(cleaned)
+		const kind = classifyBulkUrlKind(cleaned)
 		if (kind === 'single') return 'Single URL'
 		if (kind === 'playlist') return 'Playlist URL'
 		if (kind === 'channel') return 'Channel URL'
@@ -69,7 +87,7 @@ function detectUrlType(value: string): DownloadInputType | null {
 	}
 }
 
-function downloadMascotHelp({activeProfileName, hasActiveDownloads, hasInput, inputType, quickDownloadStatus}: {activeProfileName: string; hasActiveDownloads: boolean; hasInput: boolean; inputType: DownloadInputType | null; quickDownloadStatus: string}): {
+function downloadMascotHelp({activeProfileName, hasActiveDownloads, hasInput, inputType, quickDownloadStatus, t}: {activeProfileName: string; hasActiveDownloads: boolean; hasInput: boolean; inputType: DownloadInputType | null; quickDownloadStatus: string; t: TFunction}): {
 	key: string
 	title: string
 	body: string
@@ -77,55 +95,63 @@ function downloadMascotHelp({activeProfileName, hasActiveDownloads, hasInput, in
 	image: string
 } {
 	if (quickDownloadStatus === 'preparing') {
-		return {key: 'preparing', title: 'Preparing', body: `Quick Download is reading this link and applying ${activeProfileName}.`, points: ['No wizard steps', 'Queued when ready'], image: downloadingImg}
+		return {key: 'preparing', title: t('wizard.url.quickPreparing'), body: `${t('wizard.url.quickDownload')} is reading this link and applying ${activeProfileName}.`, points: ['No wizard steps', 'Queued when ready'], image: downloadingImg}
 	}
 
 	if (quickDownloadStatus === 'queued') {
-		return {key: 'queued', title: 'Queued', body: 'The queue is handling this download. You can paste another link while it works.', points: ['Queue keeps order', 'Profile already applied'], image: downloadingImg}
+		return {key: 'queued', title: t('wizard.url.quickQueued'), body: 'The queue is handling this download. You can paste another link while it works.', points: ['Queue keeps order', 'Profile applied'], image: downloadingImg}
 	}
 
 	if (!hasInput) {
 		return {
 			key: hasActiveDownloads ? 'idle-running' : 'idle',
 			title: hasActiveDownloads ? 'Downloads are running' : 'Tip',
-			body: 'Download Profiles save quality, subtitles, output folder, thumbnails, SponsorBlock, and playlist cap rules.',
-			points: ['Quick uses the active profile', 'Interactive opens the wizard', 'Bulk URLs handles lists'],
+			body: hasActiveDownloads ? t('wizard.url.mascotBusy') : t('wizard.url.mascotIdle'),
+			points: ['Quick uses the active profile', 'Interactive reviews first', 'Bulk handles lists'],
 			image: hasActiveDownloads ? downloadingImg : hiImg
 		}
 	}
 
 	if (inputType === 'Playlist URL' || inputType === 'Channel URL' || inputType === 'Search URL') {
-		return {key: `collection-${inputType}`, title: inputType, body: `Quick queues loaded items with ${activeProfileName}. Interactive lets you inspect or select items first.`, points: ['Quick queues all loaded items', 'Interactive supports selection', 'Profile rules apply to every item'], image: hiImg}
+		return {key: `collection-${inputType}`, title: inputType, body: `Quick queues loaded items with ${activeProfileName}. Interactive lets you inspect or select items first.`, points: ['Quick queues loaded items', 'Interactive supports selection', 'Profile rules apply'], image: hiImg}
 	}
 
 	if (inputType === 'Single URL') {
 		return {key: 'single', title: 'Single URL', body: `Quick starts one download with ${activeProfileName}. Use Interactive for one-off changes.`, points: ['Quick is fastest', 'Interactive can override options'], image: hiImg}
 	}
 
-	return {key: 'generic-url', title: 'URL detected', body: 'Quick will try the active profile. Interactive is safer when you want to review what the link contains.', points: ['Quick uses profile', 'Interactive reviews first'], image: hiImg}
+	return {key: 'generic-url', title: 'URL detected', body: t('wizard.url.quickSingleOnly'), points: ['Quick uses the active profile', 'Interactive reviews first'], image: hiImg}
+}
+
+function quickDownloadErrorText(t: TFunction, error: string | null | undefined): string {
+	if (!error) return ''
+	if (error === 'wizard.url.quickProbeFailed' || error === 'wizard.url.quickPrepareFailed') return t(error)
+	return error
 }
 
 export function DownloadProfilesHome(): JSX.Element {
+	const {t} = useTranslation()
 	const {cookiesConfigDialogIssue, dismissCookiesConfigDialog, openCookiesSettings, quickDownload, quickDownloadError, quickDownloadStatus, removeDownloadProfile, saveDownloadProfile, setActiveDownloadProfile, setWizardUrl, settings, submitUrl, wizardUrl} = useAppStore()
 	const hasActiveDownloads = useAppStore(state => state.queue.some(item => item.status === 'running'))
 	const inputRef = useRef<HTMLInputElement>(null)
 	const bulkOpenRef = useRef(false)
+	const initialBrowserMockScenario = browserMockScenarioId()
 	const [activeTab, setActiveTab] = useState<ProfilesTab>(() => tabFromHash())
-	const [bulkOpen, setBulkOpen] = useState(false)
-	const [editorOpen, setEditorOpen] = useState(false)
+	const [bulkOpen, setBulkOpen] = useState(() => initialBrowserMockScenario === 'profiles-bulk')
+	const [editorOpen, setEditorOpen] = useState(() => initialBrowserMockScenario === 'profiles-editor')
 	const [editorSessionId, setEditorSessionId] = useState(0)
 	const [editingProfile, setEditingProfile] = useState<DownloadProfile | null>(null)
-	const [profileMenuOpen, setProfileMenuOpen] = useState(false)
-	const [dismissedMascotKey, setDismissedMascotKey] = useState<string | null>(null)
+	const [profileMenuOpen, setProfileMenuOpen] = useState(() => initialBrowserMockScenario === 'profiles-split-menu')
 	const profilesPrefs = settings?.profiles
 	const profiles = useMemo(() => allDownloadProfiles(profilesPrefs), [profilesPrefs])
 	const {profile: activeProfile} = resolveActiveDownloadProfile(profilesPrefs)
 	const hasInput = wizardUrl.trim().length > 0
 	const inputType = detectUrlType(wizardUrl)
+	const urlReady = inputType !== null && inputType !== 'Unknown URL'
 	const quickPreparing = quickDownloadStatus === 'preparing'
-	const quickErrorText = quickDownloadError === 'wizard.url.quickProbeFailed' ? 'Could not read the URL.' : quickDownloadError === 'wizard.url.quickPrepareFailed' ? 'Could not prepare that download.' : (quickDownloadError ?? '')
-	const mascotHelp = downloadMascotHelp({activeProfileName: activeProfile.name, hasActiveDownloads, hasInput, inputType, quickDownloadStatus})
-	const showMascotHelp = dismissedMascotKey !== mascotHelp.key
+	const quickErrorText = quickDownloadErrorText(t, quickDownloadError)
+	const mascotHelp = downloadMascotHelp({activeProfileName: activeProfile.name, hasActiveDownloads, hasInput, inputType, quickDownloadStatus, t})
+	const showMascotHelp = inputType !== 'Unknown URL'
 	const activateProfile = (profile: DownloadProfile): void => {
 		void setActiveDownloadProfile(downloadProfileRefFor(profile, profilesPrefs))
 	}
@@ -186,7 +212,7 @@ export function DownloadProfilesHome(): JSX.Element {
 	}
 
 	function handleKeyDown(event: KeyboardEvent<HTMLInputElement>): void {
-		if (event.key === 'Enter' && wizardUrl.trim() && !quickPreparing) {
+		if (event.key === 'Enter' && urlReady && !quickPreparing) {
 			void submitUrl()
 		}
 	}
@@ -203,7 +229,7 @@ export function DownloadProfilesHome(): JSX.Element {
 	}
 
 	return (
-		<div className="wizard-step mx-auto flex w-full max-w-6xl flex-col gap-4 pb-5" data-testid="download-profiles-home">
+		<div className="wizard-step mx-auto flex w-full max-w-[92rem] flex-col gap-4 pb-5" data-testid="download-profiles-home">
 			<Tabs
 				value={activeTab}
 				onValueChange={value => {
@@ -211,64 +237,48 @@ export function DownloadProfilesHome(): JSX.Element {
 				}}
 				className="gap-4"
 			>
-				<TabsList variant="line" className="flex h-11 w-full justify-start gap-5 border-b border-border/80 p-0" aria-label="Download profile navigation" data-testid="profiles-tabs">
-					<TabsTrigger value="download" className="h-11 flex-none rounded-none border-b-2 px-1 data-active:border-[var(--brand)]">
-						<Download data-icon="inline-start" aria-hidden />
-						Download
+				<TabsList variant="line" className="download-home-tabs flex h-14 w-full justify-start gap-8 border-b border-border/80 p-0" aria-label="Download profile navigation" data-testid="profiles-tabs">
+					<TabsTrigger value="download" className="h-14 flex-none rounded-none border-b-2 px-2 text-[15px] data-active:border-transparent">
+						<Link2 data-icon="inline-start" aria-hidden />
+						{t('wizard.steps.url')}
 					</TabsTrigger>
-					<TabsTrigger value="profiles" className="h-11 flex-none rounded-none border-b-2 px-1 data-active:border-[var(--brand)]">
+					<TabsTrigger value="profiles" className="h-14 flex-none rounded-none border-b-2 px-2 text-[15px] data-active:border-transparent">
 						<Users data-icon="inline-start" aria-hidden />
 						Profiles
 					</TabsTrigger>
-					<TabsTrigger value="settings" className="h-11 flex-none rounded-none border-b-2 px-1 data-active:border-[var(--brand)]">
+					<TabsTrigger value="settings" className="h-14 flex-none rounded-none border-b-2 px-2 text-[15px] data-active:border-transparent">
 						<Settings data-icon="inline-start" aria-hidden />
 						Settings
 					</TabsTrigger>
 				</TabsList>
 
 				<TabsContent value="download" className="flex flex-col gap-4">
-					<Card className="rounded-lg border-[var(--border-strong)] bg-card/40" data-testid="profiles-download-panel">
-						<CardHeader className="flex-row items-center gap-3">
-							<div className="grid size-12 shrink-0 place-items-center rounded-lg border border-[var(--brand)]/40 bg-[var(--brand-dim)] text-[var(--brand)]">
-								<Download aria-hidden />
-							</div>
+					<Card className="glow-panel rounded-[1.85rem] border-transparent" data-testid="profiles-download-panel">
+						<CardHeader className="px-6 pt-6 md:px-10 md:pt-7">
 							<div className="min-w-0">
-								<CardTitle className="text-xl font-semibold leading-tight">Download input</CardTitle>
-								<CardDescription className="mt-1 text-[12px] text-[var(--text-subtle)]">Enter a URL to start your download.</CardDescription>
+								<CardTitle className="text-2xl font-semibold leading-tight tracking-[-0.01em]">{t('wizard.url.heading')}</CardTitle>
+								<CardDescription className="mt-2 text-[13px] text-[var(--text-subtle)]">{t('wizard.url.quickSingleOnly')}</CardDescription>
+								<InputGroup className="glow-tile mt-5 h-14 rounded-2xl border-transparent px-1">
+									<InputGroupAddon align="inline-start">
+										<Link2 aria-hidden />
+									</InputGroupAddon>
+									<InputGroupInput ref={inputRef} type="url" value={wizardUrl} onChange={event => setWizardUrl(event.target.value)} onKeyDown={handleKeyDown} onPaste={handlePaste} placeholder={t('wizard.url.placeholder')} spellCheck={false} data-testid="profiles-main-input" className="text-[15px]" />
+									{hasInput ? (
+										<InputGroupAddon align="inline-end">
+											<InputGroupButton type="button" size="icon-sm" aria-label={t('wizard.url.clearAria')} onClick={handleClearUrl} data-testid="url-clear">
+												<X aria-hidden />
+											</InputGroupButton>
+										</InputGroupAddon>
+									) : null}
+								</InputGroup>
 							</div>
 						</CardHeader>
-						<CardContent>
-							<InputGroup className="mt-5 h-12 border-[var(--border-strong)] bg-background/35">
-								<InputGroupAddon align="inline-start">
-									<Link2 aria-hidden />
-								</InputGroupAddon>
-								<InputGroupInput ref={inputRef} type="url" value={wizardUrl} onChange={event => setWizardUrl(event.target.value)} onKeyDown={handleKeyDown} onPaste={handlePaste} placeholder="Paste a URL..." spellCheck={false} data-testid="profiles-main-input" className="text-[13px]" />
-								{hasInput ? (
-									<InputGroupAddon align="inline-end">
-										<InputGroupButton type="button" size="icon-sm" aria-label="Clear URL" onClick={handleClearUrl} data-testid="url-clear">
-											<X aria-hidden />
-										</InputGroupButton>
-									</InputGroupAddon>
-								) : null}
-							</InputGroup>
-
-							<div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-subtle)]">
-								<Badge variant={hasInput ? 'secondary' : 'outline'} className={cn(!hasInput && 'text-[var(--text-subtle)]')}>
-									{hasInput ? 'URL entered' : 'Waiting for URL'}
-								</Badge>
-								{inputType ? (
-									<Badge variant="outline" className="border-[var(--brand)]/40 bg-[var(--brand-dim)] text-[var(--brand)]">
-										{inputType}
-									</Badge>
-								) : null}
-							</div>
-
-							<Separator className="my-5" />
-
+						<CardContent className="px-6 pb-3 md:px-10">
 							<QuickProfileCard
 								activeProfile={activeProfile}
-								disabled={!hasInput || quickPreparing}
+								disabled={!urlReady || quickPreparing}
 								menuOpen={profileMenuOpen}
+								preparing={quickPreparing}
 								onDownload={() => void quickDownload()}
 								onEditProfile={() => openEditor(activeProfile)}
 								onManageProfiles={() => {
@@ -286,17 +296,17 @@ export function DownloadProfilesHome(): JSX.Element {
 
 							{quickDownloadStatus === 'error' ? (
 								<Alert variant="warning" className="mt-2 py-2" data-testid="quick-download-feedback">
-									<AlertDescription className="text-[11px]">Quick Download failed: {quickErrorText}</AlertDescription>
+									<AlertDescription className="text-[11px]">{t('wizard.url.quickFailed', {error: quickErrorText})}</AlertDescription>
 								</Alert>
 							) : null}
 
 							<div className="mt-3 grid gap-2">
-								<ActionRow disabled={!hasInput || quickPreparing} icon={Wand2} title="Interactive Download" description="Review and customize options before downloading." onClick={() => void submitUrl()} testId="profiles-interactive-download" />
-								<ActionRow icon={ListPlus} title="Bulk URLs" description="Choose Quick or Interactive for batch downloads." onClick={() => setBulkOpen(true)} testId="profiles-bulk-urls" />
+								<ActionRow disabled={!urlReady || quickPreparing} icon={Wand2} title={t('wizard.url.interactiveDownload')} description={t('wizard.url.fetchFormatsTooltip')} onClick={() => void submitUrl()} testId="profiles-interactive-download" />
+								<ActionRow icon={ListPlus} title={t('wizard.url.bulkButton')} description={t('wizard.url.bulkTooltip')} onClick={() => setBulkOpen(true)} testId="profiles-bulk-urls" />
 							</div>
 						</CardContent>
 					</Card>
-					{showMascotHelp ? <DownloadMascotHelpCard help={mascotHelp} onDismiss={() => setDismissedMascotKey(mascotHelp.key)} /> : null}
+					{showMascotHelp ? <DownloadMascotHelpCard help={mascotHelp} /> : null}
 				</TabsContent>
 
 				<TabsContent value="profiles">
@@ -314,25 +324,55 @@ export function DownloadProfilesHome(): JSX.Element {
 	)
 }
 
-function DownloadMascotHelpCard({help, onDismiss}: {help: ReturnType<typeof downloadMascotHelp>; onDismiss: () => void}): JSX.Element {
+function DownloadMascotHelpCard({help}: {help: ReturnType<typeof downloadMascotHelp>}): JSX.Element {
 	return (
-		<Card className="flex w-full max-w-[34rem] flex-row items-center gap-4 rounded-lg border-[var(--border-strong)] bg-background/30 px-4 py-3" data-testid="profiles-mascot-help">
-			<img src={help.image} alt="" aria-hidden className="size-20 shrink-0 object-contain" />
-			<div className="min-w-0 flex-1">
-				<p className="text-sm font-semibold text-foreground">{help.title}</p>
-				<p className="mt-1 max-w-2xl text-[13px] leading-relaxed text-[var(--text-subtle)]">{help.body}</p>
-				<div className="mt-2 flex flex-wrap gap-1.5">
-					{help.points.map(point => (
-						<Badge key={point} variant="outline" className="border-border bg-muted/20 text-[var(--text-subtle)]">
-							{point}
-						</Badge>
-					))}
+		<Card className="glow-panel flex w-full flex-col gap-6 rounded-[1.5rem] border-transparent !px-8 !py-7 sm:flex-row sm:items-center md:!px-12 md:!py-8" data-testid="profiles-mascot-help">
+			<img src={help.image} alt="" aria-hidden className="size-20 shrink-0 object-contain md:size-24" />
+			<div className="grid min-w-0 flex-1 gap-8 lg:grid-cols-[minmax(14rem,0.72fr)_minmax(0,1.28fr)] lg:items-center">
+				<div className="min-w-0">
+					<p className="text-base font-semibold text-foreground">{help.title}</p>
+					<p className="mt-1 max-w-xl text-[13px] leading-relaxed text-[var(--text-glass-muted)] md:text-sm">{help.body}</p>
+					<ul className="mt-3 grid gap-1.5 text-[12px] leading-snug text-[var(--text-glass-muted)]">
+						{help.points.map(point => (
+							<li key={point} className="flex min-w-0 items-start gap-2">
+								<Check className="mt-0.5 size-3.5 shrink-0 text-[var(--brand-hover)]" aria-hidden />
+								<span className="min-w-0">{point}</span>
+							</li>
+						))}
+					</ul>
 				</div>
+				<MascotCapabilityMatrix />
 			</div>
-			<Button type="button" variant="ghost" size="sm" onClick={onDismiss} className="shrink-0 text-[var(--brand)] hover:text-[var(--brand)]" data-testid="profiles-mascot-dismiss">
-				Got it
-			</Button>
 		</Card>
+	)
+}
+
+function MascotCapabilityMatrix(): JSX.Element {
+	const {t} = useTranslation()
+	return (
+		<div className="min-w-0 lg:border-l lg:border-[var(--glow-border)] lg:pl-7" data-testid="url-capabilities">
+			<p className="text-[9px] font-bold uppercase tracking-[0.12em] text-[var(--text-subtle)]">{t('wizard.url.features.heading')}</p>
+			<div className="mt-3 grid gap-5 sm:grid-cols-3">
+				{FEATURE_GROUPS.map(group => {
+					const Icon = group.icon
+					return (
+						<div key={group.heading} className="min-w-0">
+							<p className="flex items-center gap-2 truncate text-[13px] font-semibold text-foreground">
+								<Icon className="size-4 shrink-0 text-[var(--brand-hover)]" aria-hidden />
+								{t(group.heading)}
+							</p>
+							<div className="mt-2 flex flex-wrap gap-1">
+								{group.items.map(item => (
+									<Badge key={item} variant="outline" className="glow-chip px-2 py-0 text-[12px] font-medium">
+										{t(item)}
+									</Badge>
+								))}
+							</div>
+						</div>
+					)
+				})}
+			</div>
+		</div>
 	)
 }
 
@@ -340,6 +380,7 @@ function QuickProfileCard({
 	activeProfile,
 	disabled,
 	menuOpen,
+	preparing,
 	onDownload,
 	onEditProfile,
 	onManageProfiles,
@@ -351,6 +392,7 @@ function QuickProfileCard({
 	activeProfile: DownloadProfile
 	disabled: boolean
 	menuOpen: boolean
+	preparing: boolean
 	onDownload: () => void
 	onEditProfile: () => void
 	onManageProfiles: () => void
@@ -359,47 +401,70 @@ function QuickProfileCard({
 	onPickProfile: (profile: DownloadProfile) => void
 	profiles: DownloadProfile[]
 }): JSX.Element {
+	const {t} = useTranslation()
 	const ActiveIcon = ICONS[activeProfile.icon]
 	return (
-		<div className="grid w-full grid-cols-[minmax(0,1fr)_4rem] overflow-hidden rounded-lg border border-[var(--brand)] bg-background/25 shadow-[0_4px_14px_var(--brand-glow)] md:grid-cols-[minmax(14rem,0.82fr)_minmax(20rem,1fr)_4rem]" data-testid="profiles-quick-preview">
+		<div className="grid w-full gap-5 md:grid-cols-[minmax(0,1fr)_minmax(0,1.06fr)]" data-testid="profiles-quick-preview">
 			<button
 				type="button"
 				disabled={disabled}
+				aria-busy={preparing}
 				onClick={onDownload}
-				className="group/quick flex min-h-24 min-w-0 items-center gap-4 border-e border-[var(--brand)]/40 bg-[linear-gradient(135deg,var(--brand-dim),transparent_72%)] px-5 py-5 text-left transition-colors hover:bg-background/35 focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none md:min-h-[7rem] md:gap-5 md:px-6 dark:hover:bg-white/5"
+				className={cn(
+					'glow-tile-primary group/quick relative flex min-h-[7rem] min-w-0 items-center gap-5 overflow-hidden rounded-[1.5rem] px-6 py-5 text-left text-white transition-[filter,transform] duration-200 md:min-h-[9rem] md:gap-8 md:px-8',
+					'hover:brightness-[1.08] active:translate-y-px',
+					'focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-inset focus-visible:ring-white/70',
+					disabled && !preparing && 'pointer-events-none opacity-55 saturate-[0.65]',
+					preparing && 'pointer-events-none'
+				)}
 				data-testid="profiles-quick-download"
 			>
-				<Download className="size-10 shrink-0 text-[var(--brand)] md:size-11" aria-hidden />
-				<span className="flex min-w-0 flex-col">
-					<span className="text-lg font-semibold leading-tight text-foreground group-disabled/quick:text-foreground/70 md:text-xl dark:text-white dark:group-disabled/quick:text-white/80">Quick Download</span>
-					<span className="mt-1 text-[12px] font-medium leading-snug text-[var(--text-subtle)] group-disabled/quick:text-[var(--text-subtle)]/80 dark:text-white/70 dark:group-disabled/quick:text-white/55">Start download using the active profile.</span>
+				<span aria-hidden className="pointer-events-none absolute inset-0 bg-[radial-gradient(130%_90%_at_0%_0%,hsl(190_100%_82%/0.34),transparent_52%),radial-gradient(110%_120%_at_100%_120%,hsl(288_96%_68%/0.42),transparent_50%)]" />
+				<span className="icon-tile quick-icon-tile relative grid size-16 shrink-0 place-items-center rounded-2xl md:size-20 [&_svg]:size-8 md:[&_svg]:size-10">{preparing ? <Loader2 className="animate-spin" aria-hidden /> : <Download aria-hidden />}</span>
+				<span className="relative flex min-w-0 flex-col">
+					<span className="text-xl font-semibold leading-tight tracking-[-0.01em] md:text-2xl">{preparing ? `${t('wizard.url.quickPreparing')}…` : t('wizard.url.quickDownload')}</span>
+					<span className="mt-2 text-[13px] font-medium leading-snug text-white md:text-sm">{t('wizard.url.quickDownloadTooltip')}</span>
 				</span>
+				<ChevronRight className="relative ms-auto size-6 shrink-0 text-white/90 transition-transform duration-200 group-hover/quick:translate-x-0.5" aria-hidden />
 			</button>
-			<div className="order-3 col-span-2 flex min-w-0 items-center border-t border-border bg-background/20 p-3 md:order-none md:col-auto md:border-t-0 dark:border-white/10">
-				<div className="flex min-w-0 flex-1 items-center gap-3 rounded-md border border-[var(--border-strong)] bg-background/35 px-3 py-3 dark:bg-white/5" data-testid="profiles-active-profile-card">
-					<div className="grid size-12 shrink-0 place-items-center rounded-md border border-[var(--brand)]/30 bg-[var(--brand-dim)] text-[var(--brand)]">
-						<ActiveIcon aria-hidden />
-					</div>
-					<div className="min-w-0 flex-1">
-						<p className="text-[9px] font-bold uppercase tracking-[0.12em] text-[var(--text-subtle)] dark:text-white/55">Active profile</p>
-						<p className="mt-1 truncate text-base font-semibold leading-tight text-foreground dark:text-white">{activeProfile.name}</p>
-						<p className="mt-1 truncate text-[12px] text-[var(--text-subtle)] dark:text-white/65">
-							{downloadProfileLabel(activeProfile)} · {profileDetail(activeProfile)}
-						</p>
-					</div>
+
+			<div className="glow-tile flex min-w-0 items-center gap-3 rounded-[1.5rem] border-transparent px-4 py-5 md:gap-5 md:px-7" data-testid="profiles-active-profile-card">
+				<div className="icon-tile grid size-14 shrink-0 place-items-center rounded-2xl md:size-20 [&_svg]:size-7 md:[&_svg]:size-8">
+					<ActiveIcon aria-hidden />
+				</div>
+				<div className="min-w-0 flex-1">
+					<p className="text-[9px] font-bold uppercase tracking-[0.12em] text-[var(--text-subtle)]">Active profile</p>
+					<p className="mt-2 flex min-w-0 items-center gap-1.5 truncate text-base font-semibold leading-tight text-foreground md:gap-2 md:text-xl">
+						<span className="truncate">{activeProfile.name}</span>
+						<Sparkles className="hidden size-4 shrink-0 text-[var(--brand-hover)] md:block" aria-hidden />
+					</p>
+					<p className="glass-muted-text mt-1 line-clamp-2 text-[12px] leading-snug md:text-[13px]">
+						{downloadProfileLabel(activeProfile)} · {profileDetail(activeProfile, t)}
+					</p>
+				</div>
+				<div className="flex shrink-0 items-center gap-1.5 md:gap-2">
 					<Tooltip>
 						<TooltipTrigger
 							render={props => (
-								<Button {...props} type="button" variant="outline" size="icon" onClick={onEditProfile} aria-label={`Edit selected profile: ${activeProfile.name}`} className="size-10 shrink-0 border-border bg-background/45 hover:bg-muted dark:border-white/15 dark:bg-white/5 dark:hover:bg-white/10">
+								<Button
+									{...props}
+									type="button"
+									variant="outline"
+									size="icon-lg"
+									onClick={onEditProfile}
+									aria-label={`Edit active profile: ${activeProfile.name}`}
+									className="glow-tile glow-icon-button size-10 rounded-xl border-transparent bg-transparent hover:brightness-110 md:size-14"
+									data-testid="profiles-edit-active-profile"
+								>
 									<PenLine aria-hidden />
 								</Button>
 							)}
 						/>
-						<TooltipContent>Edit selected profile</TooltipContent>
+						<TooltipContent>Edit active profile</TooltipContent>
 					</Tooltip>
+					<ProfileMenu activeProfile={activeProfile} menuOpen={menuOpen} onManageProfiles={onManageProfiles} onMenuOpenChange={onMenuOpenChange} onNewProfile={onNewProfile} onPickProfile={onPickProfile} profiles={profiles} />
 				</div>
 			</div>
-			<ProfileMenu activeProfile={activeProfile} menuOpen={menuOpen} onManageProfiles={onManageProfiles} onMenuOpenChange={onMenuOpenChange} onNewProfile={onNewProfile} onPickProfile={onPickProfile} profiles={profiles} />
 		</div>
 	)
 }
@@ -425,15 +490,8 @@ function ProfileMenu({
 		<Popover open={menuOpen} onOpenChange={onMenuOpenChange}>
 			<PopoverTrigger
 				render={
-					<Button
-						type="button"
-						size="icon-lg"
-						className="order-2 h-full min-h-24 w-full rounded-s-none border-s border-[var(--brand)]/40 bg-background/20 hover:bg-background/35 md:order-none md:min-h-[7rem] dark:bg-white/5 dark:hover:bg-white/10"
-						aria-label="Choose active download profile"
-						title="Choose active download profile"
-						data-testid="profiles-profile-menu-trigger"
-					>
-						<ChevronDown aria-hidden />
+					<Button type="button" variant="outline" size="icon-lg" aria-label="Switch download profile" title="Switch download profile" className="glow-tile glow-icon-button size-10 rounded-xl border-transparent bg-transparent hover:brightness-110 md:size-14" data-testid="profiles-profile-menu-trigger">
+						<ChevronDown aria-hidden className="transition-transform duration-200 group-aria-expanded/button:rotate-180" />
 					</Button>
 				}
 			/>
@@ -493,13 +551,22 @@ function ProfileMenu({
 
 function ActionRow({description, disabled = false, icon: Icon, onClick, testId, title}: {description: string; disabled?: boolean; icon: LucideIcon; onClick: () => void; testId: string; title: string}): JSX.Element {
 	return (
-		<Button type="button" variant="outline" disabled={disabled} onClick={onClick} data-testid={testId} className="h-auto min-h-16 justify-start gap-3 whitespace-normal px-4 py-3 text-left">
-			<Icon data-icon="inline-start" />
-			<span className="flex min-w-0 flex-1 flex-col items-start">
-				<span className="font-semibold">{title}</span>
-				<span className="text-[12px] font-normal text-[var(--text-subtle)]">{description}</span>
+		<Button
+			type="button"
+			variant="ghost"
+			disabled={disabled}
+			onClick={onClick}
+			data-testid={testId}
+			className="glow-tile group/row h-auto min-h-16 justify-start gap-4 whitespace-normal rounded-[1.25rem] border-transparent px-5 py-2.5 text-left transition-[filter,transform] duration-200 hover:bg-transparent hover:brightness-[1.12] active:translate-y-px"
+		>
+			<span className="icon-tile grid size-12 shrink-0 place-items-center rounded-xl transition-transform duration-200 group-hover/row:scale-[1.05]">
+				<Icon className="size-5" aria-hidden />
 			</span>
-			<ChevronRight className="ms-auto text-[var(--text-subtle)]" aria-hidden />
+			<span className="flex min-w-0 flex-1 flex-col items-start">
+				<span className="text-base font-semibold">{title}</span>
+				<span className="glass-muted-text text-[13px] font-normal">{description}</span>
+			</span>
+			<ChevronRight className="glass-muted-text ms-auto" aria-hidden />
 		</Button>
 	)
 }
@@ -519,8 +586,9 @@ function ProfilesTab({
 	profiles: DownloadProfile[]
 	profilesPrefs: DownloadProfilesPrefs | undefined
 }): JSX.Element {
+	const {t} = useTranslation()
 	return (
-		<Card className="rounded-lg border-[var(--border-strong)] bg-card/40" data-testid="profiles-manage-tab">
+		<Card className="glow-panel rounded-2xl border-transparent" data-testid="profiles-manage-tab">
 			<CardHeader className="flex-row flex-wrap items-center justify-between gap-3">
 				<div>
 					<CardTitle className="text-xl font-semibold leading-tight">Download Profiles</CardTitle>
@@ -551,7 +619,7 @@ function ProfilesTab({
 										{active ? <Check className="ml-auto shrink-0 text-[var(--brand)]" aria-hidden /> : null}
 									</span>
 									<span className="mt-1 block text-[12px] leading-snug text-[var(--text-subtle)]">{downloadProfileLabel(profile)}</span>
-									<span className="block text-[12px] leading-snug text-[var(--text-subtle)]">{profileDetail(profile)}</span>
+									<span className="block text-[12px] leading-snug text-[var(--text-subtle)]">{profileDetail(profile, t)}</span>
 								</span>
 							</button>
 							<div className="mt-3 grid grid-cols-2 gap-2">

--- a/src/renderer/src/components/wizard/DownloadProfilesSettingsTab.tsx
+++ b/src/renderer/src/components/wizard/DownloadProfilesSettingsTab.tsx
@@ -1,4 +1,5 @@
 import {useEffect, type JSX, type ReactNode} from 'react'
+import {useTranslation} from 'react-i18next'
 import {AlertTriangle, Gauge} from 'lucide-react'
 import {DEFAULTS} from '@shared/constants.js'
 import type {CookiesBrowser, CookiesMode} from '@shared/types.js'
@@ -58,6 +59,7 @@ function SettingSwitch({id, label, description, checked, onCheckedChange, testId
 }
 
 export function DownloadProfilesSettingsTab(): JSX.Element {
+	const {t} = useTranslation()
 	const {advancedAutoOpen, advancedAutoTarget, settings, setAdvancedAutoOpen, setClipboardWatchEnabled, setCookiesPath, setCookiesMode, setCookiesBrowser, setProxyUrl, setLimitRate, setIncludeIdInSingleFilenames, setCloseBehavior, setAnalyticsEnabled} = useAppStore()
 	const common = settings?.common
 	const cookiesPath = common?.cookiesPath ?? ''
@@ -88,16 +90,16 @@ export function DownloadProfilesSettingsTab(): JSX.Element {
 
 	return (
 		<div className="grid gap-4 lg:grid-cols-2" data-testid="profiles-settings-tab">
-			<SettingsPanel title="Input" description="Same controls that used to live in Advanced settings.">
+			<SettingsPanel title="Input" description={t('wizard.url.advanced')}>
 				<FieldGroup className="gap-4">
-					<SettingSwitch id="profiles-settings-clipboard" label="Clipboard watching" description="Detect copied links and fill the URL input automatically." checked={common?.clipboardWatchEnabled ?? false} onCheckedChange={checked => void setClipboardWatchEnabled(checked)} />
+					<SettingSwitch id="profiles-settings-clipboard" label={t('wizard.url.clipboard.toggle')} description={t('wizard.url.clipboard.toggleDescription')} checked={common?.clipboardWatchEnabled ?? false} onCheckedChange={checked => void setClipboardWatchEnabled(checked)} />
 
 					<Field className="gap-1.5" data-testid="cookies-source">
 						<FieldContent className="gap-0.5">
 							<FieldTitle id="profiles-settings-cookies-mode" className="text-[13px] font-medium text-foreground">
-								Cookie source
+								{t('wizard.url.cookies.sourceLabel')}
 							</FieldTitle>
-							<FieldDescription className="text-[11px] text-[var(--text-subtle)]">Use browser cookies only when a site requires an authenticated session.</FieldDescription>
+							<FieldDescription className="text-[11px] text-[var(--text-subtle)]">{t('wizard.url.cookies.toggleDescription')}</FieldDescription>
 						</FieldContent>
 						<ToggleGroup
 							variant="outline"
@@ -110,52 +112,54 @@ export function DownloadProfilesSettingsTab(): JSX.Element {
 							aria-labelledby="profiles-settings-cookies-mode"
 						>
 							<ToggleGroupItem value="off" className="h-7 px-3 text-[12px] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]">
-								Off
+								{t('wizard.url.cookies.sourceOff')}
 							</ToggleGroupItem>
 							<ToggleGroupItem value="file" className="h-7 px-3 text-[12px] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]">
-								File
+								{t('wizard.url.cookies.sourceFile')}
 							</ToggleGroupItem>
 							<ToggleGroupItem value="browser" className="h-7 px-3 text-[12px] aria-pressed:border-[var(--brand)] aria-pressed:bg-[var(--brand-dim)] aria-pressed:text-[var(--brand)]">
-								Browser
+								{t('wizard.url.cookies.sourceBrowser')}
 							</ToggleGroupItem>
 						</ToggleGroup>
 						<div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
 							<Button type="button" variant="link" size="xs" className="h-auto px-0 text-[11px] text-[var(--text-subtle)] hover:text-foreground" onClick={() => void window.appApi.shell.openExternal(COOKIES_HELP_URL)} data-testid="cookies-help-link">
-								Help
+								{t('wizard.url.cookies.helpLink')}
 							</Button>
 							<Button type="button" variant="link" size="xs" className="h-auto px-0 text-[11px] text-[var(--text-subtle)] hover:text-foreground" onClick={() => void window.appApi.shell.openExternal(COOKIES_FIREFOX_URL)} data-testid="cookies-firefox-link">
-								Firefox extension
+								{t('wizard.url.cookies.extensionFirefox')}
 							</Button>
 							<Button type="button" variant="link" size="xs" className="h-auto px-0 text-[11px] text-[var(--text-subtle)] hover:text-foreground" onClick={() => void window.appApi.shell.openExternal(COOKIES_CHROME_URL)} data-testid="cookies-chrome-link">
-								Chrome extension
+								{t('wizard.url.cookies.extensionChrome')}
 							</Button>
 						</div>
+						<WarningText text={t('wizard.url.cookies.risk')} />
+						{cookiesMode !== 'off' ? <WarningText text={t('wizard.url.cookies.banWarning')} /> : null}
 					</Field>
 
 					{cookiesMode === 'file' ? (
 						<Field className="gap-1.5">
 							<FieldLabel htmlFor="profiles-settings-cookies-path" className="text-[11px] font-medium text-[var(--text-subtle)]">
-								cookies.txt file
+								{t('wizard.url.cookies.fileLabel')}
 							</FieldLabel>
 							<InputGroup className="h-9">
-								<InputGroupInput id="profiles-settings-cookies-path" readOnly value={cookiesPath ? formatHomeRelativePath(cookiesPath, commonPaths) : ''} placeholder="Choose cookies.txt..." className="text-[12px] font-mono" data-testid="profiles-settings-cookies-path" />
+								<InputGroupInput id="profiles-settings-cookies-path" readOnly value={cookiesPath ? formatHomeRelativePath(cookiesPath, commonPaths) : ''} placeholder={t('wizard.url.cookies.placeholder')} className="text-[12px] font-mono" data-testid="profiles-settings-cookies-path" />
 								<InputGroupAddon align="inline-end">
 									<InputGroupButton type="button" onClick={() => void chooseCookiesFile()}>
-										Choose
+										{t('wizard.url.cookies.choose')}
 									</InputGroupButton>
 									<InputGroupButton type="button" onClick={() => void setCookiesPath('')} disabled={!cookiesPath}>
-										Clear
+										{t('wizard.url.cookies.clear')}
 									</InputGroupButton>
 								</InputGroupAddon>
 							</InputGroup>
-							{showMissingFileWarning ? <WarningText text="Cookie file mode is enabled but no file is selected." /> : null}
+							{showMissingFileWarning ? <WarningText text={t('wizard.url.cookies.enabledButNoFile')} /> : null}
 						</Field>
 					) : null}
 
 					{cookiesMode === 'browser' ? (
 						<Field className="gap-1.5">
 							<FieldLabel htmlFor="profiles-settings-cookies-browser-trigger" className="text-[11px] font-medium text-[var(--text-subtle)]">
-								Browser
+								{t('wizard.url.cookies.browserLabel')}
 							</FieldLabel>
 							<Select
 								value={cookiesBrowser ?? ''}
@@ -164,7 +168,7 @@ export function DownloadProfilesSettingsTab(): JSX.Element {
 								}}
 							>
 								<SelectTrigger id="profiles-settings-cookies-browser-trigger" className="w-full" data-testid="profiles-settings-cookies-browser">
-									<SelectValue placeholder="Choose browser...">{selected => visibleBrowsers.find(browser => browser.value === selected)?.label ?? 'Choose browser...'}</SelectValue>
+									<SelectValue placeholder={t('wizard.url.cookies.browserPlaceholder')}>{selected => visibleBrowsers.find(browser => browser.value === selected)?.label ?? t('wizard.url.cookies.browserPlaceholder')}</SelectValue>
 								</SelectTrigger>
 								<SelectContent align="start">
 									<SelectGroup>
@@ -176,22 +180,23 @@ export function DownloadProfilesSettingsTab(): JSX.Element {
 									</SelectGroup>
 								</SelectContent>
 							</Select>
-							{showMissingBrowserWarning ? <WarningText text="Browser cookie mode is enabled but no browser is selected." /> : null}
+							<FieldDescription className="text-[11px] text-[var(--text-subtle)]">{t('wizard.url.cookies.browserHelp')}</FieldDescription>
+							{showMissingBrowserWarning ? <WarningText text={t('wizard.url.cookies.enabledButNoBrowser')} /> : null}
 						</Field>
 					) : null}
 
 					<Field className="gap-1.5">
 						<FieldContent className="gap-0.5">
 							<FieldLabel htmlFor="profiles-settings-proxy-url" className="text-[13px] font-medium text-foreground">
-								Proxy URL
+								{t('wizard.url.proxy.label')}
 							</FieldLabel>
-							<FieldDescription className="text-[11px] text-[var(--text-subtle)]">Optional proxy passed to yt-dlp.</FieldDescription>
+							<FieldDescription className="text-[11px] text-[var(--text-subtle)]">{t('wizard.url.proxy.description')}</FieldDescription>
 						</FieldContent>
 						<InputGroup className="h-9">
-							<InputGroupInput id="profiles-settings-proxy-url" type="url" value={proxyUrl} onChange={event => void setProxyUrl(event.target.value)} placeholder="http://127.0.0.1:8080" className="text-[12px] font-mono" data-testid="profiles-settings-proxy-url" />
+							<InputGroupInput id="profiles-settings-proxy-url" type="url" value={proxyUrl} onChange={event => void setProxyUrl(event.target.value)} placeholder={t('wizard.url.proxy.placeholder')} className="text-[12px] font-mono" data-testid="profiles-settings-proxy-url" />
 							<InputGroupAddon align="inline-end">
 								<InputGroupButton type="button" onClick={() => void setProxyUrl('')} disabled={!proxyUrl}>
-									Clear
+									{t('wizard.url.proxy.clear')}
 								</InputGroupButton>
 							</InputGroupAddon>
 						</InputGroup>
@@ -204,23 +209,23 @@ export function DownloadProfilesSettingsTab(): JSX.Element {
 					<Field orientation="horizontal" className="items-center justify-between gap-3">
 						<FieldContent className="gap-0.5">
 							<FieldTitle id="profiles-settings-speed-limit" className="text-[13px] font-medium text-foreground">
-								Speed limit
+								{t('wizard.url.limitRate.label')}
 							</FieldTitle>
-							<FieldDescription className="text-[11px] text-[var(--text-subtle)]">Throttle new downloads.</FieldDescription>
+							<FieldDescription className="text-[11px] text-[var(--text-subtle)]">{t('wizard.url.limitRate.description')}</FieldDescription>
 						</FieldContent>
 						<Popover>
 							<PopoverTrigger
 								render={
 									<Button type="button" variant="outline" size="sm" aria-labelledby="profiles-settings-speed-limit" data-testid="profiles-settings-limit-rate-trigger">
 										<Gauge data-icon="inline-start" aria-hidden />
-										{limitRate ? formatLimitRateLabel(limitRate) : 'Off'}
+										{limitRate ? formatLimitRateLabel(limitRate) : t('wizard.url.limitRate.off')}
 									</Button>
 								}
 							/>
 							<PopoverContent align="end" sideOffset={8} className="w-64">
 								<div className="flex flex-col gap-1">
-									<p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Speed limit</p>
-									<p className="text-[11px] text-[var(--text-subtle)]">Running jobs need pause/resume to apply changes.</p>
+									<p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t('wizard.url.limitRate.label')}</p>
+									<p className="text-[11px] text-[var(--text-subtle)]">{t('wizard.url.limitRate.activeWarning')}</p>
 								</div>
 								<LimitRatePicker value={limitRate} onChange={value => void setLimitRate(value)} />
 							</PopoverContent>
@@ -231,16 +236,16 @@ export function DownloadProfilesSettingsTab(): JSX.Element {
 
 					<SettingSwitch
 						id="profiles-settings-filename-id"
-						label="Include ID in single-video filenames"
-						description="Keeps filenames stable when titles change."
+						label={t('wizard.url.singleFilenameId.toggle')}
+						description={t('wizard.url.singleFilenameId.toggleDescription')}
 						checked={common?.includeIdInSingleFilenames ?? DEFAULTS.includeIdInSingleFilenames}
 						onCheckedChange={checked => void setIncludeIdInSingleFilenames(checked)}
 						testId="single-filename-id-toggle"
 					/>
 
-					{platform !== 'darwin' ? <SettingSwitch id="profiles-settings-close-tray" label="Close to tray" description="Keep Arroxy running when the window closes." checked={common?.closeBehavior === 'tray'} onCheckedChange={checked => void setCloseBehavior(checked ? 'tray' : 'quit')} /> : null}
+					{platform !== 'darwin' ? <SettingSwitch id="profiles-settings-close-tray" label={t('wizard.url.closeToTray.toggle')} description={t('wizard.url.closeToTray.toggleDescription')} checked={common?.closeBehavior === 'tray'} onCheckedChange={checked => void setCloseBehavior(checked ? 'tray' : 'quit')} /> : null}
 
-					<SettingSwitch id="profiles-settings-analytics" label="Anonymous analytics" description="Help improve Arroxy with anonymous usage events." checked={common?.analyticsEnabled ?? true} onCheckedChange={checked => void setAnalyticsEnabled(checked)} />
+					<SettingSwitch id="profiles-settings-analytics" label={t('wizard.url.analytics.toggle')} description={t('wizard.url.analytics.toggleDescription')} checked={common?.analyticsEnabled ?? true} onCheckedChange={checked => void setAnalyticsEnabled(checked)} />
 				</FieldGroup>
 			</SettingsPanel>
 		</div>

--- a/src/renderer/src/components/wizard/MixedUrlPromptDialog.tsx
+++ b/src/renderer/src/components/wizard/MixedUrlPromptDialog.tsx
@@ -29,7 +29,9 @@ export function MixedUrlPromptDialog(): JSX.Element {
 				<DialogDescription>{t('wizard.mixedPrompt.body')}</DialogDescription>
 				<Alert variant="info" className="mt-3 flex items-center gap-3 py-2 text-[12px]" data-testid="mixed-playlist-cap">
 					<Info className="shrink-0" />
-					<AlertDescription className="min-w-0 flex-1 text-[12px]">{t('wizard.mixedPrompt.playlistLimit', {count: playlistLimit})}</AlertDescription>
+					<AlertDescription className="min-w-0 flex-1 text-[12px]" title={t('wizard.url.playlistProbeLimit.tooltip')}>
+						{t('wizard.mixedPrompt.playlistLimit', {count: playlistLimit})} · {t('wizard.url.playlistProbeLimit.description')}
+					</AlertDescription>
 					<PlaylistProbeLimitSelector testId="mixed-playlist-probe-limit" showCurrent={false} className="w-36" />
 				</Alert>
 				<DialogFooter>

--- a/src/renderer/src/dev/browserMockScenarios.ts
+++ b/src/renderer/src/dev/browserMockScenarios.ts
@@ -62,7 +62,7 @@ export const BROWSER_MOCK_SCENARIO_IDS = [
 
 export type BrowserMockScenarioId = (typeof BROWSER_MOCK_SCENARIO_IDS)[number]
 export type BrowserMockScenarioGroup = 'General' | 'Playlist' | 'Profiles' | 'Probe Results' | 'Probe Errors' | 'Dialogs' | 'Updates' | 'Queue' | 'Diagnostics'
-type ScenarioKind = 'default' | 'probe' | 'bulk' | 'queue' | 'update' | 'diagnostics' | 'dialog'
+type ScenarioKind = 'default' | 'probe' | 'bulk' | 'profile' | 'queue' | 'update' | 'diagnostics' | 'dialog'
 
 const SINGLE_NORMAL_MOCK_STEPS = ['formats', 'subtitles', 'sponsorblock', 'output', 'folder', 'confirm'] as const
 const PLAYLIST_NORMAL_MOCK_STEPS = ['playlistItems', 'playlistPresets', 'sponsorblock', 'output', 'folder', 'confirm'] as const
@@ -130,13 +130,13 @@ export const BROWSER_MOCK_SCENARIOS: readonly BrowserMockScenario[] = [
 	{id: 'playlist-no-thumbnails', group: 'Playlist', title: 'No thumbnails', description: 'Playlist rows with no thumbnail column.', kind: 'probe'},
 	{id: 'playlist-long-titles', group: 'Playlist', title: 'Long titles', description: 'Playlist rows with intentionally long titles.', kind: 'probe'},
 	{id: 'bulk-stress', group: 'Playlist', title: 'Bulk stress', description: 'Visual fixture for 50 bulk URL rows with long duplicate titles, missing thumbnails, and mixed metadata states.', kind: 'bulk'},
-	{id: 'profiles-home-empty', group: 'Profiles', title: 'Profiles home', description: 'Redesigned main screen with active built-in profile and no custom profile dialog open.', kind: 'default'},
-	{id: 'profiles-home-clipboard-single', group: 'Profiles', title: 'Clipboard single', description: 'Profile home after clipboard watching filled one link and showed a toast.', kind: 'default'},
-	{id: 'profiles-home-clipboard-bulk', group: 'Profiles', title: 'Clipboard bulk', description: 'Profile home after clipboard watching filled several links and showed a toast.', kind: 'default'},
-	{id: 'profiles-split-menu', group: 'Profiles', title: 'Profile menu', description: 'Quick Download split button with profile picker opened.', kind: 'default'},
-	{id: 'profiles-editor', group: 'Profiles', title: 'Profile editor', description: 'Create/edit profile form in one dialog.', kind: 'default'},
-	{id: 'profiles-bulk', group: 'Profiles', title: 'Bulk URLs dialog', description: 'Existing bulk dialog opened from the redesigned main screen.', kind: 'default'},
-	{id: 'profiles-playlist-cap', group: 'Profiles', title: 'Playlist cap dialog', description: 'Quick Download playlist probe limit confirmation.', kind: 'default'},
+	{id: 'profiles-home-empty', group: 'Profiles', title: 'Profiles home', description: 'Redesigned main screen with active built-in profile and no dialog open.', kind: 'profile'},
+	{id: 'profiles-home-clipboard-single', group: 'Profiles', title: 'Clipboard single', description: 'Profile home with one clipboard-detected link prefilled.', kind: 'profile'},
+	{id: 'profiles-home-clipboard-bulk', group: 'Profiles', title: 'Clipboard bulk', description: 'Profile home after several clipboard links were detected; the first link is prefilled.', kind: 'profile'},
+	{id: 'profiles-split-menu', group: 'Profiles', title: 'Profile menu', description: 'Quick Download profile picker opened.', kind: 'profile'},
+	{id: 'profiles-editor', group: 'Profiles', title: 'Profile editor', description: 'New profile form opened in a dialog.', kind: 'profile'},
+	{id: 'profiles-bulk', group: 'Profiles', title: 'Bulk URLs dialog', description: 'Bulk URLs dialog opened from the redesigned main screen.', kind: 'profile'},
+	{id: 'profiles-playlist-cap', group: 'Profiles', title: 'Playlist cap dialog', description: 'Quick Download playlist probe limit confirmation.', kind: 'profile'},
 	{id: 'probe-audio-only', group: 'Probe Results', title: 'Audio only source', description: 'isAudioOnlySource:true - wizard defaults to audio-only mode (Bandcamp/SoundCloud-like extractor).', kind: 'probe'},
 	{id: 'probe-with-subtitles', group: 'Probe Results', title: 'With subtitles', description: 'Video with manual subtitle tracks and auto-caption pool.', kind: 'probe'},
 	{id: 'probe-no-formats', group: 'Probe Results', title: 'No formats', description: 'Video probe returns empty formats array - tests graceful empty state in the format picker.', kind: 'probe'},
@@ -211,6 +211,34 @@ export function buildScenarioAppApiState(scenario: BrowserMockScenario, params?:
 	return {scenario, settings, probeResult: buildProbeResult(scenario, params), probeError: buildProbeError(scenario, params), queueItems: buildQueueItems(scenario), update: buildUpdate(scenario), warmUp: buildWarmUp(scenario)}
 }
 
+const PROFILE_SINGLE_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+const PROFILE_BULK_URLS = ['https://www.youtube.com/watch?v=dQw4w9WgXcQ', 'https://www.youtube.com/watch?v=jNQXAC9IVRw', 'https://www.youtube.com/watch?v=oHg5SJYRHA0'] as const
+
+function profileScenarioPatch(scenario: BrowserMockScenario): Partial<AppState> {
+	if (scenario.id === 'profiles-home-clipboard-single') return {wizardStep: 'url', wizardUrl: PROFILE_SINGLE_URL}
+	if (scenario.id === 'profiles-home-clipboard-bulk') return {wizardStep: 'url', wizardUrl: PROFILE_BULK_URLS[0]}
+	if (scenario.id === 'profiles-split-menu') return {wizardStep: 'url', wizardUrl: PROFILE_SINGLE_URL}
+	if (scenario.id === 'profiles-playlist-cap') {
+		const playlist = playlistProbe(DEFAULT_PLAYLIST_PROBE_LIMIT, {webpageUrl: 'https://www.youtube.com/playlist?list=PLbrowsermock&items=100'})
+		if (playlist.kind !== 'playlist') return {wizardStep: 'url', wizardUrl: ''}
+		return {
+			wizardStep: 'url',
+			wizardMode: 'playlist',
+			wizardUrl: playlist.webpageUrl,
+			wizardExtractor: playlist.extractor,
+			wizardExtractorKey: playlist.extractorKey,
+			playlistItems: playlist.entries,
+			selectedPlaylistItemIds: playlist.entries.map(entry => entry.id),
+			playlistTitle: playlist.playlistTitle,
+			playlistId: playlist.playlistId,
+			playlistIsMultiVideo: true,
+			playlistLikelyCapped: true,
+			quickPlaylistCapDialogOpen: true
+		}
+	}
+	return {wizardStep: 'url', wizardUrl: ''}
+}
+
 export async function applyScenarioWorkbenchState(input: {scenario: BrowserMockScenario; params: BrowserMockUrlParams; store: ScenarioWorkbenchStore}): Promise<void> {
 	const {scenario, params, store} = input
 	if (scenario.kind === 'probe' || params.playlistCount !== null || params.probeErrorKind !== null) {
@@ -224,6 +252,11 @@ export async function applyScenarioWorkbenchState(input: {scenario: BrowserMockS
 	if (scenario.kind === 'bulk') {
 		store.reset()
 		store.setState(bulkStressState())
+		return
+	}
+	if (scenario.kind === 'profile') {
+		store.reset()
+		store.setState(profileScenarioPatch(scenario))
 		return
 	}
 	if (scenario.kind === 'dialog') {

--- a/src/renderer/src/styles.css
+++ b/src/renderer/src/styles.css
@@ -13,11 +13,13 @@
 @theme {
 	--font-sans: "Poppins", sans-serif;
 	--font-mono: "JetBrains Mono", monospace;
-	/* Primary brand color: Arroxi Blue */
+	/* Primary brand color: Arroxi Blue — the One Voice, identical in both skies */
 	--brand: hsl(220, 100%, 56%);
 	--brand-dim: hsl(220 100% 56% / 0.12);
 	--brand-hover: hsl(220, 100%, 65%);
-	--brand-glow: hsl(220 100% 56% / 0.3);
+	--icon-tile-ink: hsl(220 100% 94%);
+	--text-glass-muted: hsl(229 36% 78%);
+	/* --brand-glow and --glow-border are mode-aware; defined per sky in :root / .dark */
 	/* Status colors from Arroxi brand palette */
 	--color-status-done: hsl(153, 74%, 45%);
 	--color-status-done-glow: hsl(153 74% 45% / 0.05);
@@ -40,10 +42,48 @@
 		@apply font-sans;
 	}
 	body {
-		@apply antialiased bg-background text-foreground;
+		@apply antialiased text-foreground;
+		position: relative;
+		background: var(--background);
 		font-family: var(--font-sans);
 		font-size: 18px;
 		line-height: 1.5;
+	}
+	#root {
+		position: relative;
+		z-index: 1;
+		min-height: 100vh;
+	}
+
+	/* ── Aurora: bloom over the void (dark) / pale wash over the field (light).
+	   Fixed, behind all content, never blurred — it is the canvas the glass floats on. */
+	body::before {
+		content: "";
+		position: fixed;
+		inset: 0;
+		z-index: 0;
+		pointer-events: none;
+		background: var(--aurora);
+	}
+
+	/* Aurora ribbon: a soft conic light streak in the top-right — the diagonal
+	   "light behind the glass" sweep. Blurred, pinned behind content. */
+	body::after {
+		content: "";
+		position: fixed;
+		inset: 2.25rem 4rem auto auto;
+		width: min(58rem, 68vw);
+		height: 12rem;
+		z-index: 0;
+		pointer-events: none;
+		background: var(--aurora-ribbon);
+		filter: blur(18px);
+		mask-image: radial-gradient(88% 72% at 62% 50%, black 0 46%, transparent 78%);
+		-webkit-mask-image: radial-gradient(88% 72% at 62% 50%, black 0 46%, transparent 78%);
+		mix-blend-mode: screen;
+		opacity: var(--aurora-ribbon-opacity);
+		transform: rotate(8deg) skewX(-14deg);
+		transform-origin: 82% 28%;
 	}
 
 	::-webkit-scrollbar {
@@ -64,6 +104,172 @@
 	}
 	* {
 		@apply border-border outline-ring/50;
+	}
+}
+
+/* ── Glass surface: frosted panel material that floats above the canvas.
+   Dark sky = translucent navy; light sky = frosted white. Two layers max. */
+@utility glass {
+	background: var(--glass-panel) !important;
+	backdrop-filter: blur(28px) saturate(160%);
+	-webkit-backdrop-filter: blur(28px) saturate(160%);
+}
+@utility glass-raised {
+	background: var(--card);
+	backdrop-filter: blur(18px) saturate(135%);
+	-webkit-backdrop-filter: blur(18px) saturate(135%);
+}
+
+/* ── Glow panel: lit-from-within glass for OUTERMOST / standalone surfaces.
+   The edge is a true GRADIENT border (cyan→blue→violet) painted via border-box,
+   not a uniform ring — that is what reads as neon edge-lighting. Plus a diagonal
+   inner sheen (padding-box), a top highlight, an inset floor bloom, and a soft
+   outer bloom. Owns the backdrop blur. The Aurora Console surface. */
+@utility glow-panel {
+	position: relative;
+	border: 1px solid transparent;
+	background:
+		radial-gradient(90% 120% at 4% 10%, var(--glass-cyan), transparent 48%) padding-box,
+		radial-gradient(100% 120% at 104% 112%, var(--glass-violet), transparent 52%) padding-box,
+		linear-gradient(145deg, hsl(212 100% 56% / 0.18), transparent 58%) padding-box,
+		var(--glass-panel) padding-box,
+		var(--glow-gradient) border-box !important;
+	backdrop-filter: blur(32px) saturate(165%);
+	-webkit-backdrop-filter: blur(32px) saturate(165%);
+	box-shadow:
+		inset 0 1px 0 0 var(--glass-sheen),
+		inset 0 -34px 74px -36px var(--inner-bloom),
+		var(--panel-glow);
+}
+/* ── Glow tile: same lit gradient edge, but NO backdrop blur. For tiles that
+   live INSIDE a glow-panel — the parent already blurred the canvas; re-blurring
+   blurred content only muddies it. Keeps the stack at one blur layer. */
+@utility glow-tile {
+	position: relative;
+	border: 1px solid transparent;
+	background:
+		radial-gradient(120% 150% at 0% 0%, var(--glass-cyan), transparent 44%) padding-box,
+		radial-gradient(120% 150% at 100% 110%, var(--glass-violet), transparent 48%) padding-box,
+		linear-gradient(145deg, hsl(212 100% 56% / 0.17), transparent 58%) padding-box,
+		var(--glass-tile) padding-box,
+		var(--glow-gradient) border-box !important;
+	box-shadow:
+		inset 0 1px 0 0 var(--glass-sheen),
+		inset 0 -28px 60px -34px var(--inner-bloom),
+		var(--panel-glow);
+}
+/* Primary inner tile: hotter gradient edge + real outer bloom (the one signal). */
+@utility glow-tile-primary {
+	position: relative;
+	border: 1.5px solid transparent;
+	background:
+		radial-gradient(105% 130% at 8% 12%, hsl(190 100% 74% / 0.38), transparent 46%) padding-box,
+		radial-gradient(105% 130% at 96% 108%, hsl(283 96% 67% / 0.5), transparent 52%) padding-box,
+		linear-gradient(135deg, hsl(211 100% 62%), hsl(226 96% 48%) 58%, hsl(259 92% 52%)) padding-box,
+		var(--glow-gradient-hot) border-box;
+	box-shadow:
+		inset 0 1px 0 0 hsl(205 100% 88% / 0.5),
+		inset 0 0 0 1px hsl(0 0% 100% / 0.12),
+		inset 0 -34px 76px -34px hsl(274 96% 62% / 0.6),
+		0 0 0 1px hsl(205 100% 80% / 0.26),
+		0 0 72px -5px hsl(212 100% 56% / 0.72),
+		0 18px 58px -14px hsl(222 100% 48% / 0.62);
+}
+
+/* ── Icon tile: small dimensional gradient chip. A diagonal blue fill, a cyan
+   top-left radial sheen, a violet floor, a top highlight, and a soft glow ring.
+   Reads as a lit object, not a flat box. */
+@utility icon-tile {
+	position: relative;
+	overflow: hidden;
+	border: 1px solid var(--glow-border);
+	background:
+		radial-gradient(105% 105% at 28% 18%, hsl(194 100% 78% / 0.46), transparent 44%) padding-box,
+		radial-gradient(110% 125% at 72% 108%, hsl(276 94% 64% / 0.42), transparent 48%) padding-box,
+		linear-gradient(145deg, hsl(214 100% 58% / 0.42), hsl(238 82% 42% / 0.18) 52%, var(--brand-dim)) padding-box !important;
+	box-shadow:
+		inset 0 1px 0 0 hsl(0 0% 100% / 0.42),
+		inset 0 -13px 28px -14px hsl(272 96% 64% / 0.62),
+		0 0 0 1px hsl(208 100% 74% / 0.18),
+		0 0 28px -5px var(--brand-glow);
+	color: var(--icon-tile-ink);
+}
+.icon-tile::before {
+	content: "";
+	position: absolute;
+	inset: 1px;
+	border-radius: inherit;
+	pointer-events: none;
+	background: linear-gradient(160deg, hsl(0 0% 100% / 0.28), transparent 38%);
+}
+.icon-tile > svg {
+	position: relative;
+	z-index: 1;
+	filter: drop-shadow(0 0 8px hsl(213 100% 76% / 0.72));
+	stroke-width: 2.2;
+}
+
+.quick-icon-tile {
+	color: white;
+	background:
+		radial-gradient(105% 105% at 26% 18%, hsl(199 100% 82% / 0.34), transparent 44%) padding-box,
+		radial-gradient(110% 125% at 72% 108%, hsl(302 94% 70% / 0.5), transparent 48%) padding-box,
+		linear-gradient(145deg, hsl(211 100% 66% / 0.48), hsl(239 90% 48% / 0.18) 52%, hsl(278 100% 62% / 0.28)) padding-box !important;
+	box-shadow:
+		inset 0 1px 0 0 hsl(0 0% 100% / 0.48),
+		inset 0 -14px 28px -13px hsl(300 96% 68% / 0.7),
+		0 0 0 1px hsl(205 100% 82% / 0.24),
+		0 0 30px -4px hsl(207 100% 72% / 0.82);
+}
+
+.glass-muted-text {
+	color: var(--text-glass-muted);
+}
+
+.glow-icon-button {
+	color: hsl(225 100% 95%);
+	box-shadow:
+		inset 0 1px 0 var(--glass-sheen),
+		inset 0 -16px 30px -22px var(--inner-bloom),
+		0 0 24px -14px var(--brand-glow);
+}
+
+.chrome-glass {
+	background: linear-gradient(180deg, hsl(214 100% 56% / 0.08), transparent 64%), color-mix(in srgb, var(--background) 68%, transparent);
+	backdrop-filter: blur(20px) saturate(150%);
+	-webkit-backdrop-filter: blur(20px) saturate(150%);
+	box-shadow: inset 0 1px 0 var(--glass-sheen);
+}
+
+.download-home-tabs [data-slot="tabs-trigger"][data-active] {
+	color: var(--foreground);
+	text-shadow: 0 0 18px var(--brand-glow);
+}
+.download-home-tabs [data-slot="tabs-trigger"][data-active]::after {
+	background: linear-gradient(90deg, hsl(194 100% 72%), var(--brand-hover), hsl(268 95% 72%));
+	box-shadow: 0 0 16px var(--brand-glow);
+	opacity: 1;
+}
+
+.glow-chip {
+	border-color: hsl(214 100% 72% / 0.22);
+	background: linear-gradient(180deg, hsl(216 100% 70% / 0.13), hsl(259 92% 62% / 0.08)), color-mix(in srgb, var(--background) 42%, transparent);
+	box-shadow:
+		inset 0 1px 0 hsl(0 0% 100% / 0.12),
+		0 0 16px -8px var(--brand-glow);
+	color: var(--muted-foreground);
+}
+
+/* ── Reduced motion: collapse slide/float/shimmer/pulse to instant.
+   Static glows (box-shadow) are state, not motion, so they survive. */
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+		scroll-behavior: auto !important;
 	}
 }
 
@@ -362,6 +568,7 @@
 	--font-heading: var(--font-sans);
 	--font-sans: "Poppins", sans-serif;
 	--color-border-strong: var(--border-strong);
+	--color-glow-border: var(--glow-border);
 	--color-text-subtle: var(--text-subtle);
 	--color-sidebar-ring: var(--sidebar-ring);
 	--color-sidebar-border: var(--sidebar-border);
@@ -425,12 +632,33 @@
 	--input: hsl(220, 18%, 88%);
 	--ring: hsl(220, 100%, 56%);
 	--text-subtle: hsl(240, 10%, 64%);
+	--text-glass-muted: hsl(240 15% 38%);
+	--icon-tile-ink: hsl(220 100% 48%);
+	/* Light sky — the field: frosted-white glass, lit blue edges, blue aurora wash */
+	--glass: hsl(0 0% 100% / 0.58);
+	--glass-panel: hsl(0 0% 100% / 0.36);
+	--glass-tile: hsl(0 0% 100% / 0.44);
+	--glass-cyan: hsl(200 100% 60% / 0.14);
+	--glass-violet: hsl(266 85% 62% / 0.1);
+	--glass-sheen: hsl(0 0% 100% / 0.8);
+	--glow-border: hsl(220 100% 56% / 0.3);
+	/* Lighter edge gradient over the field — same hue arc, lower alpha */
+	--glow-gradient: linear-gradient(135deg, hsl(200 100% 60% / 0.5), hsl(220 100% 56% / 0.16) 48%, hsl(266 85% 62% / 0.42));
+	--glow-gradient-hot: linear-gradient(120deg, hsl(198 100% 56% / 0.7), hsl(220 100% 56% / 0.4) 50%, hsl(268 88% 60% / 0.62));
+	--inner-bloom: hsl(220 100% 56% / 0.14);
+	--brand-glow: hsl(220 100% 56% / 0.22);
+	--panel-glow: 0 0 28px -10px hsl(220 100% 56% / 0.22), 0 8px 28px -16px hsl(225 60% 20% / 0.25);
+	--aurora-ribbon: linear-gradient(100deg, transparent 0 15%, hsl(198 100% 62% / 0.12) 31%, hsl(198 100% 62% / 0.3) 47%, hsl(220 100% 58% / 0.24) 57%, hsl(266 85% 64% / 0.28) 69%, transparent 86%);
+	--aurora-ribbon-opacity: 0.86;
+	--aurora:
+		radial-gradient(70% 50% at 78% -4%, hsl(212 100% 60% / 0.26), transparent 58%), linear-gradient(152deg, transparent 0 22%, hsl(198 100% 60% / 0.14) 39%, hsl(220 100% 58% / 0.12) 50%, hsl(266 85% 64% / 0.13) 61%, transparent 80%), radial-gradient(86% 70% at 84% 66%, hsl(220 100% 56% / 0.12), transparent 62%),
+		radial-gradient(86% 78% at 10% 76%, hsl(265 85% 62% / 0.09), transparent 64%), var(--background);
 	--chart-1: oklch(0.87 0 0);
 	--chart-2: oklch(0.556 0 0);
 	--chart-3: oklch(0.439 0 0);
 	--chart-4: oklch(0.371 0 0);
 	--chart-5: oklch(0.269 0 0);
-	--radius: 0.625rem;
+	--radius: 1rem;
 	--sidebar: hsl(0, 0%, 100%);
 	--sidebar-foreground: hsl(240, 35%, 12%);
 	--sidebar-primary: hsl(220, 100%, 56%);
@@ -443,37 +671,60 @@
 
 .dark {
 	color-scheme: dark;
-	--background: hsl(240, 20%, 6%);
+	/* Dark sky — the void: near-black navy (225 hue) so the aurora has something to tint */
+	--background: hsl(225, 45%, 5%);
 	--foreground: hsl(240, 40%, 96%);
-	--card: hsl(240, 18%, 10%);
+	--card: hsl(225, 30%, 10%);
 	--card-foreground: hsl(240, 40%, 96%);
-	--popover: hsl(240, 18%, 8%);
+	--popover: hsl(225, 28%, 13%);
 	--popover-foreground: hsl(240, 40%, 96%);
 	--primary: hsl(220, 100%, 56%);
 	--primary-foreground: hsl(240, 40%, 96%);
-	--secondary: hsl(240, 15%, 12%);
+	--secondary: hsl(225, 18%, 13%);
 	--secondary-foreground: hsl(240, 40%, 96%);
-	--muted: hsl(240, 15%, 12%);
-	--muted-foreground: hsl(240, 17%, 60%);
-	--accent: hsl(240, 14%, 15%);
+	--muted: hsl(225, 18%, 13%);
+	--muted-foreground: hsl(228, 24%, 69%);
+	--accent: hsl(225, 16%, 16%);
 	--accent-foreground: hsl(240, 40%, 96%);
 	--destructive: hsl(349, 100%, 61%);
-	--border: hsla(0, 0%, 100%, 0.07);
+	--border: hsla(0, 0%, 100%, 0.08);
 	--border-strong: hsla(0, 0%, 100%, 0.13);
-	--input: hsla(0, 0%, 100%, 0.07);
+	--input: hsla(0, 0%, 100%, 0.08);
 	--ring: hsl(220, 100%, 56%);
-	--text-subtle: hsl(240, 15%, 55%);
+	--text-subtle: hsl(228, 15%, 60%);
+	--text-glass-muted: hsl(229 36% 78%);
+	--icon-tile-ink: hsl(220 100% 94%);
+	/* Dark sky surfaces + signal — lit-from-within glass over a bright nebula */
+	--glass: hsl(223 48% 11% / 0.46);
+	--glass-panel: hsl(224 48% 7% / 0.34);
+	--glass-tile: hsl(222 46% 9% / 0.4);
+	--glass-cyan: hsl(196 100% 64% / 0.18);
+	--glass-violet: hsl(268 95% 64% / 0.15);
+	--glass-sheen: hsl(205 100% 82% / 0.22);
+	--glow-border: hsl(204 100% 68% / 0.68);
+	/* Neon edge gradient: cyan → blue → violet, painted on border-box */
+	--glow-gradient: linear-gradient(135deg, hsl(194 100% 76% / 0.86), hsl(216 100% 64% / 0.38) 46%, hsl(266 95% 72% / 0.76));
+	--glow-gradient-hot: linear-gradient(120deg, hsl(190 100% 82%), hsl(212 100% 70% / 0.86) 48%, hsl(274 98% 76%));
+	--inner-bloom: hsl(212 100% 60% / 0.5);
+	--brand-glow: hsl(218 100% 58% / 0.52);
+	--panel-glow: 0 0 54px -8px hsl(212 100% 56% / 0.52), 0 16px 50px -18px hsl(225 80% 3% / 0.9);
+	--aurora-ribbon: linear-gradient(100deg, transparent 0 14%, hsl(194 100% 66% / 0.2) 31%, hsl(194 100% 66% / 0.86) 47%, hsl(218 100% 60% / 0.72) 57%, hsl(268 95% 66% / 0.82) 69%, transparent 87%);
+	--aurora-ribbon-opacity: 1;
+	--aurora:
+		radial-gradient(66% 46% at 78% -5%, hsl(197 100% 60% / 0.74), transparent 62%), radial-gradient(46% 34% at 73% 0%, hsl(222 100% 62% / 0.42), transparent 58%), radial-gradient(38% 34% at 93% 12%, hsl(276 96% 64% / 0.38), transparent 60%),
+		linear-gradient(152deg, transparent 0 18%, hsl(196 100% 58% / 0.27) 34%, hsl(220 100% 58% / 0.24) 48%, hsl(269 96% 62% / 0.22) 60%, transparent 82%), radial-gradient(92% 74% at 74% 52%, hsl(204 100% 56% / 0.22), transparent 63%), radial-gradient(88% 74% at 96% 82%, hsl(268 96% 58% / 0.18), transparent 66%),
+		radial-gradient(78% 72% at 4% 74%, hsl(260 95% 62% / 0.18), transparent 62%), radial-gradient(120% 90% at 102% 104%, hsl(220 92% 28% / 0.42), transparent 62%), var(--background);
 	--chart-1: oklch(0.87 0 0);
 	--chart-2: oklch(0.556 0 0);
 	--chart-3: oklch(0.439 0 0);
 	--chart-4: oklch(0.371 0 0);
 	--chart-5: oklch(0.269 0 0);
-	--sidebar: hsl(240, 18%, 8%);
+	--sidebar: hsl(225, 28%, 13%);
 	--sidebar-foreground: hsl(240, 40%, 96%);
 	--sidebar-primary: hsl(220, 100%, 56%);
 	--sidebar-primary-foreground: hsl(240, 40%, 96%);
-	--sidebar-accent: hsl(240, 14%, 15%);
+	--sidebar-accent: hsl(225, 16%, 16%);
 	--sidebar-accent-foreground: hsl(240, 40%, 96%);
-	--sidebar-border: hsla(0, 0%, 100%, 0.07);
+	--sidebar-border: hsla(0, 0%, 100%, 0.08);
 	--sidebar-ring: hsl(220, 100%, 56%);
 }

--- a/src/shared/downloadProfiles.ts
+++ b/src/shared/downloadProfiles.ts
@@ -49,7 +49,7 @@ export const BUILTIN_DOWNLOAD_PROFILES: readonly DownloadProfile[] = [
 	baseProfile('best-2160', '2160p', videoAudio('best', ['2160']), 'video'),
 	baseProfile('best-1440', '1440p', videoAudio('best', ['1440']), 'video'),
 	baseProfile('hd-1080', 'HD 1080p', videoAudio('best', ['1080']), 'video'),
-	baseProfile('balanced', 'Balanced', videoAudio('best', ['720']), 'download'),
+	baseProfile('balanced', 'Balanced', videoAudio('best', ['720']), 'controls'),
 	baseProfile('small-file', 'Small file', videoAudio('best', ['480', '360']), 'clip'),
 	baseProfile('mp4-2160', 'MP4 2160p', videoAudio('mp4', ['2160']), 'video'),
 	baseProfile('mp4-1440', 'MP4 1440p', videoAudio('mp4', ['1440']), 'video'),

--- a/src/shared/i18n/locales/am.ts
+++ b/src/shared/i18n/locales/am.ts
@@ -69,8 +69,7 @@ const am = {
 			ignoredCount: 'ተተው',
 			emptyPreview: 'ቡድኑን ለማየት አንድ ወይም ከዚያ በላይ URLዎች ለጥፍ።',
 			needsAtLeastOne: 'ለመቀጠል ቢያንስ አንድ የሚደገፍ URL ጨምር።',
-			confirm: 'እነዚህን URLዎች ተጠቀም',
-			reject: {duplicate: 'ተደጋጋሚ', playlist: 'የplaylist ፍሰት ተጠቀም', channel: 'የchannel ፍሰት ተጠቀም'}
+			reject: {duplicate: 'ተደጋጋሚ'}
 		},
 		playlistPresets: {heading: 'ለቡድኑ ጥራት ይምረጡ', subhead: 'እያንዳንዱ ቪዲዮ የተመረጠውን ደረጃ ራሱን ችሎ ይፈታል — የተለያዩ playlists ያለ ችግር ይሰራሉ።', itemCount_one: '{{count}} ንጥል', itemCount_other: '{{count}} ንጥሎች'},
 		mixedPrompt: {
@@ -79,7 +78,6 @@ const am = {
 			singleVideo: 'ይህን ብቻ',
 			pickFromPlaylist: 'ከ Playlist ምረጥ',
 			playlistLimit: 'የፕሌይሊስት መፈተሻ ገደብ፦ {{count}} ንጥሎች',
-			advancedSettings: 'የላቁ ቅንብሮች',
 			singleTooltip: 'yt-dlp የነጠላ ቪዲዮ ሁነታን ይጠቀማል፣ ከዚህ URL ጋር የተያያዘው playlist ይተዋል።',
 			playlistTooltip: 'yt-dlp የplaylist ሁነታን ተጠቅሞ አስመራጩን ከማሳየቱ በፊት እስከ ገደብዎ ይወስዳል።'
 		},
@@ -87,7 +85,7 @@ const am = {
 		url: {
 			heading: 'YouTube URL',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'ቅርጸቶችን ጫን',
+			interactiveDownload: 'ቅርጸቶችን ጫን',
 			fetchFormatsTooltip: 'ወደ ወረፋ ከመጨመርዎ በፊት ቅርጸቶችን፣ ንዑስ ጽሑፎችን፣ አቃፊን እና የፕሌይሊስት ንጥሎችን በደረጃ ይምረጡ።',
 			quickDownload: 'ፈጣን አውርድ',
 			quickDownloadTooltip: 'የተቀመጡ ወይም ነባሪ ምርጫዎችዎን ተጠቅሞ ይህን ነጠላ ቪዲዮ የማዘጋጃ ደረጃዎችን ሳይከፍት ወደ ወረፋ ያክላል።',
@@ -109,23 +107,7 @@ const am = {
 			mascotBusy: 'በዳራ ዳውንሎድ እያደረጉ ነው… ብዙ ስራ አሰራ 😎',
 			advanced: 'ከፍተኛ',
 			clearAria: 'URL አጽዳ',
-			clipboard: {
-				toggle: 'ቅጂ ሰሌዳ ተቆጣጠር',
-				toggleDescription: 'YouTube አገናኝ ሲቀዱ የ URL መስክን በራስ ሞላ።',
-				dialog: {
-					title: 'YouTube URL ተገኝቷል',
-					body: 'ይህን አገናኝ ከቅጂ ሰሌዳ ይጠቀሙ?',
-					bulkTitle: 'ብዙ URLዎች ተገኙ',
-					bulkBody: 'እነዚህን የclipboard አገናኞች እንደ ብዙ ዳውንሎድ ትጠቀም?',
-					bulkSummary: '{{count}} URLዎች ዝግጁ',
-					bulkIgnored: '{{count}} ተተው',
-					bulkButton: 'ብዙ አውርድ',
-					useButton: 'URL ጠቀም',
-					disableButton: 'አሰናክል',
-					cancelButton: 'ሰርዝ',
-					disableNote: 'የቅጂ ሰሌዳ ክትትልን በኋላ በከፍተኛ ቅንብሮች ውስጥ ዳግም ማስቻል ይችላሉ።'
-				}
-			},
+			clipboard: {toggle: 'ቅጂ ሰሌዳ ተቆጣጠር', toggleDescription: 'YouTube አገናኝ ሲቀዱ የ URL መስክን በራስ ሞላ።', dialog: {cancelButton: 'ሰርዝ'}},
 			cookies: {
 				sourceLabel: 'የ Cookies ምንጭ',
 				sourceOff: 'ጠፍ',
@@ -411,7 +393,6 @@ const am = {
 		footerTooltip: 'Arroxy አጋራ',
 		footerLabel: 'አጋራ',
 		shareAction: 'Arroxy አጋራ',
-		inlineCard: {body: 'Arroxy ደስ ይለዎታል? ጠቃሚ ሊሆን ከሚችልለት ሰው ጋር ያጋሩት።', dismiss: 'የማጋሪያ ሀሳቡን አትኩረው'},
 		highValueBanner: {body: 'Arroxy ደስ ይለዎታል? ሌሎች እንዲያገኙት ይርዷቸው።', dismiss: 'የማጋሪያ ሀሳቡን አትኩረው'}
 	}
 } as const

--- a/src/shared/i18n/locales/ar.ts
+++ b/src/shared/i18n/locales/ar.ts
@@ -69,8 +69,7 @@ const ar = {
 			ignoredCount: 'متجاهلة',
 			emptyPreview: 'الصق رابطًا واحدًا أو أكثر لمعاينة الدفعة.',
 			needsAtLeastOne: 'أضف رابطًا مدعومًا واحدًا على الأقل للمتابعة.',
-			confirm: 'استخدم هذه الروابط',
-			reject: {duplicate: 'مكرر', playlist: 'استخدم مسار قائمة التشغيل', channel: 'استخدم مسار القناة'}
+			reject: {duplicate: 'مكرر'}
 		},
 		playlistPresets: {heading: 'اختر الجودة للدفعة', subhead: 'يحل كل فيديو المستوى المختار بشكل مستقل — قوائم التشغيل غير المتجانسة تعمل بدون مفاجآت.', itemCount_one: '{{count}} عنصر', itemCount_other: '{{count}} عناصر'},
 		mixedPrompt: {
@@ -79,7 +78,6 @@ const ar = {
 			singleVideo: 'هذا الواحد فقط',
 			pickFromPlaylist: 'اختر من الـ Playlist',
 			playlistLimit: 'حد فحص قائمة التشغيل: {{count}} عنصرًا',
-			advancedSettings: 'إعدادات متقدمة',
 			singleTooltip: 'يستخدم وضع الفيديو المفرد في yt-dlp بحيث يتم تجاهل قائمة التشغيل المرتبطة بهذا الرابط.',
 			playlistTooltip: 'يستخدم وضع قائمة التشغيل في yt-dlp ويجلب العناصر حتى حد الفحص قبل عرض أداة الاختيار.'
 		},
@@ -87,7 +85,7 @@ const ar = {
 		url: {
 			heading: 'رابط YouTube',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'جلب الصيغ',
+			interactiveDownload: 'جلب الصيغ',
 			fetchFormatsTooltip: 'اختر الصيغ والترجمات والمجلد وعناصر قوائم التشغيل خطوة بخطوة قبل الإضافة إلى قائمة الانتظار.',
 			quickDownload: 'تنزيل سريع',
 			quickDownloadTooltip: 'يستخدم تفضيلاتك المحفوظة أو الافتراضية ويضيف هذا الفيديو المفرد إلى قائمة الانتظار دون فتح خطوات الإعداد.',
@@ -109,23 +107,7 @@ const ar = {
 			mascotBusy: 'جارٍ التنزيل في الخلفية… أستطيع تعدد المهام 😎',
 			advanced: 'متقدم',
 			clearAria: 'مسح الرابط',
-			clipboard: {
-				toggle: 'مراقبة الحافظة',
-				toggleDescription: 'يملأ حقل الرابط تلقائياً عند نسخ رابط YouTube.',
-				dialog: {
-					title: 'تم اكتشاف رابط YouTube',
-					body: 'هل تريد استخدام هذا الرابط من الحافظة؟',
-					bulkTitle: 'تم اكتشاف روابط متعددة',
-					bulkBody: 'استخدام روابط الحافظة هذه كتنزيل دفعي؟',
-					bulkSummary: '{{count}} روابط جاهزة',
-					bulkIgnored: '{{count}} متجاهلة',
-					bulkButton: 'تنزيل دفعي',
-					useButton: 'استخدام الرابط',
-					disableButton: 'تعطيل',
-					cancelButton: 'إلغاء',
-					disableNote: 'يمكنك إعادة تفعيل مراقبة الحافظة لاحقاً في الإعدادات المتقدمة.'
-				}
-			},
+			clipboard: {toggle: 'مراقبة الحافظة', toggleDescription: 'يملأ حقل الرابط تلقائياً عند نسخ رابط YouTube.', dialog: {cancelButton: 'إلغاء'}},
 			cookies: {
 				sourceLabel: 'مصدر الكوكيز',
 				sourceOff: 'إيقاف',
@@ -456,7 +438,6 @@ const ar = {
 		footerTooltip: 'مشاركة Arroxy',
 		footerLabel: 'مشاركة',
 		shareAction: 'مشاركة Arroxy',
-		inlineCard: {body: 'هل تستمتع بـ Arroxy؟ شاركه مع شخص قد يجده مفيداً.', dismiss: 'إغلاق اقتراح المشاركة'},
 		highValueBanner: {body: 'هل تستمتع بـ Arroxy؟ ساعد الآخرين على اكتشافه.', dismiss: 'إغلاق اقتراح المشاركة'}
 	}
 } as const

--- a/src/shared/i18n/locales/bn.ts
+++ b/src/shared/i18n/locales/bn.ts
@@ -69,8 +69,7 @@ const bn = {
 			ignoredCount: 'উপেক্ষিত',
 			emptyPreview: 'ব্যাচ দেখতে এক বা একাধিক URL পেস্ট করুন।',
 			needsAtLeastOne: 'চালিয়ে যেতে অন্তত একটি সমর্থিত URL যোগ করুন।',
-			confirm: 'এই URLগুলো ব্যবহার করুন',
-			reject: {duplicate: 'ডুপ্লিকেট', playlist: 'playlist flow ব্যবহার করুন', channel: 'channel flow ব্যবহার করুন'}
+			reject: {duplicate: 'ডুপ্লিকেট'}
 		},
 		playlistPresets: {heading: 'ব্যাচের জন্য মান বেছে নিন', subhead: 'প্রতিটি ভিডিও স্বাধীনভাবে বেছে নেওয়া স্তর অনুযায়ী রেজোলিউশন করে — বৈচিত্র্যময় playlist অবাক করা ছাড়াই কাজ করে।', itemCount_one: '{{count}}টি আইটেম', itemCount_other: '{{count}}টি আইটেম'},
 		mixedPrompt: {
@@ -79,7 +78,6 @@ const bn = {
 			singleVideo: 'শুধু এটি',
 			pickFromPlaylist: 'Playlist থেকে বেছে নিন',
 			playlistLimit: 'প্লেলিস্ট প্রোব সীমা: {{count}}টি আইটেম',
-			advancedSettings: 'উন্নত সেটিংস',
 			singleTooltip: 'yt-dlp-এর একক-ভিডিও মোড ব্যবহার করে, তাই এই URL-এর সঙ্গে থাকা প্লেলিস্ট উপেক্ষা করা হয়।',
 			playlistTooltip: 'yt-dlp-এর প্লেলিস্ট মোড ব্যবহার করে এবং পিকার দেখানোর আগে আপনার সীমা পর্যন্ত আইটেম আনে।'
 		},
@@ -87,7 +85,7 @@ const bn = {
 		url: {
 			heading: 'YouTube URL',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'ফরম্যাট আনুন',
+			interactiveDownload: 'ফরম্যাট আনুন',
 			fetchFormatsTooltip: 'কিউতে যোগ করার আগে ধাপে ধাপে ফরম্যাট, সাবটাইটেল, ফোল্ডার এবং প্লেলিস্ট আইটেম বেছে নিন।',
 			quickDownload: 'দ্রুত ডাউনলোড',
 			quickDownloadTooltip: 'সেভ করা বা ডিফল্ট পছন্দ ব্যবহার করে সেটআপ ধাপ না খুলেই এই একক ভিডিওটি কিউতে যোগ করে।',
@@ -109,23 +107,7 @@ const bn = {
 			mascotBusy: 'ব্যাকগ্রাউন্ডে ডাউনলোড হচ্ছে… আমি একসাথে অনেক কাজ করতে পারি 😎',
 			advanced: 'উন্নত',
 			clearAria: 'URL মুছুন',
-			clipboard: {
-				toggle: 'ক্লিপবোর্ড দেখুন',
-				toggleDescription: 'YouTube লিংক কপি করলে URL ফিল্ড স্বয়ংক্রিয়ভাবে পূরণ হবে।',
-				dialog: {
-					title: 'YouTube URL পাওয়া গেছে',
-					body: 'ক্লিপবোর্ডের এই লিংকটি ব্যবহার করবেন?',
-					bulkTitle: 'বাল্ক URL পাওয়া গেছে',
-					bulkBody: 'clipboard-এর এই লিংকগুলো bulk download হিসেবে ব্যবহার করবেন?',
-					bulkSummary: '{{count}} URL প্রস্তুত',
-					bulkIgnored: '{{count}} উপেক্ষিত',
-					bulkButton: 'বাল্ক ডাউনলোড',
-					useButton: 'URL ব্যবহার করুন',
-					disableButton: 'বন্ধ করুন',
-					cancelButton: 'বাতিল',
-					disableNote: 'পরে উন্নত সেটিংসে ক্লিপবোর্ড দেখা আবার চালু করা যাবে।'
-				}
-			},
+			clipboard: {toggle: 'ক্লিপবোর্ড দেখুন', toggleDescription: 'YouTube লিংক কপি করলে URL ফিল্ড স্বয়ংক্রিয়ভাবে পূরণ হবে।', dialog: {cancelButton: 'বাতিল'}},
 			cookies: {
 				sourceLabel: 'কুকিজের উৎস',
 				sourceOff: 'বন্ধ',
@@ -440,7 +422,6 @@ const bn = {
 		footerTooltip: 'Arroxy শেয়ার করুন',
 		footerLabel: 'শেয়ার',
 		shareAction: 'Arroxy শেয়ার করুন',
-		inlineCard: {body: 'Arroxy পছন্দ হচ্ছে? এমন কাউকে শেয়ার করুন যে উপকৃত হতে পারেন।', dismiss: 'শেয়ার পরামর্শ বাতিল করুন'},
 		highValueBanner: {body: 'Arroxy পছন্দ হচ্ছে? অন্যদের আবিষ্কার করতে সাহায্য করুন।', dismiss: 'শেয়ার পরামর্শ বাতিল করুন'}
 	}
 } as const

--- a/src/shared/i18n/locales/de.ts
+++ b/src/shared/i18n/locales/de.ts
@@ -78,8 +78,7 @@ const de = {
 			ignoredCount: 'Ignoriert',
 			emptyPreview: 'Füge eine oder mehrere URLs ein, um den Stapel anzuzeigen.',
 			needsAtLeastOne: 'Füge mindestens eine unterstützte URL hinzu, um fortzufahren.',
-			confirm: 'Diese URLs verwenden',
-			reject: {duplicate: 'Duplikat', playlist: 'Playlist-Ablauf verwenden', channel: 'Kanal-Ablauf verwenden'}
+			reject: {duplicate: 'Duplikat'}
 		},
 		playlistPresets: {heading: 'Qualität für den Stapel wählen', subhead: 'Jedes Video löst die gewählte Stufe unabhängig auf — heterogene Playlists funktionieren ohne Überraschungen.', itemCount_one: '{{count}} Element', itemCount_other: '{{count}} Elemente'},
 		mixedPrompt: {
@@ -88,7 +87,6 @@ const de = {
 			singleVideo: 'Nur dieses eine',
 			pickFromPlaylist: 'Aus Playlist auswählen',
 			playlistLimit: 'Playlist-Prüflimit: {{count}} Einträge',
-			advancedSettings: 'Erweiterte Einstellungen',
 			singleTooltip: 'Verwendet den Einzelvideo-Modus von yt-dlp, sodass die an diese URL angehängte Playlist ignoriert wird.',
 			playlistTooltip: 'Verwendet den Playlist-Modus von yt-dlp und lädt bis zu deinem Playlist-Prüflimit, bevor die Auswahl angezeigt wird.'
 		},
@@ -96,7 +94,7 @@ const de = {
 		url: {
 			heading: 'YouTube-URL',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'Formate abrufen',
+			interactiveDownload: 'Formate abrufen',
 			fetchFormatsTooltip: 'Formate, Untertitel, Ordner und Playlist-Elemente Schritt für Schritt auswählen, bevor sie zur Warteschlange hinzugefügt werden.',
 			quickDownload: 'Schnelldownload',
 			quickDownloadTooltip: 'Verwendet deine gespeicherten oder Standard-Einstellungen und fügt dieses einzelne Video zur Warteschlange hinzu, ohne die Einrichtungsschritte zu öffnen.',
@@ -118,23 +116,7 @@ const de = {
 			mascotBusy: 'Lade im Hintergrund… ich kann mehrere Dinge gleichzeitig 😎',
 			advanced: 'Erweitert',
 			clearAria: 'URL löschen',
-			clipboard: {
-				toggle: 'Zwischenablage beobachten',
-				toggleDescription: 'Füllt das URL-Feld automatisch aus, wenn ein YouTube-Link kopiert wird.',
-				dialog: {
-					title: 'YouTube-URL erkannt',
-					body: 'Diesen Link aus deiner Zwischenablage verwenden?',
-					bulkTitle: 'Bulk-URLs erkannt',
-					bulkBody: 'Diese Links aus der Zwischenablage als Bulk-Download verwenden?',
-					bulkSummary: '{{count}} URLs bereit',
-					bulkIgnored: '{{count}} ignoriert',
-					bulkButton: 'Bulk-Download',
-					useButton: 'URL verwenden',
-					disableButton: 'Deaktivieren',
-					cancelButton: 'Abbrechen',
-					disableNote: 'Du kannst die Zwischenablage-Beobachtung später in den erweiterten Einstellungen wieder aktivieren.'
-				}
-			},
+			clipboard: {toggle: 'Zwischenablage beobachten', toggleDescription: 'Füllt das URL-Feld automatisch aus, wenn ein YouTube-Link kopiert wird.', dialog: {cancelButton: 'Abbrechen'}},
 			cookies: {
 				sourceLabel: 'Cookies-Quelle',
 				sourceOff: 'Aus',
@@ -474,7 +456,6 @@ const de = {
 		footerTooltip: 'Arroxy teilen',
 		footerLabel: 'Teilen',
 		shareAction: 'Arroxy teilen',
-		inlineCard: {body: 'Gefällt dir Arroxy? Teile es mit jemandem, dem es nützlich sein könnte.', dismiss: 'Teilen-Vorschlag schließen'},
 		highValueBanner: {body: 'Gefällt dir Arroxy? Hilf anderen, es zu entdecken.', dismiss: 'Teilen-Vorschlag schließen'}
 	}
 } as const

--- a/src/shared/i18n/locales/el.ts
+++ b/src/shared/i18n/locales/el.ts
@@ -78,8 +78,7 @@ const el = {
 			ignoredCount: 'Αγνοήθηκαν',
 			emptyPreview: 'Επικολλήστε ένα ή περισσότερα URL για προεπισκόπηση της παρτίδας.',
 			needsAtLeastOne: 'Προσθέστε τουλάχιστον ένα υποστηριζόμενο URL για συνέχεια.',
-			confirm: 'Χρήση αυτών των URL',
-			reject: {duplicate: 'Διπλότυπο', playlist: 'Χρήση ροής playlist', channel: 'Χρήση ροής καναλιού'}
+			reject: {duplicate: 'Διπλότυπο'}
 		},
 		playlistPresets: {heading: 'Επιλογή ποιότητας για την ομαδική λήψη', subhead: 'Κάθε βίντεο επιλύει το επιλεγμένο επίπεδο ανεξάρτητα — οι ανομοιογενείς playlist λειτουργούν χωρίς εκπλήξεις.', itemCount_one: '{{count}} στοιχείο', itemCount_other: '{{count}} στοιχεία'},
 		mixedPrompt: {
@@ -88,7 +87,6 @@ const el = {
 			singleVideo: 'Μόνο αυτό',
 			pickFromPlaylist: 'Επιλογή από την playlist',
 			playlistLimit: 'Όριο ελέγχου playlist: {{count}} στοιχεία',
-			advancedSettings: 'Σύνθετες ρυθμίσεις',
 			singleTooltip: 'Χρησιμοποιεί τη λειτουργία μεμονωμένου βίντεο του yt-dlp ώστε να αγνοηθεί η playlist που είναι συνδεδεμένη με αυτό το URL.',
 			playlistTooltip: 'Χρησιμοποιεί τη λειτουργία playlist του yt-dlp και ανακτά μέχρι το όριό σου πριν εμφανίσει τον επιλογέα.'
 		},
@@ -96,7 +94,7 @@ const el = {
 		url: {
 			heading: 'YouTube URL',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'Φόρτωση μορφών',
+			interactiveDownload: 'Φόρτωση μορφών',
 			fetchFormatsTooltip: 'Επίλεξε μορφές, υπότιτλους, φάκελο και στοιχεία playlist βήμα προς βήμα πριν μπουν στην ουρά.',
 			quickDownload: 'Γρήγορη λήψη',
 			quickDownloadTooltip: 'Χρησιμοποιεί τις αποθηκευμένες ή προεπιλεγμένες προτιμήσεις σου και προσθέτει αυτό το μεμονωμένο βίντεο στην ουρά χωρίς τα βήματα ρύθμισης.',
@@ -118,23 +116,7 @@ const el = {
 			mascotBusy: 'Λήψη στο παρασκήνιο… Ξέρω να κάνω πολλά μαζί 😎',
 			advanced: 'Για προχωρημένους',
 			clearAria: 'Εκκαθάριση URL',
-			clipboard: {
-				toggle: 'Παρακολούθηση πρόχειρου',
-				toggleDescription: 'Αυτόματη συμπλήρωση του πεδίου URL όταν αντιγράφεις σύνδεσμο YouTube.',
-				dialog: {
-					title: 'Εντοπίστηκε YouTube URL',
-					body: 'Να χρησιμοποιηθεί αυτός ο σύνδεσμος από το πρόχειρο;',
-					bulkTitle: 'Εντοπίστηκαν μαζικά URL',
-					bulkBody: 'Χρήση αυτών των συνδέσμων από το πρόχειρο ως μαζική λήψη;',
-					bulkSummary: '{{count}} URL έτοιμα',
-					bulkIgnored: '{{count}} αγνοήθηκαν',
-					bulkButton: 'Μαζική λήψη',
-					useButton: 'Χρήση URL',
-					disableButton: 'Απενεργοποίηση',
-					cancelButton: 'Ακύρωση',
-					disableNote: 'Μπορείς να επανενεργοποιήσεις την παρακολούθηση πρόχειρου αργότερα στις Ρυθμίσεις για προχωρημένους.'
-				}
-			},
+			clipboard: {toggle: 'Παρακολούθηση πρόχειρου', toggleDescription: 'Αυτόματη συμπλήρωση του πεδίου URL όταν αντιγράφεις σύνδεσμο YouTube.', dialog: {cancelButton: 'Ακύρωση'}},
 			cookies: {
 				sourceLabel: 'Πηγή cookies',
 				sourceOff: 'Απενεργοποιημένο',
@@ -474,7 +456,6 @@ const el = {
 		footerTooltip: 'Κοινή χρήση Arroxy',
 		footerLabel: 'Κοινή χρήση',
 		shareAction: 'Κοινή χρήση Arroxy',
-		inlineCard: {body: 'Σου αρέσει το Arroxy; Μοιράσου το με κάποιον που μπορεί να το βρει χρήσιμο.', dismiss: 'Απόρριψη πρότασης κοινοποίησης'},
 		highValueBanner: {body: 'Σου αρέσει το Arroxy; Βοήθησε άλλους να το ανακαλύψουν.', dismiss: 'Απόρριψη πρότασης κοινοποίησης'}
 	}
 } as const

--- a/src/shared/i18n/locales/en.ts
+++ b/src/shared/i18n/locales/en.ts
@@ -70,8 +70,7 @@ const en = {
 			ignoredCount: 'Ignored',
 			emptyPreview: 'Paste one or more URLs to preview the batch.',
 			needsAtLeastOne: 'Add at least one supported URL to continue.',
-			confirm: 'Use these URLs',
-			reject: {duplicate: 'Duplicate', playlist: 'Playlist', channel: 'Channel'}
+			reject: {duplicate: 'Duplicate'}
 		},
 		mixedPrompt: {
 			title: 'This link has a playlist',
@@ -79,14 +78,13 @@ const en = {
 			singleVideo: 'Just this one',
 			pickFromPlaylist: 'Pick from playlist',
 			playlistLimit: 'Playlist probe limit: {{count}} items',
-			advancedSettings: 'Advanced settings',
 			singleTooltip: 'Uses yt-dlp single-video mode so the playlist attached to this URL is ignored.',
 			playlistTooltip: 'Uses yt-dlp playlist mode and fetches up to your playlist probe limit before showing the picker.'
 		},
 		url: {
 			heading: 'Video URL',
 			placeholder: 'https://...',
-			fetchFormats: 'Fetch formats',
+			interactiveDownload: 'Interactive Download',
 			fetchFormatsTooltip: 'Choose formats, subtitles, folder, and playlist items step by step before queueing.',
 			quickDownload: 'Quick download',
 			quickDownloadTooltip: 'Uses the active Download Profile and queues the URL without opening the setup steps.',
@@ -102,29 +100,13 @@ const en = {
 				heading: 'What Arroxy can pull',
 				youtube: {heading: 'YouTube', video: 'Videos', channel: 'Channels', playlist: 'Playlists', short: 'Shorts', music: 'Music', podcast: 'Podcasts'},
 				anySite: {heading: '2000+ sites', video: 'Videos', videoPlaylist: 'Video playlists', musicPlaylist: 'Music playlists'},
-				always: {heading: 'Always available', audioOnly: 'Audios only', subtitles: 'Subtitles'}
+				always: {heading: 'Always available', audioOnly: 'Audio only', subtitles: 'Subtitles'}
 			},
 			mascotIdle: 'Drop a link — YouTube or any of 2000+ sites ✨',
 			mascotBusy: 'Downloading in the background… I can multitask 😎',
 			advanced: 'Advanced',
 			clearAria: 'Clear URL',
-			clipboard: {
-				toggle: 'Watch clipboard',
-				toggleDescription: 'Auto-fill the URL field when you copy a video link.',
-				dialog: {
-					title: 'Video URL detected',
-					body: 'Use this link from your clipboard?',
-					bulkTitle: 'Bulk URLs detected',
-					bulkBody: 'Use these clipboard links as a bulk download?',
-					bulkSummary: '{{count}} URLs ready',
-					bulkIgnored: '{{count}} ignored',
-					bulkButton: 'Bulk download',
-					useButton: 'Use URL',
-					disableButton: 'Disable',
-					cancelButton: 'Cancel',
-					disableNote: 'You can re-enable clipboard watching later in Advanced settings.'
-				}
-			},
+			clipboard: {toggle: 'Watch clipboard', toggleDescription: 'Auto-fill the URL field when you copy a video link.', dialog: {cancelButton: 'Cancel'}},
 			cookies: {
 				sourceLabel: 'Cookies source',
 				sourceOff: 'Off',
@@ -452,7 +434,6 @@ const en = {
 		footerTooltip: 'Share Arroxy',
 		footerLabel: 'Share',
 		shareAction: 'Share Arroxy',
-		inlineCard: {body: 'Enjoying Arroxy? Share it with someone who might find it useful.', dismiss: 'Dismiss share suggestion'},
 		highValueBanner: {body: 'Enjoying Arroxy? Help others discover it.', dismiss: 'Dismiss share suggestion'}
 	}
 } as const

--- a/src/shared/i18n/locales/es.ts
+++ b/src/shared/i18n/locales/es.ts
@@ -78,8 +78,7 @@ const es = {
 			ignoredCount: 'Ignoradas',
 			emptyPreview: 'Pega una o más URLs para previsualizar el lote.',
 			needsAtLeastOne: 'Añade al menos una URL compatible para continuar.',
-			confirm: 'Usar estas URLs',
-			reject: {duplicate: 'Duplicado', playlist: 'Usar flujo de playlist', channel: 'Usar flujo de canal'}
+			reject: {duplicate: 'Duplicado'}
 		},
 		playlistPresets: {heading: 'Elige la calidad para el lote', subhead: 'Cada vídeo resuelve el nivel elegido de forma independiente — las playlists heterogéneas funcionan sin sorpresas.', itemCount_one: '{{count}} elemento', itemCount_other: '{{count}} elementos'},
 		mixedPrompt: {
@@ -88,14 +87,13 @@ const es = {
 			singleVideo: 'Solo este',
 			pickFromPlaylist: 'Elegir de la Playlist',
 			playlistLimit: 'Límite de análisis de playlist: {{count}} elementos',
-			advancedSettings: 'Ajustes avanzados',
 			singleTooltip: 'Usa el modo de vídeo único de yt-dlp para ignorar la playlist adjunta a esta URL.',
 			playlistTooltip: 'Usa el modo playlist de yt-dlp y carga hasta tu límite de análisis antes de mostrar el selector.'
 		},
 		url: {
 			heading: 'URL de YouTube',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'Obtener formatos',
+			interactiveDownload: 'Obtener formatos',
 			fetchFormatsTooltip: 'Elige formatos, subtítulos, carpeta y elementos de playlist paso a paso antes de enviar a la cola.',
 			quickDownload: 'Descarga rápida',
 			quickDownloadTooltip: 'Usa tus preferencias guardadas o predeterminadas y añade este video individual a la cola sin abrir los pasos de configuración.',
@@ -117,23 +115,7 @@ const es = {
 			mascotBusy: 'Descargando en segundo plano… puedo hacer varias cosas a la vez 😎',
 			advanced: 'Avanzado',
 			clearAria: 'Borrar URL',
-			clipboard: {
-				toggle: 'Vigilar portapapeles',
-				toggleDescription: 'Rellena automáticamente el campo URL al copiar un enlace de YouTube.',
-				dialog: {
-					title: 'URL de YouTube detectada',
-					body: '¿Usar este enlace de tu portapapeles?',
-					bulkTitle: 'URLs en lote detectadas',
-					bulkBody: '¿Usar estos enlaces del portapapeles como descarga en lote?',
-					bulkSummary: '{{count}} URLs listas',
-					bulkIgnored: '{{count}} ignoradas',
-					bulkButton: 'Descarga en lote',
-					useButton: 'Usar URL',
-					disableButton: 'Desactivar',
-					cancelButton: 'Cancelar',
-					disableNote: 'Puedes volver a activar la vigilancia del portapapeles más tarde en Avanzado.'
-				}
-			},
+			clipboard: {toggle: 'Vigilar portapapeles', toggleDescription: 'Rellena automáticamente el campo URL al copiar un enlace de YouTube.', dialog: {cancelButton: 'Cancelar'}},
 			cookies: {
 				sourceLabel: 'Fuente de cookies',
 				sourceOff: 'Desactivado',
@@ -473,7 +455,6 @@ const es = {
 		footerTooltip: 'Compartir Arroxy',
 		footerLabel: 'Compartir',
 		shareAction: 'Compartir Arroxy',
-		inlineCard: {body: '¿Disfrutando Arroxy? Compártelo con alguien a quien le pueda resultar útil.', dismiss: 'Descartar sugerencia de compartir'},
 		highValueBanner: {body: '¿Disfrutando Arroxy? Ayuda a otros a descubrirlo.', dismiss: 'Descartar sugerencia de compartir'}
 	}
 } as const

--- a/src/shared/i18n/locales/fr.ts
+++ b/src/shared/i18n/locales/fr.ts
@@ -78,8 +78,7 @@ const fr = {
 			ignoredCount: 'Ignorées',
 			emptyPreview: 'Collez une ou plusieurs URLs pour prévisualiser le lot.',
 			needsAtLeastOne: 'Ajoutez au moins une URL prise en charge pour continuer.',
-			confirm: 'Utiliser ces URLs',
-			reject: {duplicate: 'Doublon', playlist: 'Utiliser le flux playlist', channel: 'Utiliser le flux chaîne'}
+			reject: {duplicate: 'Doublon'}
 		},
 		playlistPresets: {heading: 'Choisir la qualité pour le lot', subhead: 'Chaque vidéo résout le niveau choisi indépendamment — les playlists hétérogènes fonctionnent sans surprise.', itemCount_one: '{{count}} élément', itemCount_other: '{{count}} éléments'},
 		mixedPrompt: {
@@ -88,7 +87,6 @@ const fr = {
 			singleVideo: 'Juste celle-ci',
 			pickFromPlaylist: 'Choisir dans la Playlist',
 			playlistLimit: 'Limite d’analyse de playlist : {{count}} éléments',
-			advancedSettings: 'Paramètres avancés',
 			singleTooltip: 'Utilise le mode vidéo seule de yt-dlp afin d’ignorer la playlist attachée à cette URL.',
 			playlistTooltip: 'Utilise le mode playlist de yt-dlp et récupère jusqu’à votre limite avant d’afficher le sélecteur.'
 		},
@@ -96,7 +94,7 @@ const fr = {
 		url: {
 			heading: 'URL YouTube',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'Récupérer les formats',
+			interactiveDownload: 'Récupérer les formats',
 			fetchFormatsTooltip: 'Choisissez les formats, sous-titres, dossier et éléments de playlist étape par étape avant l’ajout à la file.',
 			quickDownload: 'Téléchargement rapide',
 			quickDownloadTooltip: 'Utilise vos préférences enregistrées ou par défaut et ajoute cette vidéo seule à la file sans ouvrir les étapes de configuration.',
@@ -118,23 +116,7 @@ const fr = {
 			mascotBusy: 'Téléchargement en arrière-plan… je peux faire plusieurs choses à la fois 😎',
 			advanced: 'Avancé',
 			clearAria: "Effacer l'URL",
-			clipboard: {
-				toggle: 'Surveiller le presse-papiers',
-				toggleDescription: 'Remplit automatiquement le champ URL lorsque vous copiez un lien YouTube.',
-				dialog: {
-					title: 'URL YouTube détectée',
-					body: 'Utiliser ce lien depuis votre presse-papiers ?',
-					bulkTitle: 'URLs en lot détectées',
-					bulkBody: 'Utiliser ces liens du presse-papiers comme téléchargement en lot ?',
-					bulkSummary: '{{count}} URLs prêtes',
-					bulkIgnored: '{{count}} ignorées',
-					bulkButton: 'Téléchargement en lot',
-					useButton: "Utiliser l'URL",
-					disableButton: 'Désactiver',
-					cancelButton: 'Annuler',
-					disableNote: 'Vous pouvez réactiver la surveillance du presse-papiers plus tard dans les Réglages avancés.'
-				}
-			},
+			clipboard: {toggle: 'Surveiller le presse-papiers', toggleDescription: 'Remplit automatiquement le champ URL lorsque vous copiez un lien YouTube.', dialog: {cancelButton: 'Annuler'}},
 			cookies: {
 				sourceLabel: 'Source des cookies',
 				sourceOff: 'Désactivé',
@@ -475,7 +457,6 @@ const fr = {
 		footerTooltip: 'Partager Arroxy',
 		footerLabel: 'Partager',
 		shareAction: 'Partager Arroxy',
-		inlineCard: {body: "Tu apprécies Arroxy ? Partage-le avec quelqu'un qui pourrait le trouver utile.", dismiss: 'Fermer la suggestion de partage'},
 		highValueBanner: {body: "Tu apprécies Arroxy ? Aide d'autres personnes à le découvrir.", dismiss: 'Fermer la suggestion de partage'}
 	}
 } as const

--- a/src/shared/i18n/locales/hi.ts
+++ b/src/shared/i18n/locales/hi.ts
@@ -69,8 +69,7 @@ const hi = {
 			ignoredCount: 'नज़रअंदाज़',
 			emptyPreview: 'बैच देखने के लिए एक या अधिक URLs पेस्ट करें।',
 			needsAtLeastOne: 'जारी रखने के लिए कम से कम एक समर्थित URL जोड़ें।',
-			confirm: 'ये URLs इस्तेमाल करें',
-			reject: {duplicate: 'डुप्लिकेट', playlist: 'playlist flow इस्तेमाल करें', channel: 'channel flow इस्तेमाल करें'}
+			reject: {duplicate: 'डुप्लिकेट'}
 		},
 		playlistPresets: {heading: 'बैच के लिए गुणवत्ता चुनें', subhead: 'हर वीडियो चुनी गई श्रेणी के अनुसार स्वतंत्र रूप से रेज़ॉल्व होता है — मिश्रित Playlist बिना किसी परेशानी के काम करती है।', itemCount_one: '{{count}} आइटम', itemCount_other: '{{count}} आइटम'},
 		mixedPrompt: {
@@ -79,7 +78,6 @@ const hi = {
 			singleVideo: 'बस यही एक',
 			pickFromPlaylist: 'Playlist में से चुनें',
 			playlistLimit: 'प्लेलिस्ट जाँच सीमा: {{count}} आइटम',
-			advancedSettings: 'उन्नत सेटिंग्स',
 			singleTooltip: 'yt-dlp का एकल-वीडियो मोड उपयोग करता है ताकि इस URL से जुड़ी प्लेलिस्ट अनदेखी हो।',
 			playlistTooltip: 'yt-dlp का प्लेलिस्ट मोड उपयोग करता है और पिकर दिखाने से पहले आपकी सीमा तक आइटम लाता है।'
 		},
@@ -87,7 +85,7 @@ const hi = {
 		url: {
 			heading: 'YouTube URL',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'फ़ॉर्मेट लाएँ',
+			interactiveDownload: 'फ़ॉर्मेट लाएँ',
 			fetchFormatsTooltip: 'क्यू में जोड़ने से पहले फॉर्मैट, सबटाइटल, फ़ोल्डर और प्लेलिस्ट आइटम चरण-दर-चरण चुनें।',
 			quickDownload: 'त्वरित डाउनलोड',
 			quickDownloadTooltip: 'आपकी सेव की गई या डिफ़ॉल्ट पसंदों का उपयोग करके सेटअप चरण खोले बिना इस एकल वीडियो को क्यू में जोड़ता है।',
@@ -109,23 +107,7 @@ const hi = {
 			mascotBusy: 'पीछे चुपचाप डाउनलोड कर रहा हूँ… मैं एक साथ कई काम कर सकता हूँ 😎',
 			advanced: 'उन्नत',
 			clearAria: 'URL हटाएँ',
-			clipboard: {
-				toggle: 'क्लिपबोर्ड देखें',
-				toggleDescription: 'YouTube लिंक कॉपी करने पर URL फ़ील्ड स्वतः भर जाता है।',
-				dialog: {
-					title: 'YouTube URL मिला',
-					body: 'क्या आप अपने क्लिपबोर्ड का यह लिंक उपयोग करना चाहते हैं?',
-					bulkTitle: 'बल्क URLs मिले',
-					bulkBody: 'clipboard के इन links को bulk download के रूप में इस्तेमाल करें?',
-					bulkSummary: '{{count}} URLs तैयार',
-					bulkIgnored: '{{count}} नज़रअंदाज़',
-					bulkButton: 'बल्क डाउनलोड',
-					useButton: 'URL उपयोग करें',
-					disableButton: 'बंद करें',
-					cancelButton: 'रद्द करें',
-					disableNote: 'आप बाद में उन्नत सेटिंग्स में क्लिपबोर्ड देखना फिर से चालू कर सकते हैं।'
-				}
-			},
+			clipboard: {toggle: 'क्लिपबोर्ड देखें', toggleDescription: 'YouTube लिंक कॉपी करने पर URL फ़ील्ड स्वतः भर जाता है।', dialog: {cancelButton: 'रद्द करें'}},
 			cookies: {
 				sourceLabel: 'कुकी स्रोत',
 				sourceOff: 'बंद',
@@ -440,7 +422,6 @@ const hi = {
 		footerTooltip: 'Arroxy साझा करें',
 		footerLabel: 'साझा करें',
 		shareAction: 'Arroxy साझा करें',
-		inlineCard: {body: 'Arroxy पसंद आ रहा है? किसी ऐसे व्यक्ति के साथ शेयर करें जिसे यह उपयोगी लग सकता है।', dismiss: 'शेयर सुझाव हटाएँ'},
 		highValueBanner: {body: 'Arroxy पसंद आ रहा है? दूसरों को भी इसे खोजने में मदद करें।', dismiss: 'शेयर सुझाव हटाएँ'}
 	}
 } as const

--- a/src/shared/i18n/locales/ja.ts
+++ b/src/shared/i18n/locales/ja.ts
@@ -78,8 +78,7 @@ const ja = {
 			ignoredCount: '無視',
 			emptyPreview: '一括内容を確認するには、URL を 1 件以上貼り付けてください。',
 			needsAtLeastOne: '続行するには、対応している URL を少なくとも 1 件追加してください。',
-			confirm: 'これらの URL を使う',
-			reject: {duplicate: '重複', playlist: 'playlist フローを使う', channel: 'channel フローを使う'}
+			reject: {duplicate: '重複'}
 		},
 		playlistPresets: {heading: 'バッチの画質を選択', subhead: '各動画が選択した画質ティアを独立して解決します — 異なる動画が混在するPlaylistも問題なく処理できます。', itemCount_one: '{{count}} 件', itemCount_other: '{{count}} 件'},
 		mixedPrompt: {
@@ -88,7 +87,6 @@ const ja = {
 			singleVideo: 'この1本だけ',
 			pickFromPlaylist: 'Playlist から選ぶ',
 			playlistLimit: 'プレイリスト取得上限: {{count}} 件',
-			advancedSettings: '詳細設定',
 			singleTooltip: 'yt-dlp の単一動画モードを使い、この URL に付いたプレイリストを無視します。',
 			playlistTooltip: 'yt-dlp のプレイリストモードを使い、選択画面を出す前に上限まで取得します。'
 		},
@@ -96,7 +94,7 @@ const ja = {
 		url: {
 			heading: 'YouTube URL',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: '形式を取得',
+			interactiveDownload: '形式を取得',
 			fetchFormatsTooltip: 'キューに追加する前に、形式、字幕、フォルダー、プレイリスト項目を手順ごとに選びます。',
 			quickDownload: 'クイックダウンロード',
 			quickDownloadTooltip: '保存済みまたは既定の設定を使い、設定手順を開かずにこの単一動画をキューへ追加します。',
@@ -118,23 +116,7 @@ const ja = {
 			mascotBusy: 'バックグラウンドでダウンロード中… マルチタスクは得意なんだ 😎',
 			advanced: '詳細設定',
 			clearAria: 'URLをクリア',
-			clipboard: {
-				toggle: 'クリップボードを監視',
-				toggleDescription: 'YouTubeのリンクをコピーすると自動的にURLフィールドに入力します。',
-				dialog: {
-					title: 'YouTubeのURLを検出',
-					body: 'クリップボードのこのリンクを使いますか?',
-					bulkTitle: '一括 URL を検出しました',
-					bulkBody: 'クリップボードのこれらのリンクを一括ダウンロードとして使いますか？',
-					bulkSummary: '{{count}} URL が準備完了',
-					bulkIgnored: '{{count}} 件を無視',
-					bulkButton: '一括ダウンロード',
-					useButton: 'URLを使う',
-					disableButton: '無効化',
-					cancelButton: 'キャンセル',
-					disableNote: '詳細設定からクリップボード監視をいつでも再有効化できます。'
-				}
-			},
+			clipboard: {toggle: 'クリップボードを監視', toggleDescription: 'YouTubeのリンクをコピーすると自動的にURLフィールドに入力します。', dialog: {cancelButton: 'キャンセル'}},
 			cookies: {
 				sourceLabel: 'Cookieのソース',
 				sourceOff: 'オフ',
@@ -474,7 +456,6 @@ const ja = {
 		footerTooltip: 'Arroxy を共有',
 		footerLabel: '共有',
 		shareAction: 'Arroxy を共有',
-		inlineCard: {body: 'Arroxyを気に入ってくれてる? 役に立ちそうな人にシェアしてみて。', dismiss: 'シェアの提案を閉じる'},
 		highValueBanner: {body: 'Arroxyを気に入ってくれてる? ほかの人にも見つけてもらおう。', dismiss: 'シェアの提案を閉じる'}
 	}
 } as const

--- a/src/shared/i18n/locales/my.ts
+++ b/src/shared/i18n/locales/my.ts
@@ -69,8 +69,7 @@ const my = {
 			ignoredCount: 'လျစ်လျူရှုထားသည်',
 			emptyPreview: 'batch ကိုကြည့်ရန် URL တစ်ခု သို့မဟုတ် ထို့ထက်ပိုပြီး paste လုပ်ပါ။',
 			needsAtLeastOne: 'ဆက်လက်လုပ်ဆောင်ရန် supported URL အနည်းဆုံးတစ်ခု ထည့်ပါ။',
-			confirm: 'ဤ URL များကိုသုံးမည်',
-			reject: {duplicate: 'ထပ်နေသည်', playlist: 'playlist flow သုံးမည်', channel: 'channel flow သုံးမည်'}
+			reject: {duplicate: 'ထပ်နေသည်'}
 		},
 		playlistPresets: {heading: 'Batch အတွက် အရည်အသွေးရွေးပါ', subhead: 'ဗီဒီယိုတစ်ခုချင်းစီသည် ရွေးချယ်ထားသော tier အတိုင်း သီးခြားဖြေရှင်းသည် — မတူညီသော playlist များ အဆင်မပြေမှုမရှိဘဲ အလုပ်လုပ်သည်။', itemCount_one: '{{count}} ခု', itemCount_other: '{{count}} ခု'},
 		mixedPrompt: {
@@ -79,7 +78,6 @@ const my = {
 			singleVideo: 'ဤတစ်ခုသာ',
 			pickFromPlaylist: 'Playlist မှ ရွေးမည်',
 			playlistLimit: 'Playlist စစ်ဆေးမှု ကန့်သတ်ချက်: {{count}} ခု',
-			advancedSettings: 'အဆင့်မြင့် ဆက်တင်များ',
 			singleTooltip: 'ဤ URL နှင့်တွဲနေသော playlist ကို လျစ်လျူရှုရန် yt-dlp ၏ ဗီဒီယိုတစ်ခုချင်း မုဒ်ကို သုံးသည်။',
 			playlistTooltip: 'yt-dlp ၏ playlist မုဒ်ကို သုံးပြီး ရွေးချယ်ကိရိယာ မပြမီ သင့်ကန့်သတ်ချက်အထိ ယူသည်။'
 		},
@@ -87,7 +85,7 @@ const my = {
 		url: {
 			heading: 'YouTube URL',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'ဖော်မတ်များရယူမည်',
+			interactiveDownload: 'ဖော်မတ်များရယူမည်',
 			fetchFormatsTooltip: 'တန်းစီစာရင်းထဲ မထည့်မီ ဖော်မတ်များ၊ စာတန်းထိုးများ၊ ဖိုင်တွဲနှင့် playlist အရာများကို အဆင့်လိုက် ရွေးပါ။',
 			quickDownload: 'အမြန်ဒေါင်းလုဒ်',
 			quickDownloadTooltip: 'သိမ်းထားသော သို့မဟုတ် မူရင်းရွေးချယ်မှုများကို အသုံးပြုပြီး ပြင်ဆင်မှုအဆင့်များ မဖွင့်ဘဲ ဤဗီဒီယိုတစ်ခုကို တန်းစီစာရင်းထဲ ထည့်သည်။',
@@ -109,23 +107,7 @@ const my = {
 			mascotBusy: 'နောက်ခံတွင် ဒေါင်းလုဒ်လုပ်နေသည်… ကျွန်ုပ် တစ်ချိန်တည်းလုပ်နိုင်သည် 😎',
 			advanced: 'အဆင့်မြင့်',
 			clearAria: 'URL ရှင်းလင်းမည်',
-			clipboard: {
-				toggle: 'ကလစ်ဘုတ်ကြည့်မည်',
-				toggleDescription: 'YouTube လင့်ခ်ကော်ပီလုပ်လျှင် URL ဖြည့်သွင်းမည်။',
-				dialog: {
-					title: 'YouTube URL တွေ့ပြီ',
-					body: 'ကလစ်ဘုတ်မှ ဤလင့်ခ်ကို အသုံးပြုမည်လား?',
-					bulkTitle: 'URL အများအပြား တွေ့ရှိသည်',
-					bulkBody: 'clipboard ထဲရှိ link များကို bulk download အဖြစ်သုံးမလား?',
-					bulkSummary: '{{count}} URL အဆင်သင့်',
-					bulkIgnored: '{{count}} လျစ်လျူရှုထားသည်',
-					bulkButton: 'Bulk download',
-					useButton: 'URL အသုံးပြုမည်',
-					disableButton: 'ပိတ်မည်',
-					cancelButton: 'မလုပ်တော့ပါ',
-					disableNote: 'အဆင့်မြင့်ဆက်တင်တွင် ကလစ်ဘုတ်ကြည့်ရှုမှုကို နောက်မှပြန်ဖွင့်နိုင်သည်။'
-				}
-			},
+			clipboard: {toggle: 'ကလစ်ဘုတ်ကြည့်မည်', toggleDescription: 'YouTube လင့်ခ်ကော်ပီလုပ်လျှင် URL ဖြည့်သွင်းမည်။', dialog: {cancelButton: 'မလုပ်တော့ပါ'}},
 			cookies: {
 				sourceLabel: 'ကွတ်ကီးရင်းမြစ်',
 				sourceOff: 'ပိတ်',
@@ -455,7 +437,6 @@ const my = {
 		footerTooltip: 'Arroxy ကိုမျှဝေရန်',
 		footerLabel: 'မျှဝေရန်',
 		shareAction: 'Arroxy ကိုမျှဝေရန်',
-		inlineCard: {body: 'Arroxy ကို နှစ်သက်ပါသလား? အသုံးဝင်နိုင်သော သူတစ်ဦးနှင့် မျှဝေပါ။', dismiss: 'မျှဝေရန်အကြံပြုချက် ပယ်ဖျက်မည်'},
 		highValueBanner: {body: 'Arroxy ကို နှစ်သက်ပါသလား? အခြားသူများ ရှာဖွေတွေ့ရှိနိုင်ရန် ကူညီပါ။', dismiss: 'မျှဝေရန်အကြံပြုချက် ပယ်ဖျက်မည်'}
 	}
 } as const

--- a/src/shared/i18n/locales/om.ts
+++ b/src/shared/i18n/locales/om.ts
@@ -78,8 +78,7 @@ const om = {
 			ignoredCount: 'Tuffatame',
 			emptyPreview: 'Garee ilaaluu dura URL tokko yookaan isaa ol maxxansi.',
 			needsAtLeastOne: 'Itti fufuuf URL deeggaraman yoo xiqqaate tokko dabali.',
-			confirm: 'URL kana fayyadami',
-			reject: {duplicate: 'Irra-deebi', playlist: 'Adeemsa playlist fayyadami', channel: 'Adeemsa channel fayyadami'}
+			reject: {duplicate: 'Irra-deebi'}
 		},
 		playlistPresets: {heading: 'Kutaa gurmuu barbaadi', subhead: 'Viidiyoon hundi sadarkaa filatame ofumaan qorata — playlist garagaraa sodaa malee hojjeta.', itemCount_one: '{{count}} wanta', itemCount_other: '{{count}} wantota'},
 		mixedPrompt: {
@@ -88,14 +87,13 @@ const om = {
 			singleVideo: 'Kana qofa',
 			pickFromPlaylist: 'Playlist keessaa filadhu',
 			playlistLimit: 'Daangaa sakatta’iinsa playlist: wantoota {{count}}',
-			advancedSettings: 'Qindaa’inoota sadarkaa olaanaa',
 			singleTooltip: 'Haala viidiyoo tokkoo yt-dlp fayyadama; playlist URL kanaan hidhame ni tuffatama.',
 			playlistTooltip: 'Haala playlist yt-dlp fayyadamee hanga daangaa sakatta’iinsa playlist kee dura filannoo agarsiisa.'
 		},
 		url: {
 			heading: 'YouTube URL',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'Foormaatii fidi',
+			interactiveDownload: 'Foormaatii fidi',
 			fetchFormatsTooltip: 'Osoo tarree buusuu hin dabaliin dura formatoota, subtaitiloota, galmee fi wantoota playlist tarkaanfiin fili.',
 			quickDownload: 'Buusuu ariifachiisaa',
 			quickDownloadTooltip: 'Filannoowwan kee kuufaman yookiin durtii fayyadamee viidiyoo tokko kana tarree buusutti dabala, tarkaanfii qindaa’inaa osoo hin banu.',
@@ -117,23 +115,7 @@ const om = {
 			mascotBusy: 'Duubaan buusaa jira… rakkoo guguddaa hojjechuuf dandeessa 😎',
 			advanced: 'Ammayyaa',
 			clearAria: 'URL qulqulleessi',
-			clipboard: {
-				toggle: 'Kliipboordii hordofi',
-				toggleDescription: 'Liinkii YouTube koopii gootee booda dirree URL ofumaan guuti.',
-				dialog: {
-					title: 'YouTube URL argame',
-					body: 'Liinkii kana kliipboordii kee irraa fayyadamduu?',
-					bulkTitle: 'URL hedduun argaman',
-					bulkBody: 'Hidhannoowwan clipboard kana buufannaa hedduuf fayyadamuu?',
-					bulkSummary: '{{count}} URL qophaa’e',
-					bulkIgnored: '{{count}} tuffatame',
-					bulkButton: 'Hedduu buusi',
-					useButton: 'URL fayyadami',
-					disableButton: 'Dhaabbi',
-					cancelButton: 'Haqi',
-					disableNote: "Hordoffii kliipboordii booda Qindaa'inoota Ammayyaa keessatti deebi'sitee dandeessa."
-				}
-			},
+			clipboard: {toggle: 'Kliipboordii hordofi', toggleDescription: 'Liinkii YouTube koopii gootee booda dirree URL ofumaan guuti.', dialog: {cancelButton: 'Haqi'}},
 			cookies: {
 				sourceLabel: 'Madda Cookies',
 				sourceOff: 'Dhaabbi',
@@ -472,7 +454,6 @@ const om = {
 		footerTooltip: 'Arroxy qoodi',
 		footerLabel: 'Qoodi',
 		shareAction: 'Arroxy qoodi',
-		inlineCard: {body: "Arroxy si gammachiisaa jiraa? Namaa faayidaa qabu ta'uu danda'u wajjin qoodi.", dismiss: 'Yaada qooduu haqdhaabi'},
 		highValueBanner: {body: 'Arroxy si gammachiisaa jiraa? Namoota biroo argachuu gargaari.', dismiss: 'Yaada qooduu haqdhaabi'}
 	}
 } as const

--- a/src/shared/i18n/locales/ps.ts
+++ b/src/shared/i18n/locales/ps.ts
@@ -69,8 +69,7 @@ const ps = {
 			ignoredCount: 'له پامه غورځول شوي',
 			emptyPreview: 'د ډلې د کتلو لپاره یو یا زیات URLونه ونښلوئ.',
 			needsAtLeastOne: 'د دوام لپاره لږ تر لږه یو ملاتړ شوی URL زیات کړئ.',
-			confirm: 'دا URLونه وکاروئ',
-			reject: {duplicate: 'تکراري', playlist: 'د playlist لاره وکاروئ', channel: 'د channel لاره وکاروئ'}
+			reject: {duplicate: 'تکراري'}
 		},
 		playlistPresets: {heading: 'د بیچ لپاره کیفیت وټاکئ', subhead: 'هر ویډیو خپلواکه د غوره شوي کچې سره حل کوي — مخلوط Playlist ونه بیا پرته له مشکل کار کوي.', itemCount_one: '{{count}} توکی', itemCount_other: '{{count}} توکي'},
 		mixedPrompt: {
@@ -79,7 +78,6 @@ const ps = {
 			singleVideo: 'یوازې دا یو',
 			pickFromPlaylist: 'له Playlist نه غوره کړئ',
 			playlistLimit: 'د پلی‌لېسټ کتنې حد: {{count}} توکي',
-			advancedSettings: 'پرمختللې امستنې',
 			singleTooltip: 'د yt-dlp د یوه ویډیو حالت کاروي، نو له دې URL سره تړلی پلی‌لېسټ له پامه غورځول کېږي.',
 			playlistTooltip: 'د yt-dlp د پلی‌لېسټ حالت کاروي او د انتخابګر تر ښودلو مخکې ستاسې تر ټاکلي حد پورې توکي راولي.'
 		},
@@ -87,7 +85,7 @@ const ps = {
 		url: {
 			heading: 'YouTube URL',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'بڼې ترلاسه کړه',
+			interactiveDownload: 'بڼې ترلاسه کړه',
 			fetchFormatsTooltip: 'له قطار ته تر زیاتولو مخکې بڼې، فرعي لیکنې، پوښۍ او د پلی‌لېسټ توکي ګام په ګام وټاکئ.',
 			quickDownload: 'چټک ډاونلوډ',
 			quickDownloadTooltip: 'ستاسې خوندي شوې یا تلواله خوښې کاروي او دا یو ویډیو د چمتو کولو پړاوونو له پرانیستو پرته قطار ته زیاتوي.',
@@ -109,23 +107,7 @@ const ps = {
 			mascotBusy: 'شاتهپرده ډاونلوډ کیږي… زه کولی شم له ډیرو کارونو سره معامله وکړم 😎',
 			advanced: 'پرمختللي',
 			clearAria: 'URL پاکول',
-			clipboard: {
-				toggle: 'کلیپبورډ وګورئ',
-				toggleDescription: 'کله چې تاسو یو YouTube لینک کاپي کړئ، د URL ساحه اتوماتیک ډکه کړئ.',
-				dialog: {
-					title: 'YouTube URL وموندل شو',
-					body: 'ایا د کلیپبورډ دا لینک وکاروئ؟',
-					bulkTitle: 'ډېر URLونه وموندل شول',
-					bulkBody: 'د clipboard دا لینکونه د bulk download په توګه وکارول شي؟',
-					bulkSummary: '{{count}} URLونه چمتو',
-					bulkIgnored: '{{count}} له پامه غورځول شوي',
-					bulkButton: 'ډله‌ییز ډاونلوډ',
-					useButton: 'URL وکاروئ',
-					disableButton: 'غیر فعاله کړه',
-					cancelButton: 'لغوه کړه',
-					disableNote: 'تاسو کولی شئ وروسته د پرمختللو تنظیماتو کې د کلیپبورډ لیدل بیا فعاله کړئ.'
-				}
-			},
+			clipboard: {toggle: 'کلیپبورډ وګورئ', toggleDescription: 'کله چې تاسو یو YouTube لینک کاپي کړئ، د URL ساحه اتوماتیک ډکه کړئ.', dialog: {cancelButton: 'لغوه کړه'}},
 			cookies: {
 				sourceLabel: 'د کوکیزو سرچینه',
 				sourceOff: 'بند',
@@ -445,7 +427,6 @@ const ps = {
 		footerTooltip: 'Arroxy شریک کړئ',
 		footerLabel: 'شریک کړئ',
 		shareAction: 'Arroxy شریک کړئ',
-		inlineCard: {body: 'ایا Arroxy خوند درکوي؟ له چا سره یې شریک کړئ چې ممکن ورته ګټور وي.', dismiss: 'د شریکولو وړاندیز رد کړئ'},
 		highValueBanner: {body: 'ایا Arroxy خوند درکوي؟ نورو خلکو سره مرسته وکړئ چې ومومي.', dismiss: 'د شریکولو وړاندیز رد کړئ'}
 	}
 } as const

--- a/src/shared/i18n/locales/ru.ts
+++ b/src/shared/i18n/locales/ru.ts
@@ -78,8 +78,7 @@ const ru = {
 			ignoredCount: 'Пропущено',
 			emptyPreview: 'Вставьте один или несколько URL, чтобы просмотреть пакет.',
 			needsAtLeastOne: 'Добавьте хотя бы один поддерживаемый URL, чтобы продолжить.',
-			confirm: 'Использовать эти URL',
-			reject: {duplicate: 'Дубликат', playlist: 'Использовать сценарий плейлиста', channel: 'Использовать сценарий канала'}
+			reject: {duplicate: 'Дубликат'}
 		},
 		playlistPresets: {heading: 'Выбери качество для пакетной загрузки', subhead: 'Каждое видео независимо подбирает подходящий уровень качества — неоднородные плейлисты работают без сюрпризов.', itemCount_one: '{{count}} элемент', itemCount_other: '{{count}} элементов'},
 		mixedPrompt: {
@@ -88,7 +87,6 @@ const ru = {
 			singleVideo: 'Только это одно',
 			pickFromPlaylist: 'Выбрать из Playlist',
 			playlistLimit: 'Лимит проверки плейлиста: {{count}} элементов',
-			advancedSettings: 'Дополнительные настройки',
 			singleTooltip: 'Использует режим одиночного видео yt-dlp, поэтому плейлист в этой ссылке игнорируется.',
 			playlistTooltip: 'Использует режим плейлиста yt-dlp и загружает элементы до выбранного лимита перед показом выбора.'
 		},
@@ -96,7 +94,7 @@ const ru = {
 		url: {
 			heading: 'Ссылка YouTube',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'Получить форматы',
+			interactiveDownload: 'Получить форматы',
 			fetchFormatsTooltip: 'Выберите форматы, субтитры, папку и элементы плейлиста по шагам перед добавлением в очередь.',
 			quickDownload: 'Быстрая загрузка',
 			quickDownloadTooltip: 'Использует сохранённые или стандартные настройки и добавляет это одиночное видео в очередь без шагов настройки.',
@@ -118,23 +116,7 @@ const ru = {
 			mascotBusy: 'Качаю в фоне… могу делать несколько дел сразу 😎',
 			advanced: 'Дополнительно',
 			clearAria: 'Очистить URL',
-			clipboard: {
-				toggle: 'Следить за буфером обмена',
-				toggleDescription: 'Автоматически подставляет ссылку YouTube в поле URL при копировании.',
-				dialog: {
-					title: 'Найдена ссылка YouTube',
-					body: 'Использовать эту ссылку из буфера обмена?',
-					bulkTitle: 'Обнаружены массовые URL',
-					bulkBody: 'Использовать эти ссылки из буфера как массовую загрузку?',
-					bulkSummary: '{{count}} URL готовы',
-					bulkIgnored: '{{count}} пропущено',
-					bulkButton: 'Массовая загрузка',
-					useButton: 'Использовать URL',
-					disableButton: 'Отключить',
-					cancelButton: 'Отмена',
-					disableNote: 'Слежение за буфером обмена можно снова включить в дополнительных настройках.'
-				}
-			},
+			clipboard: {toggle: 'Следить за буфером обмена', toggleDescription: 'Автоматически подставляет ссылку YouTube в поле URL при копировании.', dialog: {cancelButton: 'Отмена'}},
 			cookies: {
 				sourceLabel: 'Источник cookies',
 				sourceOff: 'Отключено',
@@ -473,7 +455,6 @@ const ru = {
 		footerTooltip: 'Поделиться Arroxy',
 		footerLabel: 'Поделиться',
 		shareAction: 'Поделиться Arroxy',
-		inlineCard: {body: 'Нравится Arroxy? Поделись с тем, кому это может пригодиться.', dismiss: 'Скрыть предложение поделиться'},
 		highValueBanner: {body: 'Нравится Arroxy? Помоги другим его найти.', dismiss: 'Скрыть предложение поделиться'}
 	}
 } as const

--- a/src/shared/i18n/locales/sr.ts
+++ b/src/shared/i18n/locales/sr.ts
@@ -78,8 +78,7 @@ const sr = {
 			ignoredCount: 'Занемарено',
 			emptyPreview: 'Налепи један или више URL-ова за преглед групе.',
 			needsAtLeastOne: 'Додај најмање један подржан URL за наставак.',
-			confirm: 'Користи ове URL-ове',
-			reject: {duplicate: 'Дупликат', playlist: 'Користи playlist ток', channel: 'Користи channel ток'}
+			reject: {duplicate: 'Дупликат'}
 		},
 		playlistPresets: {heading: 'Изабери квалитет за групно преузимање', subhead: 'Свaki видео самостално проналази одговарајући ниво квалитета — хетерогене плејлисте раде без изненађења.', itemCount_one: '{{count}} ставка', itemCount_other: '{{count}} ставки'},
 		mixedPrompt: {
@@ -88,7 +87,6 @@ const sr = {
 			singleVideo: 'Само овај',
 			pickFromPlaylist: 'Бирај из плејлисте',
 			playlistLimit: 'Limit provere plejliste: {{count}} stavki',
-			advancedSettings: 'Napredna podešavanja',
 			singleTooltip: 'Koristi yt-dlp režim za pojedinačni video, pa se plejlista vezana za ovaj URL ignoriše.',
 			playlistTooltip: 'Koristi yt-dlp režim plejliste i učitava do vašeg limita pre prikaza birača.'
 		},
@@ -96,7 +94,7 @@ const sr = {
 		url: {
 			heading: 'YouTube URL',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'Учитај формате',
+			interactiveDownload: 'Учитај формате',
 			fetchFormatsTooltip: 'Izaberite formate, titlove, fasciklu i stavke plejliste korak po korak pre dodavanja u red.',
 			quickDownload: 'Brzo preuzimanje',
 			quickDownloadTooltip: 'Koristi sačuvana ili podrazumevana podešavanja i dodaje ovaj pojedinačni video u red bez otvaranja koraka podešavanja.',
@@ -118,23 +116,7 @@ const sr = {
 			mascotBusy: 'Преузимање у позадини… Умем да радим више ствари одједном 😎',
 			advanced: 'Напредно',
 			clearAria: 'Обриши URL',
-			clipboard: {
-				toggle: 'Прати клипборд',
-				toggleDescription: 'Аутоматски попуни поље URL-а када копираш YouTube линк.',
-				dialog: {
-					title: 'Откривен YouTube URL',
-					body: 'Да ли да користиш овај линк из клипборда?',
-					bulkTitle: 'Откривени су групни URL-ови',
-					bulkBody: 'Користити ове линкове из clipboard-а као групно преузимање?',
-					bulkSummary: '{{count}} URL-ова спремно',
-					bulkIgnored: '{{count}} занемарено',
-					bulkButton: 'Групно преузимање',
-					useButton: 'Користи URL',
-					disableButton: 'Онемогући',
-					cancelButton: 'Откажи',
-					disableNote: 'Праћење клипборда можеш поново укључити касније у Напредним подешавањима.'
-				}
-			},
+			clipboard: {toggle: 'Прати клипборд', toggleDescription: 'Аутоматски попуни поље URL-а када копираш YouTube линк.', dialog: {cancelButton: 'Откажи'}},
 			cookies: {
 				sourceLabel: 'Извор cookies',
 				sourceOff: 'Искључено',
@@ -466,7 +448,6 @@ const sr = {
 		footerTooltip: 'Подели Arroxy',
 		footerLabel: 'Подели',
 		shareAction: 'Подели Arroxy',
-		inlineCard: {body: 'Свиђа ти се Arroxy? Подели га с неким коме би могао бити користан.', dismiss: 'Одбаци предлог за дељење'},
 		highValueBanner: {body: 'Свиђа ти се Arroxy? Помози другима да га открију.', dismiss: 'Одбаци предлог за дељење'}
 	}
 } as const

--- a/src/shared/i18n/locales/sw.ts
+++ b/src/shared/i18n/locales/sw.ts
@@ -78,8 +78,7 @@ const sw = {
 			ignoredCount: 'Zimepuuzwa',
 			emptyPreview: 'Bandika URL moja au zaidi ili kuona kundi.',
 			needsAtLeastOne: 'Ongeza angalau URL moja inayotumika ili kuendelea.',
-			confirm: 'Tumia URL hizi',
-			reject: {duplicate: 'Imerudiwa', playlist: 'Tumia mtiririko wa playlist', channel: 'Tumia mtiririko wa channel'}
+			reject: {duplicate: 'Imerudiwa'}
 		},
 		playlistPresets: {heading: 'Chagua ubora wa kundi', subhead: 'Kila video inatatua kiwango kilichochaguliwa kwa kujitegemea — playlists tofauti hufanya kazi bila mshangao.', itemCount_one: '{{count}} kipande', itemCount_other: '{{count}} vipande'},
 		mixedPrompt: {
@@ -88,14 +87,13 @@ const sw = {
 			singleVideo: 'Hii tu',
 			pickFromPlaylist: 'Chagua kutoka Playlist',
 			playlistLimit: 'Kikomo cha kuchunguza playlist: vipengee {{count}}',
-			advancedSettings: 'Mipangilio ya kina',
 			singleTooltip: 'Hutumia modi ya video moja ya yt-dlp ili kupuuza playlist iliyounganishwa na URL hii.',
 			playlistTooltip: 'Hutumia modi ya playlist ya yt-dlp na kuchukua hadi kikomo chako kabla ya kuonyesha kichaguaji.'
 		},
 		url: {
 			heading: 'YouTube URL',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'Pata maumbo',
+			interactiveDownload: 'Pata maumbo',
 			fetchFormatsTooltip: 'Chagua fomati, manukuu, folda na vipengee vya orodha ya kucheza hatua kwa hatua kabla ya kuongeza kwenye foleni.',
 			quickDownload: 'Pakua haraka',
 			quickDownloadTooltip: 'Hutumia mapendeleo yako yaliyohifadhiwa au chaguomsingi na kuongeza video hii moja kwenye foleni bila kufungua hatua za usanidi.',
@@ -117,23 +115,7 @@ const sw = {
 			mascotBusy: 'Inapakua nyuma ya pazia… Ninaweza kufanya mambo mengi kwa wakati mmoja 😎',
 			advanced: 'Hali ya juu',
 			clearAria: 'Futa URL',
-			clipboard: {
-				toggle: 'Angalia ubao wa kunakili',
-				toggleDescription: 'Jaza sehemu ya URL kiotomatiki unaponakili kiungo cha YouTube.',
-				dialog: {
-					title: 'YouTube URL imegunduliwa',
-					body: 'Tumia kiungo hiki kutoka kwenye ubao wako wa kunakili?',
-					bulkTitle: 'URL nyingi zimegunduliwa',
-					bulkBody: 'Utumie viungo hivi vya clipboard kama upakuaji wa kundi?',
-					bulkSummary: '{{count}} URL tayari',
-					bulkIgnored: '{{count}} zimepuuzwa',
-					bulkButton: 'Pakua kundi',
-					useButton: 'Tumia URL',
-					disableButton: 'Zima',
-					cancelButton: 'Ghairi',
-					disableNote: 'Unaweza kuwezesha tena uangalifu wa ubao wa kunakili baadaye katika mipangilio ya Hali ya juu.'
-				}
-			},
+			clipboard: {toggle: 'Angalia ubao wa kunakili', toggleDescription: 'Jaza sehemu ya URL kiotomatiki unaponakili kiungo cha YouTube.', dialog: {cancelButton: 'Ghairi'}},
 			cookies: {
 				sourceLabel: 'Chanzo cha vidakuzi',
 				sourceOff: 'Zima',
@@ -473,7 +455,6 @@ const sw = {
 		footerTooltip: 'Shiriki Arroxy',
 		footerLabel: 'Shiriki',
 		shareAction: 'Shiriki Arroxy',
-		inlineCard: {body: 'Unafurahia Arroxy? Shiriki na mtu anayeweza kuifaidika.', dismiss: 'Funga pendekezo la kushiriki'},
 		highValueBanner: {body: 'Unafurahia Arroxy? Saidia wengine kuigundua.', dismiss: 'Funga pendekezo la kushiriki'}
 	}
 } as const

--- a/src/shared/i18n/locales/uk.ts
+++ b/src/shared/i18n/locales/uk.ts
@@ -78,8 +78,7 @@ const uk = {
 			ignoredCount: 'Пропущено',
 			emptyPreview: 'Вставте один або кілька URL, щоб переглянути пакет.',
 			needsAtLeastOne: 'Додайте щонайменше один підтримуваний URL, щоб продовжити.',
-			confirm: 'Використати ці URL',
-			reject: {duplicate: 'Дублікат', playlist: 'Використати сценарій плейлиста', channel: 'Використати сценарій каналу'}
+			reject: {duplicate: 'Дублікат'}
 		},
 		playlistPresets: {heading: 'Вибери якість для пакетного завантаження', subhead: 'Кожне відео самостійно підбирає відповідний рівень якості — неоднорідні плейлисти працюють без сюрпризів.', itemCount_one: '{{count}} елемент', itemCount_other: '{{count}} елементів'},
 		mixedPrompt: {
@@ -88,7 +87,6 @@ const uk = {
 			singleVideo: 'Лише це одне',
 			pickFromPlaylist: 'Вибрати з Playlist',
 			playlistLimit: 'Ліміт перевірки плейлиста: {{count}} елементів',
-			advancedSettings: 'Додаткові налаштування',
 			singleTooltip: 'Використовує режим одного відео yt-dlp, тому плейлист у цьому URL ігнорується.',
 			playlistTooltip: 'Використовує режим плейлиста yt-dlp і завантажує елементи до твого ліміту перед показом вибору.'
 		},
@@ -96,7 +94,7 @@ const uk = {
 		url: {
 			heading: 'Посилання YouTube',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'Отримати формати',
+			interactiveDownload: 'Отримати формати',
 			fetchFormatsTooltip: 'Вибери формати, субтитри, папку й елементи плейлиста крок за кроком перед додаванням у чергу.',
 			quickDownload: 'Швидке завантаження',
 			quickDownloadTooltip: 'Використовує збережені або стандартні налаштування й додає це окреме відео в чергу без кроків налаштування.',
@@ -118,23 +116,7 @@ const uk = {
 			mascotBusy: 'Завантажую у фоні… можу робити кілька справ одночасно 😎',
 			advanced: 'Додатково',
 			clearAria: 'Очистити URL',
-			clipboard: {
-				toggle: 'Стежити за буфером обміну',
-				toggleDescription: 'Автоматично підставляє посилання YouTube у поле URL при копіюванні.',
-				dialog: {
-					title: 'Знайдено посилання YouTube',
-					body: 'Використати це посилання з буфера обміну?',
-					bulkTitle: 'Виявлено масові URL',
-					bulkBody: 'Використати ці посилання з буфера як масове завантаження?',
-					bulkSummary: '{{count}} URL готові',
-					bulkIgnored: '{{count}} пропущено',
-					bulkButton: 'Масове завантаження',
-					useButton: 'Використати URL',
-					disableButton: 'Вимкнути',
-					cancelButton: 'Скасувати',
-					disableNote: 'Стеження за буфером обміну можна знову ввімкнути в додаткових налаштуваннях.'
-				}
-			},
+			clipboard: {toggle: 'Стежити за буфером обміну', toggleDescription: 'Автоматично підставляє посилання YouTube у поле URL при копіюванні.', dialog: {cancelButton: 'Скасувати'}},
 			cookies: {
 				sourceLabel: 'Джерело cookies',
 				sourceOff: 'Вимк',
@@ -473,7 +455,6 @@ const uk = {
 		footerTooltip: 'Поділитися Arroxy',
 		footerLabel: 'Поділитися',
 		shareAction: 'Поділитися Arroxy',
-		inlineCard: {body: 'Подобається Arroxy? Поділися ним із кимось, кому він може стати в пригоді.', dismiss: 'Закрити пропозицію поділитися'},
 		highValueBanner: {body: 'Подобається Arroxy? Допоможи іншим знайти його.', dismiss: 'Закрити пропозицію поділитися'}
 	}
 } as const

--- a/src/shared/i18n/locales/ur.ts
+++ b/src/shared/i18n/locales/ur.ts
@@ -78,8 +78,7 @@ const ur = {
 			ignoredCount: 'نظر انداز',
 			emptyPreview: 'بیچ دیکھنے کے لیے ایک یا زیادہ URLs پیسٹ کریں۔',
 			needsAtLeastOne: 'جاری رکھنے کے لیے کم از کم ایک supported URL شامل کریں۔',
-			confirm: 'یہ URLs استعمال کریں',
-			reject: {duplicate: 'نقل', playlist: 'playlist فلو استعمال کریں', channel: 'channel فلو استعمال کریں'}
+			reject: {duplicate: 'نقل'}
 		},
 		playlistPresets: {heading: 'بیچ کے لیے کوالٹی منتخب کریں', subhead: 'ہر ویڈیو منتخب درجے کو آزادانہ طور پر حل کرتی ہے — مختلف قسم کی playlists بغیر کسی پریشانی کے کام کرتی ہیں۔', itemCount_one: '{{count}} آئٹم', itemCount_other: '{{count}} آئٹمز'},
 		mixedPrompt: {
@@ -88,7 +87,6 @@ const ur = {
 			singleVideo: 'صرف یہ ایک',
 			pickFromPlaylist: 'Playlist سے انتخاب',
 			playlistLimit: 'پلے لسٹ جانچ حد: {{count}} آئٹمز',
-			advancedSettings: 'اعلیٰ ترتیبات',
 			singleTooltip: 'yt-dlp کا واحد ویڈیو موڈ استعمال کرتا ہے تاکہ اس URL سے منسلک پلے لسٹ نظر انداز ہو۔',
 			playlistTooltip: 'yt-dlp کا پلے لسٹ موڈ استعمال کرتا ہے اور انتخاب دکھانے سے پہلے آپ کی حد تک آئٹمز لاتا ہے۔'
 		},
@@ -96,7 +94,7 @@ const ur = {
 		url: {
 			heading: 'YouTube URL',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'فارمیٹس لائیں',
+			interactiveDownload: 'فارمیٹس لائیں',
 			fetchFormatsTooltip: 'قطار میں شامل کرنے سے پہلے فارمیٹس، سب ٹائٹلز، فولڈر اور پلے لسٹ آئٹمز مرحلہ وار منتخب کریں۔',
 			quickDownload: 'فوری ڈاؤن لوڈ',
 			quickDownloadTooltip: 'آپ کی محفوظ یا ڈیفالٹ ترجیحات استعمال کرکے سیٹ اپ مراحل کھولے بغیر اس واحد ویڈیو کو قطار میں شامل کرتا ہے۔',
@@ -118,23 +116,7 @@ const ur = {
 			mascotBusy: 'بیک گراؤنڈ میں ڈاؤن لوڈ ہو رہا ہے… میں ملٹی ٹاسک کر سکتا ہوں 😎',
 			advanced: 'ایڈوانسڈ',
 			clearAria: 'URL صاف کریں',
-			clipboard: {
-				toggle: 'کلپ بورڈ پر نظر رکھیں',
-				toggleDescription: 'جب آپ YouTube لنک کاپی کریں تو URL فیلڈ خود بھر جائے۔',
-				dialog: {
-					title: 'YouTube URL ملا',
-					body: 'کلپ بورڈ سے یہ لنک استعمال کریں؟',
-					bulkTitle: 'متعدد URLs ملے',
-					bulkBody: 'کیا clipboard کے یہ لنکس bulk download کے طور پر استعمال کریں؟',
-					bulkSummary: '{{count}} URLs تیار',
-					bulkIgnored: '{{count}} نظر انداز',
-					bulkButton: 'Bulk download',
-					useButton: 'URL استعمال کریں',
-					disableButton: 'بند کریں',
-					cancelButton: 'منسوخ کریں',
-					disableNote: 'آپ بعد میں ایڈوانسڈ سیٹنگز سے کلپ بورڈ واچنگ دوبارہ آن کر سکتے ہیں۔'
-				}
-			},
+			clipboard: {toggle: 'کلپ بورڈ پر نظر رکھیں', toggleDescription: 'جب آپ YouTube لنک کاپی کریں تو URL فیلڈ خود بھر جائے۔', dialog: {cancelButton: 'منسوخ کریں'}},
 			cookies: {
 				sourceLabel: 'Cookies کا ذریعہ',
 				sourceOff: 'بند',
@@ -454,7 +436,6 @@ const ur = {
 		footerTooltip: 'Arroxy شیئر کریں',
 		footerLabel: 'شیئر کریں',
 		shareAction: 'Arroxy شیئر کریں',
-		inlineCard: {body: 'Arroxy پسند آ رہا ہے؟ کسی ایسے شخص کے ساتھ شیئر کریں جسے یہ مفید لگ سکتا ہو۔', dismiss: 'شیئر کی تجویز برخاست کریں'},
 		highValueBanner: {body: 'Arroxy پسند آ رہا ہے؟ دوسروں کو اسے دریافت کرنے میں مدد کریں۔', dismiss: 'شیئر کی تجویز برخاست کریں'}
 	}
 } as const

--- a/src/shared/i18n/locales/uz.ts
+++ b/src/shared/i18n/locales/uz.ts
@@ -78,8 +78,7 @@ const uz = {
 			ignoredCount: 'E’tiborsiz',
 			emptyPreview: 'To‘plamni ko‘rish uchun bitta yoki undan ko‘p URL joylang.',
 			needsAtLeastOne: 'Davom etish uchun kamida bitta qo‘llab-quvvatlanadigan URL qo‘shing.',
-			confirm: 'Bu URLlardan foydalanish',
-			reject: {duplicate: 'Takror', playlist: 'Playlist oqimidan foydalanish', channel: 'Kanal oqimidan foydalanish'}
+			reject: {duplicate: 'Takror'}
 		},
 		playlistPresets: {heading: 'Paket uchun sifatni tanlang', subhead: 'Har bir video tanlangan darajani mustaqil ravishda hal qiladi — turli xil playlistlar muammosiz ishlaydi.', itemCount_one: '{{count}} ta element', itemCount_other: '{{count}} ta element'},
 		mixedPrompt: {
@@ -88,7 +87,6 @@ const uz = {
 			singleVideo: 'Faqat shu birini',
 			pickFromPlaylist: 'Playlist dan tanlash',
 			playlistLimit: 'Pleylist tekshiruv chegarasi: {{count}} ta element',
-			advancedSettings: 'Kengaytirilgan sozlamalar',
 			singleTooltip: 'Bu URLga ulangan pleylist e’tiborsiz qolishi uchun yt-dlp bitta video rejimidan foydalanadi.',
 			playlistTooltip: 'Tanlagichni ko‘rsatishdan oldin yt-dlp pleylist rejimida belgilangan chegaragacha yuklaydi.'
 		},
@@ -96,7 +94,7 @@ const uz = {
 		url: {
 			heading: 'YouTube URL',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'Formatlarni olish',
+			interactiveDownload: 'Formatlarni olish',
 			fetchFormatsTooltip: 'Navbatga qo‘shishdan oldin formatlar, subtitrlar, jild va pleylist elementlarini bosqichma-bosqich tanlang.',
 			quickDownload: 'Tez yuklab olish',
 			quickDownloadTooltip: 'Saqlangan yoki standart sozlamalaringizdan foydalanib, sozlash bosqichlarini ochmasdan bu bitta videoni navbatga qo‘shadi.',
@@ -118,23 +116,7 @@ const uz = {
 			mascotBusy: "Fonda yuklanmoqda… Men bir vaqtda ko'p ish qila olaman 😎",
 			advanced: 'Kengaytirilgan',
 			clearAria: 'URLni tozalash',
-			clipboard: {
-				toggle: 'Buferga nazar solish',
-				toggleDescription: "YouTube havolasini nusxalaganda URL maydonini avtomatik to'ldiradi.",
-				dialog: {
-					title: 'YouTube URL aniqlandi',
-					body: 'Buferingizdagi bu havoladan foydalanasizmi?',
-					bulkTitle: 'Ommaviy URLlar topildi',
-					bulkBody: 'Clipboarddagi bu havolalarni ommaviy yuklama sifatida ishlatilsinmi?',
-					bulkSummary: '{{count}} URL tayyor',
-					bulkIgnored: '{{count}} e’tiborsiz',
-					bulkButton: 'Ommaviy yuklash',
-					useButton: 'URLdan foydalanish',
-					disableButton: "O'chirish",
-					cancelButton: 'Bekor qilish',
-					disableNote: 'Buferga nazar solishni keyinroq Kengaytirilgan sozlamalarda qayta yoqishingiz mumkin.'
-				}
-			},
+			clipboard: {toggle: 'Buferga nazar solish', toggleDescription: "YouTube havolasini nusxalaganda URL maydonini avtomatik to'ldiradi.", dialog: {cancelButton: 'Bekor qilish'}},
 			cookies: {
 				sourceLabel: 'Cookies manbai',
 				sourceOff: "O'chirilgan",
@@ -463,7 +445,6 @@ const uz = {
 		footerTooltip: 'Arroxy ulashish',
 		footerLabel: 'Ulashish',
 		shareAction: 'Arroxy ulashish',
-		inlineCard: {body: "Arroxy yoqdimi? Uni foydali deb topishi mumkin bo'lgan biri bilan ulashing.", dismiss: 'Ulashish taklifini yopish'},
 		highValueBanner: {body: 'Arroxy yoqdimi? Boshqalarga uni topishga yordam bering.', dismiss: 'Ulashish taklifini yopish'}
 	}
 } as const

--- a/src/shared/i18n/locales/vi.ts
+++ b/src/shared/i18n/locales/vi.ts
@@ -69,8 +69,7 @@ const vi = {
 			ignoredCount: 'Bị bỏ qua',
 			emptyPreview: 'Dán một hoặc nhiều URL để xem trước lô.',
 			needsAtLeastOne: 'Thêm ít nhất một URL được hỗ trợ để tiếp tục.',
-			confirm: 'Dùng các URL này',
-			reject: {duplicate: 'Trùng lặp', playlist: 'Dùng luồng playlist', channel: 'Dùng luồng kênh'}
+			reject: {duplicate: 'Trùng lặp'}
 		},
 		playlistPresets: {heading: 'Chọn chất lượng cho lô', subhead: 'Mỗi video tự xử lý cấp độ đã chọn một cách độc lập — danh sách phát không đồng nhất hoạt động mượt mà.', itemCount_one: '{{count}} mục', itemCount_other: '{{count}} mục'},
 		mixedPrompt: {
@@ -79,7 +78,6 @@ const vi = {
 			singleVideo: 'Chỉ cái này thôi',
 			pickFromPlaylist: 'Chọn từ Playlist',
 			playlistLimit: 'Giới hạn dò playlist: {{count}} mục',
-			advancedSettings: 'Cài đặt nâng cao',
 			singleTooltip: 'Dùng chế độ video đơn của yt-dlp để bỏ qua playlist gắn với URL này.',
 			playlistTooltip: 'Dùng chế độ playlist của yt-dlp và lấy đến giới hạn dò playlist trước khi hiện bộ chọn.'
 		},
@@ -87,7 +85,7 @@ const vi = {
 		url: {
 			heading: 'YouTube URL',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: 'Tải định dạng',
+			interactiveDownload: 'Tải định dạng',
 			fetchFormatsTooltip: 'Chọn định dạng, phụ đề, thư mục và mục playlist từng bước trước khi thêm vào hàng đợi.',
 			quickDownload: 'Tải nhanh',
 			quickDownloadTooltip: 'Dùng tùy chọn đã lưu hoặc mặc định của bạn và thêm video đơn này vào hàng đợi mà không mở các bước thiết lập.',
@@ -109,23 +107,7 @@ const vi = {
 			mascotBusy: 'Đang tải xuống trong nền… Tôi có thể làm nhiều việc cùng lúc 😎',
 			advanced: 'Nâng cao',
 			clearAria: 'Xóa URL',
-			clipboard: {
-				toggle: 'Theo dõi bộ nhớ tạm',
-				toggleDescription: 'Tự động điền vào trường URL khi bạn sao chép một liên kết YouTube.',
-				dialog: {
-					title: 'Đã phát hiện YouTube URL',
-					body: 'Sử dụng liên kết này từ bộ nhớ tạm của bạn?',
-					bulkTitle: 'Đã phát hiện URL hàng loạt',
-					bulkBody: 'Dùng các liên kết trong clipboard này làm tải xuống hàng loạt?',
-					bulkSummary: '{{count}} URL sẵn sàng',
-					bulkIgnored: '{{count}} bị bỏ qua',
-					bulkButton: 'Tải hàng loạt',
-					useButton: 'Dùng URL',
-					disableButton: 'Tắt',
-					cancelButton: 'Hủy',
-					disableNote: 'Bạn có thể bật lại tính năng theo dõi bộ nhớ tạm sau trong cài đặt Nâng cao.'
-				}
-			},
+			clipboard: {toggle: 'Theo dõi bộ nhớ tạm', toggleDescription: 'Tự động điền vào trường URL khi bạn sao chép một liên kết YouTube.', dialog: {cancelButton: 'Hủy'}},
 			cookies: {
 				sourceLabel: 'Nguồn cookies',
 				sourceOff: 'Tắt',
@@ -464,7 +446,6 @@ const vi = {
 		footerTooltip: 'Chia sẻ Arroxy',
 		footerLabel: 'Chia sẻ',
 		shareAction: 'Chia sẻ Arroxy',
-		inlineCard: {body: 'Bạn thích Arroxy không? Hãy chia sẻ với ai đó có thể thấy nó hữu ích.', dismiss: 'Bỏ qua gợi ý chia sẻ'},
 		highValueBanner: {body: 'Bạn thích Arroxy không? Hãy giúp người khác khám phá nó.', dismiss: 'Bỏ qua gợi ý chia sẻ'}
 	}
 } as const

--- a/src/shared/i18n/locales/zh.ts
+++ b/src/shared/i18n/locales/zh.ts
@@ -69,8 +69,7 @@ const zh = {
 			ignoredCount: '已忽略',
 			emptyPreview: '粘贴一个或多个 URL 以预览批次。',
 			needsAtLeastOne: '至少添加一个受支持的 URL 才能继续。',
-			confirm: '使用这些 URL',
-			reject: {duplicate: '重复', playlist: '使用播放列表流程', channel: '使用频道流程'}
+			reject: {duplicate: '重复'}
 		},
 		playlistPresets: {heading: '选择批量下载画质', subhead: '每个视频独立匹配所选画质档位——混合内容的播放列表也能正常处理，无意外。', itemCount_one: '{{count}} 项', itemCount_other: '{{count}} 项'},
 		mixedPrompt: {
@@ -79,7 +78,6 @@ const zh = {
 			singleVideo: '就这一个',
 			pickFromPlaylist: '从 Playlist 中挑选',
 			playlistLimit: '播放列表探测限制：{{count}} 个项目',
-			advancedSettings: '高级设置',
 			singleTooltip: '使用 yt-dlp 单视频模式，因此会忽略此 URL 附带的播放列表。',
 			playlistTooltip: '使用 yt-dlp 播放列表模式，并在显示选择器前获取到你的探测限制。'
 		},
@@ -87,7 +85,7 @@ const zh = {
 		url: {
 			heading: 'YouTube 链接',
 			placeholder: 'https://www.youtube.com/watch?v=...',
-			fetchFormats: '获取格式',
+			interactiveDownload: '获取格式',
 			fetchFormatsTooltip: '加入队列前，逐步选择格式、字幕、文件夹和播放列表项目。',
 			quickDownload: '快速下载',
 			quickDownloadTooltip: '使用已保存或默认偏好设置，将此单个视频加入队列，而不打开设置步骤。',
@@ -109,23 +107,7 @@ const zh = {
 			mascotBusy: '正在后台下载… 我可以同时处理多个任务 😎',
 			advanced: '高级',
 			clearAria: '清除 URL',
-			clipboard: {
-				toggle: '监听剪贴板',
-				toggleDescription: '复制 YouTube 链接时自动填充 URL 字段。',
-				dialog: {
-					title: '检测到 YouTube 链接',
-					body: '使用剪贴板中的此链接吗?',
-					bulkTitle: '检测到批量 URL',
-					bulkBody: '将剪贴板中的这些链接作为批量下载使用？',
-					bulkSummary: '{{count}} 个 URL 就绪',
-					bulkIgnored: '已忽略 {{count}} 个',
-					bulkButton: '批量下载',
-					useButton: '使用 URL',
-					disableButton: '禁用',
-					cancelButton: '取消',
-					disableNote: '你可以稍后在高级设置中重新启用剪贴板监听。'
-				}
-			},
+			clipboard: {toggle: '监听剪贴板', toggleDescription: '复制 YouTube 链接时自动填充 URL 字段。', dialog: {cancelButton: '取消'}},
 			cookies: {
 				sourceLabel: 'Cookies 来源',
 				sourceOff: '关闭',
@@ -411,7 +393,6 @@ const zh = {
 		footerTooltip: '分享 Arroxy',
 		footerLabel: '分享',
 		shareAction: '分享 Arroxy',
-		inlineCard: {body: '喜欢 Arroxy 吗？把它分享给可能觉得有用的人吧。', dismiss: '关闭分享建议'},
 		highValueBanner: {body: '喜欢 Arroxy 吗？帮助其他人发现它。', dismiss: '关闭分享建议'}
 	}
 } as const

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -28,7 +28,7 @@ export type PlaylistAudioFormat = z.infer<typeof playlistAudioFormatSchema>
 
 const downloadProfileAudioFormatSchema = z.enum(['best', 'mp3', 'm4a', 'opus', 'wav'])
 
-export const downloadProfileIconSchema = z.enum(['download', 'video', 'captions', 'audio', 'music', 'podcast', 'classes', 'clip', 'archive'])
+export const downloadProfileIconSchema = z.enum(['controls', 'download', 'video', 'captions', 'audio', 'music', 'podcast', 'classes', 'clip', 'archive'])
 export type DownloadProfileIcon = z.infer<typeof downloadProfileIconSchema>
 export const DOWNLOAD_PROFILE_ICONS = downloadProfileIconSchema.options
 

--- a/tests/browser/scenario-gallery.spec.ts
+++ b/tests/browser/scenario-gallery.spec.ts
@@ -82,6 +82,28 @@ test('screen preset scenarios expose the screen picker', async ({page}) => {
 	await expect(page.getByTestId('mock-step-select')).toBeVisible()
 })
 
+test('profile scenarios render their seeded browser-mock states', async ({page}) => {
+	await openScenario(page, 'profiles-home-empty')
+	await expect(page.getByTestId('download-profiles-home')).toBeVisible()
+	await expect(page.getByTestId('profiles-active-profile-card')).toContainText('Balanced')
+
+	await openScenario(page, 'profiles-home-clipboard-single')
+	await expect(page.getByTestId('profiles-main-input')).toHaveValue('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+
+	await openScenario(page, 'profiles-split-menu')
+	await expect(page.getByTestId('profiles-profile-menu')).toBeVisible()
+
+	await openScenario(page, 'profiles-editor')
+	await expect(page.getByTestId('profiles-editor-dialog')).toBeVisible()
+
+	await openScenario(page, 'profiles-bulk')
+	await expect(page.getByTestId('bulk-url-dialog')).toBeVisible()
+
+	await openScenario(page, 'profiles-playlist-cap')
+	await expect(page.getByTestId('quick-playlist-cap-dialog')).toBeVisible()
+	await expect(page.getByTestId('quick-playlist-cap-dialog')).toContainText('Mock Browser Playlist')
+})
+
 test('playlist scope empty reload scenario stays on playlist with inline error', async ({page}) => {
 	await openScenario(page, 'playlist-scope-empty-reload')
 	await waitForPlaylist(page)

--- a/tests/e2e/fixture-resilience.spec.ts
+++ b/tests/e2e/fixture-resilience.spec.ts
@@ -52,8 +52,8 @@ test('Electron metadata failure surfaces retry and recovers', async () => {
 	const videoId = FIXTURE_VIDEO_IDS[3]
 
 	await withFixtureProductApp({behavior: {metadataFailureIds: [videoId]}, userDataPrefix: 'arroxy-fixture-metadata-retry-user-', outputPrefix: 'arroxy-fixture-metadata-retry-out-'}, async ({page, fixtureServer, urls}) => {
-		await page.locator('[data-testid="url-input"]').fill(urls.video(videoId))
-		await page.locator('[data-testid="btn-find-formats"]').click()
+		await page.locator('[data-testid="profiles-main-input"]').fill(urls.video(videoId))
+		await page.locator('[data-testid="profiles-interactive-download"]').click()
 		await expect(page.locator('[data-testid="step-error"]')).toBeVisible({timeout: 60_000})
 		await expect(page.locator('[data-testid="error-message"]')).toContainText('Fixture metadata failed')
 

--- a/tests/e2e/fixture-workflows.spec.ts
+++ b/tests/e2e/fixture-workflows.spec.ts
@@ -1,24 +1,41 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import {expect, test} from '@playwright/test'
+import {BUILTIN_DOWNLOAD_PROFILES} from '../../src/shared/downloadProfiles.js'
 import {FIXTURE_PLAYLIST_VIDEO_IDS, FIXTURE_VIDEO_IDS} from './fixtureHarness.js'
 import {withFixtureProductApp} from './fixtureProductE2E.js'
 import {clickContinue, preparePlaylistConfirm, prepareSingleConfirm, startBulkFromClipboard} from './fixtureWorkflow.js'
 
 test.describe.configure({mode: 'serial'})
 
-test('Electron quick download queues and completes a fixture video', async () => {
+test('Electron quick download applies the active Download Profile to a fixture video', async () => {
 	test.setTimeout(140_000)
 	const videoId = FIXTURE_VIDEO_IDS[7]
 
-	await withFixtureProductApp({userDataPrefix: 'arroxy-fixture-quick-user-', outputPrefix: 'arroxy-fixture-quick-out-'}, async ({page, urls, queue, files}) => {
-		await page.locator('[data-testid="url-input"]').fill(urls.video(videoId))
-		await page.locator('[data-testid="btn-quick-download"]').click()
-		await expect(page.locator('[data-testid="quick-download-feedback"]')).toContainText(/queue/i, {timeout: 60_000})
-		await queue.expectStatus('Fixture Video 8', 'done', 120_000)
+	await withFixtureProductApp(
+		{
+			userDataPrefix: 'arroxy-fixture-profile-quick-user-',
+			outputPrefix: 'arroxy-fixture-profile-quick-out-',
+			settings: settings => {
+				const smallFileProfile = BUILTIN_DOWNLOAD_PROFILES.find(profile => profile.id === 'small-file')
+				if (!smallFileProfile) throw new Error('small-file built-in profile missing')
+				settings.profiles.active = {kind: 'builtin', id: 'small-file'}
+				settings.profiles.overrides = [{...smallFileProfile, embed: {chapters: false, metadata: false, thumbnail: false, description: false, thumbnailSidecar: false}, sponsorBlock: {mode: 'off', categories: []}}]
+			}
+		},
+		async ({page, outputDir, fixtureServer, urls, queue, files}) => {
+			await expect(page.locator('[data-testid="profiles-active-profile-card"]')).toContainText('Small file')
+			await page.locator('[data-testid="profiles-main-input"]').fill(urls.video(videoId))
+			await page.locator('[data-testid="profiles-quick-download"]').click()
+			await expect(page.locator('[data-testid="profiles-mascot-help"]')).toContainText(/queued/i, {timeout: 60_000})
+			await queue.expectStatus('Fixture Video 8', 'done', 120_000)
 
-		files.expectMp4Count(1)
-	})
+			const profileOutputDir = path.join(outputDir, 'Small file')
+			files.expectMp4Count(1, profileOutputDir)
+			const mediaRequest = fixtureServer.telemetry().requests.find(request => request.kind === 'media' && request.videoId === videoId && request.status === 200)
+			expect(mediaRequest).toMatchObject({kind: 'media', videoId, formatId: '18', status: 200})
+		}
+	)
 })
 
 test('Electron full single-video wizard completes media and sidecar subtitles', async () => {
@@ -80,10 +97,10 @@ test('Electron bulk metadata concurrency and back/next navigation reach complete
 	test.setTimeout(240_000)
 
 	await withFixtureProductApp({behavior: {metadataDelayMs: 2_000}, userDataPrefix: 'arroxy-fixture-electron-user-', outputPrefix: 'arroxy-fixture-electron-out-'}, async ({app, page, fixtureServer, urls, files}) => {
-		const rawBulkText = [...urls.videos(FIXTURE_VIDEO_IDS), urls.video(FIXTURE_VIDEO_IDS[0]), urls.playlist()].join('\n')
+		const rawBulkText = [...urls.videos(FIXTURE_VIDEO_IDS), urls.video(FIXTURE_VIDEO_IDS[0])].join('\n')
 		await startBulkFromClipboard(page, app, rawBulkText)
 		await expect(page.locator('[data-testid="bulk-url-valid-count"]')).toContainText('10')
-		await expect(page.locator('[data-testid="bulk-url-ignored-count"]')).toContainText('2')
+		await expect(page.locator('[data-testid="bulk-url-ignored-count"]')).toContainText('1')
 		await page.locator('[data-testid="bulk-url-confirm"]').click()
 
 		await expect(page.locator('[data-testid="step-playlist-items"]')).toBeVisible()

--- a/tests/e2e/fixtureWorkflow.ts
+++ b/tests/e2e/fixtureWorkflow.ts
@@ -77,12 +77,12 @@ export async function launchFixtureApp(ytDlpPath: string, input: {userDataDir: s
 	const app = await electron.launch({args: [path.join(process.cwd(), 'out', 'main', 'index.js')], env: buildFixtureElectronEnv({userDataDir: input.userDataDir, fixtureServer: input.fixtureServer, denyProxy: input.denyProxy, ytDlpPath})})
 	const page = await app.firstWindow()
 	await expect(page.locator('[data-testid="app-root"]')).toBeVisible({timeout: 60_000})
-	await expect(page.locator('[data-testid="url-input"]')).toBeVisible()
+	await expect(page.locator('[data-testid="profiles-main-input"]')).toBeVisible()
 	return {app, page}
 }
 
 export async function startBulkFromClipboard(page: Page, app: ElectronApplication, rawUrls: string): Promise<void> {
-	await page.locator('[data-testid="btn-bulk-download"]').click()
+	await page.locator('[data-testid="profiles-bulk-urls"]').click()
 	await expect(page.locator('[data-testid="bulk-url-dialog"]')).toBeVisible()
 	await writeClipboard(app, rawUrls)
 	const bulkTextarea = page.locator('[data-testid="bulk-url-textarea"]')
@@ -91,8 +91,8 @@ export async function startBulkFromClipboard(page: Page, app: ElectronApplicatio
 }
 
 export async function prepareSingleConfirm(page: Page, videoId: string, subtitleChoice: 'skip' | 'continue' = 'skip'): Promise<void> {
-	await page.locator('[data-testid="url-input"]').fill(fixtureUrl(videoId))
-	await page.locator('[data-testid="btn-find-formats"]').click()
+	await page.locator('[data-testid="profiles-main-input"]').fill(fixtureUrl(videoId))
+	await page.locator('[data-testid="profiles-interactive-download"]').click()
 	await expect(page.locator('[data-testid="step-formats"]')).toBeVisible({timeout: 60_000})
 	await clickContinue(page)
 
@@ -115,8 +115,8 @@ export async function prepareSingleConfirm(page: Page, videoId: string, subtitle
 }
 
 export async function preparePlaylistConfirm(page: Page, playlistUrl: string): Promise<void> {
-	await page.locator('[data-testid="url-input"]').fill(playlistUrl)
-	await page.locator('[data-testid="btn-find-formats"]').click()
+	await page.locator('[data-testid="profiles-main-input"]').fill(playlistUrl)
+	await page.locator('[data-testid="profiles-interactive-download"]').click()
 	await expect(page.locator('[data-testid="step-playlist-items"]')).toBeVisible({timeout: 60_000})
 	await clickContinue(page)
 	await expect(page.locator('[data-testid="step-playlist-presets"]')).toBeVisible()

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -22,7 +22,7 @@ test('app shell renders with expected structure', async () => {
 
 	await expect(page.locator('[data-testid="app-root"]')).toBeVisible({timeout: 15_000})
 	await expect(page.locator('[data-testid="app-content"]')).toBeVisible()
-	await expect(page.locator('[data-testid="url-input"]')).toBeVisible()
+	await expect(page.locator('[data-testid="profiles-main-input"]')).toBeVisible()
 
 	await app.close()
 })
@@ -63,7 +63,7 @@ test('URL input is interactive', async () => {
 	const app = await launchApp(userDataDir)
 	const page = await app.firstWindow()
 
-	const input = page.locator('[data-testid="url-input"]')
+	const input = page.locator('[data-testid="profiles-main-input"]')
 	await input.waitFor({timeout: 15_000})
 
 	await input.fill('https://www.youtube.com/watch?v=test')

--- a/tests/e2e/startup-resilience.spec.ts
+++ b/tests/e2e/startup-resilience.spec.ts
@@ -24,7 +24,7 @@ test('corrupted settings.json → app still reaches shell', async () => {
 
 	// App must reach the shell despite corrupt settings — falls back to defaults.
 	await expect(page.locator('[data-testid="app-root"]')).toBeVisible({timeout: 15_000})
-	await expect(page.locator('[data-testid="url-input"]')).toBeVisible()
+	await expect(page.locator('[data-testid="profiles-main-input"]')).toBeVisible()
 
 	await app.close()
 })
@@ -37,7 +37,7 @@ test('corrupted queue.json → app still reaches shell', async () => {
 	const page = await app.firstWindow()
 
 	await expect(page.locator('[data-testid="app-root"]')).toBeVisible({timeout: 15_000})
-	await expect(page.locator('[data-testid="url-input"]')).toBeVisible()
+	await expect(page.locator('[data-testid="profiles-main-input"]')).toBeVisible()
 
 	await app.close()
 })

--- a/tests/renderer/app.test.tsx
+++ b/tests/renderer/app.test.tsx
@@ -63,16 +63,16 @@ describe('App renderer', () => {
 
 		const quick = await screen.findByTestId('profiles-quick-download')
 		const fetch = screen.getByTestId('profiles-interactive-download')
-		expect(quick).toHaveTextContent('Quick Download')
+		expect(quick).toHaveTextContent(/Quick download/i)
 		expect(screen.getByTestId('profiles-quick-preview')).toHaveTextContent('Active profile')
-		expect(screen.getByRole('button', {name: 'Edit selected profile: Balanced'})).toBeInTheDocument()
-		const profileMenuTrigger = screen.getByRole('button', {name: 'Choose active download profile'})
+		expect(screen.getByRole('button', {name: 'Edit active profile: Balanced'})).toBeInTheDocument()
+		const profileMenuTrigger = screen.getByRole('button', {name: 'Switch download profile'})
 		expect(profileMenuTrigger).toBeInTheDocument()
 		expect(quick).toBeDisabled()
 
 		fireEvent.click(profileMenuTrigger)
 		expect(await screen.findByText('Switch profile')).toBeInTheDocument()
-		expect(screen.getByText('Change the active profile for Quick Download, Bulk URLs, and playlists.')).toBeInTheDocument()
+		expect(screen.getByTestId('profiles-profile-menu')).toBeInTheDocument()
 
 		const input = await screen.findByTestId('profiles-main-input')
 		fireEvent.change(input, {target: {value: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'}})
@@ -109,7 +109,7 @@ describe('App renderer', () => {
 	it('closes the profile picker when opening profile editor surfaces', async () => {
 		render(<App />)
 
-		const profileMenuTrigger = await screen.findByRole('button', {name: 'Choose active download profile'})
+		const profileMenuTrigger = await screen.findByRole('button', {name: 'Switch download profile'})
 		fireEvent.click(profileMenuTrigger)
 		expect(await screen.findByText('Switch profile')).toBeInTheDocument()
 

--- a/tests/unit/browser-mock-scenarios.test.ts
+++ b/tests/unit/browser-mock-scenarios.test.ts
@@ -115,6 +115,26 @@ describe('browser mock scenarios', () => {
 		expect(lastPatch).toMatchObject({wizardStep: 'confirm'})
 	})
 
+	it('applies profile scenario states through the workbench interface', async () => {
+		const store: ScenarioWorkbenchStore = {reset: vi.fn(), setWizardUrl: vi.fn(), submitUrl: vi.fn().mockResolvedValue(undefined), setState: vi.fn()}
+
+		await applyScenarioWorkbenchState({scenario: getScenario('profiles-home-clipboard-single'), params: readUrlParams(new URL('http://localhost:5173/?scenario=profiles-home-clipboard-single')), store})
+
+		expect(store.reset).toHaveBeenCalledOnce()
+		expect(store.submitUrl).not.toHaveBeenCalled()
+		expect(vi.mocked(store.setState).mock.calls[0]?.[0]).toMatchObject({wizardStep: 'url', wizardUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'})
+
+		vi.mocked(store.reset).mockClear()
+		vi.mocked(store.setState).mockClear()
+
+		await applyScenarioWorkbenchState({scenario: getScenario('profiles-playlist-cap'), params: readUrlParams(new URL('http://localhost:5173/?scenario=profiles-playlist-cap')), store})
+
+		const playlistCapPatch = vi.mocked(store.setState).mock.calls[0]?.[0]
+		expect(store.reset).toHaveBeenCalledOnce()
+		expect(playlistCapPatch).toMatchObject({wizardStep: 'url', wizardMode: 'playlist', playlistTitle: 'Mock Browser Playlist', playlistLikelyCapped: true, quickPlaylistCapDialogOpen: true})
+		expect((playlistCapPatch as {playlistItems?: unknown[]}).playlistItems).toHaveLength(100)
+	})
+
 	it('flags only scoped playlist reloads for the empty-scope scenario', () => {
 		const scenario = getScenario('playlist-scope-empty-reload')
 


### PR DESCRIPTION
## Summary
- Redesign the download profiles home screen with darker glass material, visible aurora, glow panels, and clearer action hierarchy.
- Replace the misleading URL-tab/download icon treatment with link/profile semantics and move capability copy into the state-driven mascot tip.
- Add the controls profile icon, browser-mock profile scenarios, and updated renderer/E2E selectors for the new profile home.

## Validation
- bun run check