### PR TITLE
fix: repair browser specs that CI never runs

### DIFF
--- a/src/renderer/src/browserMock.ts
+++ b/src/renderer/src/browserMock.ts
@@ -312,6 +312,7 @@ export function installBrowserMock(): void {
 				}
 
 				if (shouldMockEmptyPlaylistScopeReload(scenarioState.scenario, input.playlistMode, input.playlistScope)) {
+					await delay(1400)
 					return {ok: false, error: {kind: 'other', code: 'playlist_empty', message: 'Playlist returned no entries'}}
 				}
 

--- a/tests/browser/queue-manager-workbench.spec.ts
+++ b/tests/browser/queue-manager-workbench.spec.ts
@@ -8,7 +8,7 @@ async function openScenario(page: Page, scenario: string): Promise<void> {
 
 async function openQueueScenario(page: Page, scenario: string): Promise<void> {
 	await openScenario(page, scenario)
-	await page.getByRole('tab', {name: /^queue/i}).click()
+	await page.getByRole('tab', {name: /^downloads/i}).click()
 	await expect(page.getByTestId('queue-manager-tab')).toBeVisible()
 }
 
@@ -16,7 +16,7 @@ test('queue manager scenario states hydrate without walking a fake download', as
 	for (const [scenario, status] of [
 		['queue-active', 'running'],
 		['queue-pending', 'pending'],
-		['queue-mixed-selection', 'paused-active'],
+		['queue-mixed-selection', 'running'],
 		['queue-errors', 'error'],
 		['queue-artifacts', 'done']
 	] as const) {
@@ -39,7 +39,7 @@ test('"Clear completed" removes terminal scenario items and keeps queue manager 
 
 	await expect(page.getByTestId('queue-manager-tab')).toBeVisible()
 	await expect(page.locator('[data-testid^="queue-manager-row-"]')).toHaveCount(0)
-	await expect(page.getByTestId('queue-manager-tab')).toContainText('Downloads you queue')
+	await expect(page.getByTestId('queue-manager-tab')).toContainText('Queued downloads will appear here')
 })
 
 test('screenshot - Clear button in queue manager toolbar for completed scenario', async ({page}) => {

--- a/tests/browser/scenario-gallery.spec.ts
+++ b/tests/browser/scenario-gallery.spec.ts
@@ -203,18 +203,18 @@ test('update scenarios render channel-specific actions', async ({page}) => {
 	await expect(page.getByTestId('update-command')).toHaveText('scoop update arroxy')
 
 	await openScenario(page, 'update-portable')
-	await expect(page.getByTestId('update-banner').getByRole('link', {name: 'Download'})).toBeVisible()
+	await expect(page.getByTestId('update-banner').getByRole('button', {name: 'Download'})).toBeVisible()
 })
 
 test('queue scenarios hydrate manager states', async ({page}) => {
 	for (const [scenario, status] of [
 		['queue-active', 'running'],
-		['queue-mixed-selection', 'paused-active'],
+		['queue-mixed-selection', 'running'],
 		['queue-errors', 'error'],
 		['queue-artifacts', 'done']
 	] as const) {
 		await openScenario(page, scenario)
-		await page.getByRole('tab', {name: /^queue/i}).click()
+		await page.getByRole('tab', {name: /^downloads/i}).click()
 		await expect(page.getByTestId('queue-manager-tab')).toBeVisible()
 		await expect(page.locator('[data-testid^="queue-manager-row-"]').first()).toHaveAttribute('data-status', status)
 	}

--- a/tests/unit/download-service-subs.test.ts
+++ b/tests/unit/download-service-subs.test.ts
@@ -155,7 +155,7 @@ describe('DownloadService — sidecar mux after Merger + MoveFiles regressions',
 			})
 		}) as never)
 
-		const {service} = makeService()
+		const {service, recentJobsStore} = makeService()
 		await service.start({url: YOUTUBE_URL, outputDir: workDir, job: makeJob({formatId: '330+251', subtitles: {languages: ['en-orig'], mode: 'embed', format: 'srt', writeAuto: true}})})
 		await vi.waitFor(() => expect(ffmpegCalls).toHaveLength(1))
 
@@ -163,6 +163,11 @@ describe('DownloadService — sidecar mux after Merger + MoveFiles regressions',
 		const firstInputIdx = args.indexOf('-i')
 		expect(args[firstInputIdx + 1]).toBe(finalVideoPath)
 		expect(args[firstInputIdx + 1]).not.toBe(tempVideoPath)
+
+		// Wait for finalize() to fully drain tempDir/mux disposables before the
+		// outer afterEach() rmSync()s workDir — otherwise still-running cleanup
+		// races the synchronous rmSync and intermittently throws ENOTEMPTY.
+		await vi.waitFor(() => expect(recentJobsStore.push).toHaveBeenCalledOnce())
 	})
 
 	it('passes the post-"already been downloaded" path to ffmpeg when the merged file pre-exists', async () => {
@@ -191,12 +196,16 @@ describe('DownloadService — sidecar mux after Merger + MoveFiles regressions',
 			})
 		}) as never)
 
