### PR TITLE
chore: make the setup-node contract assertion version-agnostic

### DIFF
--- a/scripts/check-tooling-contract.mjs
+++ b/scripts/check-tooling-contract.mjs
@@ -278,7 +278,10 @@ for (const workflow of publishWorkflows) {
 	assert(text.includes(`run: ${workflow.command}`), `${workflow.path} must call "${workflow.command}".`)
 	assert(text.includes('bun pm view'), `${workflow.path} must use bun pm view for registry version checks.`)
 	assert(text.includes('bun pm pack --destination'), `${workflow.path} must pack artifacts with bun pm pack.`)
-	assert(text.includes('uses: actions/setup-node@v6'), `${workflow.path} must set up Node for registry trusted publishing.`)
+	// Version-agnostic on purpose: the contract cares that Node is set up for
+	// trusted publishing, not which release of the action does it. Pinning the
+	// major here meant every setup-node bump failed the gate.
+	assert(/uses: actions\/setup-node@/.test(text), `${workflow.path} must set up Node for registry trusted publishing.`)
 	assert(text.includes('node-version: 24'), `${workflow.path} must use Node 24 for registry trusted publishing.`)
 	assert(text.includes('registry-url: https://registry.npmjs.org'), `${workflow.path} must target the npmjs registry for trusted publishing.`)
 	assert(text.includes('package-manager-cache: false'), `${workflow.path} must keep package-manager caching disabled in publish jobs.`)

--- a/scripts/check-tooling-contract.mjs
+++ b/scripts/check-tooling-contract.mjs
@@ -281,7 +281,7 @@ for (const workflow of publishWorkflows) {
 	// Version-agnostic on purpose: the contract cares that Node is set up for
 	// trusted publishing, not which release of the action does it. Pinning the
 	// major here meant every setup-node bump failed the gate.
-	assert(/uses: actions\/setup-node@/.test(text), `${workflow.path} must set up Node for registry trusted publishing.`)
+	assert(text.includes('uses: actions/setup-node@'), `${workflow.path} must set up Node for registry trusted publishing.`)
 	assert(text.includes('node-version: 24'), `${workflow.path} must use Node 24 for registry trusted publishing.`)
 	assert(text.includes('registry-url: https://registry.npmjs.org'), `${workflow.path} must target the npmjs registry for trusted publishing.`)
 	assert(text.includes('package-manager-cache: false'), `${workflow.path} must keep package-manager caching disabled in publish jobs.`)


### PR DESCRIPTION
Unblocks #138 (actions/setup-node v6 → v7).

`check-tooling-contract.mjs` asserted the literal string `uses: actions/setup-node@v6`, so *any* setup-node major bump fails the gate regardless of whether anything is actually wrong. That is what #138 tripped over.

The contract's intent is that Node is set up for registry trusted publishing — not which release of the action does it. `node-version: 24`, the registry URL, the OIDC permission and the publish command all stay asserted, because those are the parts that carry meaning.

Verified the relaxed assertion still fails when `setup-node` is removed from the workflow entirely, so it has not become vacuous.

`bun run check` green.