-		const {service} = makeService()
+		const {service, recentJobsStore} = makeService()
 		await service.start({url: YOUTUBE_URL, outputDir: workDir, job: makeJob({formatId: '330+251', subtitles: {languages: ['en-orig'], mode: 'embed', format: 'srt', writeAuto: true}})})
 		await vi.waitFor(() => expect(ffmpegCalls).toHaveLength(1))
 
 		const args = ffmpegCalls[0]
 		expect(args[args.indexOf('-i') + 1]).toBe(finalVideoPath)
+
+		// See the comment in the previous test — wait for the job to fully
+		// settle before the outer afterEach() rmSync()s workDir.
+		await vi.waitFor(() => expect(recentJobsStore.push).toHaveBeenCalledOnce())
 	})
 })
 
@@ -271,7 +280,7 @@ describe('DownloadService — embed+auto muxing after subtitle dedupe', () => {
 		vi.mocked(spawnYtDlp).mockImplementation(makeTwoPhaseSpawn(videoPath, subPath, rolling) as never)
 		mockSuccessfulMux()
 
-		const {service} = makeService()
+		const {service, recentJobsStore} = makeService()
 		const events = captureStatuses(service)
 		await service.start({url: YOUTUBE_URL, outputDir: workDir, job: makeJob({formatId: '137+251', subtitles: {languages: ['en'], mode: 'embed', format: 'srt', writeAuto: true}})})
 		await vi.waitFor(() => expect(statusKeys(events)).toContain('mergingFormats'))
@@ -280,6 +289,13 @@ describe('DownloadService — embed+auto muxing after subtitle dedupe', () => {
 		const fetchIdx = keys.lastIndexOf('fetchingSubtitles')
 		const mergeIdx = keys.lastIndexOf('mergingFormats')
 		expect(mergeIdx).toBeGreaterThan(fetchIdx)
+
+		// Let the mux phase finish and finalize() drain its tempDir disposables
+		// before the outer afterEach() rmSync()s workDir — otherwise the
+		// still-running mux/cleanup work races the synchronous rmSync and
+		// intermittently throws ENOTEMPTY (only reproduces under load, since it
+		// needs the background chain to still be in flight at teardown time).
+		await vi.waitFor(() => expect(recentJobsStore.push).toHaveBeenCalledOnce())
 	})
 
 	it('cancel during ffmpeg mux kills the ffmpeg process and removes the .muxing.mkv temp file', async () => {
@@ -296,7 +312,7 @@ describe('DownloadService — embed+auto muxing after subtitle dedupe', () => {
 			return proc
 		}) as never)
 
-		const {service} = makeService()
+		const {service, recentJobsStore} = makeService()
 		const startResult = await service.start({url: YOUTUBE_URL, outputDir: workDir, job: makeJob({formatId: '137+251', subtitles: {languages: ['en'], mode: 'embed', format: 'srt', writeAuto: true}})})
 		expect(startResult.ok).toBe(true)
 		if (!startResult.ok) return
@@ -307,5 +323,9 @@ describe('DownloadService — embed+auto muxing after subtitle dedupe', () => {
 
 		const tempPath = join(workDir, 'Title.muxing.mkv')
 		await vi.waitFor(() => expect(() => readFileSync(tempPath)).toThrow())
+
+		// See the comment above — wait for the job to fully settle before the
+		// outer afterEach() rmSync()s workDir.
+		await vi.waitFor(() => expect(recentJobsStore.push).toHaveBeenCalledOnce())
 	})
 })


### PR DESCRIPTION
## Summary

`bun run test:browser` fails on `main` — 7 failed / 21 passed. This repairs all seven, plus an intermittent `ENOTEMPTY` race in the unit suite. No feature work.

**Why nobody noticed.** CI's `dev-smoke.yml` runs `bun run test:browser:smoke`, which per `scripts/dev-env.ts:641` executes **only `tests/browser/dev-smoke.spec.ts`** — one file. The rest of `tests/browser/` has never been run in CI, so `main` stays green while these specs rot.

**How long they have been broken.** The four queue-manager failures trace to `0c0c568` (#115, June), which renamed the tab from "Download Queue" to "Downloads". The specs locate that tab with `/^queue/i`, so they have been failing since June without anyone seeing it.

## Base branch

- [x] This PR targets `main`.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling
- [ ] Docs

## Checks

- [x] `bun run check`

Also `bun run test:browser`: **28 passed / 0 failed** (~1.0 min, run twice, no flakes). The previous 3.6-minute runtime was almost entirely the four dead-end 30s click timeouts.

## Testing

| Spec | Cause | Fixed |
| --- | --- | --- |
| `queue-manager-workbench.spec.ts:15,28,35,45` | stale `/^queue/i` tab locator after the #115 rename; `:15` also had a fixture-mismatched expected status; `:35` asserted pre-#115 empty-state copy | test |
| `scenario-gallery.spec.ts:209` | same stale tab locator + fixture-mismatched status | test |
| `scenario-gallery.spec.ts:198` | asserted `role: 'link'` on what has always been a `<button>` (it calls `shell.openExternal` over IPC, never an `<a>`) — wrong since the test was introduced | test |
| `scenario-gallery.spec.ts:176` | the browser-mock's empty-playlist-scope-reload probe path was the only probe branch missing the `await delay(1400)` its siblings have, so the transient "Reloading…" state never rendered for the spec to observe | mock |
| `tests/unit/download-service-subs.test.ts` | temp-directory teardown raced a job still holding a handle; surfaced only under `bun run check`'s concurrent load | source |

Six of the seven were stale assertions chasing UI that had legitimately changed. One was a genuine gap in the browser-mock. **Nothing was skipped or deleted**, and no assertion was loosened to get green.

## Notes for the reviewer

**The systemic issue is the CI gap, not these seven tests.** They will rot again the moment the next rename lands, because nothing runs them. Deliberately not changed here — that is your call, and it affects every PR's cycle time.

Evidence if you want to gate the full suite: it ran clean twice at ~1 minute, and every fix targeted a real defect rather than loosening an assertion, so there is no known-flaky test riding along. Caveat: that is two clean local runs on macOS, not a soak on the actual GitHub runner. A few confirmatory runs before flipping the gate would be cheap insurance.

The change would be one line in `dev-smoke.yml` — `bun run test:browser:smoke` → `bun run test:browser`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-facing changes

- Updated browser tests for renamed tabs, status values, empty-state text, and the update-banner button role.
- Added a 1.4-second delay to the empty-playlist reload mock so the reloading state can render.

## Internal changes

- Added job-finalization waits before temporary-directory teardown in download-service tests.
- Prevented background download cleanup from racing with test teardown.

## Risk areas

- No production Electron, IPC, build, release, or dependency changes.
- Changes affect browser fixtures, mocks, and test synchronization only.

## Tests and checks

- Run `bun run check`.
- Run `bun run test:browser`.
- Run the unit test suite, including `tests/unit/download-service-subs.test.ts`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->