### PR TITLE
feat(intent): classify youtube live stream and clip urls as individual videos

### DIFF
--- a/src/shared/urlIntent.ts
+++ b/src/shared/urlIntent.ts
@@ -14,7 +14,7 @@ function parseUrl(url: string): URL | null {
 
 function isYouTubeHost(hostname: string): boolean {
 	const host = hostname.toLowerCase()
-	return host === 'youtube.com' || host.endsWith('.youtube.com') || host === 'youtu.be'
+	return host === 'youtube.com' || host.endsWith('.youtube.com') || host === 'youtu.be' || host === 'youtube-nocookie.com' || host.endsWith('.youtube-nocookie.com')
 }
 
 function youtubePathSegments(parsed: URL): string[] {
@@ -22,7 +22,16 @@ function youtubePathSegments(parsed: URL): string[] {
 }
 
 function isYouTubeVideoPath(host: string, segments: string[], searchParams: URLSearchParams): boolean {
-	return (host === 'youtu.be' && segments.length === 1 && !!segments[0]) || (segments[0] === 'watch' && !!searchParams.get('v')) || (segments[0] === 'shorts' && segments.length === 2 && !!segments[1])
+	return (
+		(host === 'youtu.be' && segments.length === 1 && !!segments[0]) ||
+		(segments[0] === 'watch' && !!searchParams.get('v')) ||
+		(segments[0] === 'shorts' && segments.length === 2 && !!segments[1]) ||
+		(segments[0] === 'live' && segments.length === 2 && !!segments[1]) ||
+		(segments[0] === 'clip' && segments.length === 2 && !!segments[1]) ||
+		(segments[0] === 'embed' && segments.length === 2 && !!segments[1]) ||
+		(segments[0] === 'v' && segments.length === 2 && !!segments[1]) ||
+		(segments[0] === 'e' && segments.length === 2 && !!segments[1])
+	)
 }
 
 function isYouTubeChannelPath(segments: string[]): boolean {
@@ -81,7 +90,7 @@ export function extractUrlIntentYouTubeVideoId(intent: UrlIntent): string | null
 	const segments = youtubePathSegments(parsed)
 	if (host === 'youtu.be') return segments[0] ?? null
 	if (segments[0] === 'watch') return parsed.searchParams.get('v')
-	if (segments[0] === 'shorts') return segments[1] ?? null
+	if (segments[0] === 'shorts' || segments[0] === 'live' || segments[0] === 'clip' || segments[0] === 'embed' || segments[0] === 'v' || segments[0] === 'e') return segments[1] ?? null
 	return null
 }
 

--- a/tests/unit/bulk-urls.test.ts
+++ b/tests/unit/bulk-urls.test.ts
@@ -60,9 +60,11 @@ describe('parseBulkUrls', () => {
 })
 
 describe('isClearlyIndividualYouTubeUrl', () => {
-	it('accepts watch, short, and youtu.be URLs without playlist params', () => {
+	it('accepts watch, short, live, clip, and youtu.be URLs without playlist params', () => {
 		expect(isClearlyIndividualYouTubeUrl('https://www.youtube.com/watch?v=abc123')).toBe(true)
 		expect(isClearlyIndividualYouTubeUrl('https://www.youtube.com/shorts/abc123')).toBe(true)
+		expect(isClearlyIndividualYouTubeUrl('https://www.youtube.com/live/abc123')).toBe(true)
+		expect(isClearlyIndividualYouTubeUrl('https://www.youtube.com/clip/clip123')).toBe(true)
 		expect(isClearlyIndividualYouTubeUrl('https://youtu.be/abc123')).toBe(true)
 	})
 
@@ -76,6 +78,8 @@ describe('extractYouTubeVideoId', () => {
 	it('derives ids for supported individual YouTube URL shapes', () => {
 		expect(extractYouTubeVideoId('https://www.youtube.com/watch?v=abc123')).toBe('abc123')
 		expect(extractYouTubeVideoId('https://www.youtube.com/shorts/short123')).toBe('short123')
+		expect(extractYouTubeVideoId('https://www.youtube.com/live/live123')).toBe('live123')
+		expect(extractYouTubeVideoId('https://www.youtube.com/clip/clip123')).toBe('clip123')
 		expect(extractYouTubeVideoId('https://youtu.be/bee123')).toBe('bee123')
 	})
 
@@ -89,6 +93,8 @@ describe('extractYouTubeVideoId', () => {
 describe('classifyBulkUrlKind', () => {
 	it.each([
 		['https://www.youtube.com/watch?v=abc123', 'single'],
+		['https://www.youtube.com/live/abc123', 'single'],
+		['https://www.youtube.com/clip/clip123', 'single'],
 		['https://www.youtube.com/watch?v=abc123&list=PLtest', 'mixed'],
 		['https://www.youtube.com/playlist?list=PLtest', 'playlist'],
 		['https://www.youtube.com/@arroxy', 'channel'],

--- a/tests/unit/url-intent.test.ts
+++ b/tests/unit/url-intent.test.ts
@@ -1,11 +1,17 @@
 import {describe, expect, it} from 'vitest'
-import {classifyUrlIntent, isMixedUrlIntent, isObviousSingleUrlIntent, urlIntentBulkLabel, urlIntentHomeLabel} from '@shared/urlIntent.js'
+import {classifyUrlIntent, deriveUrlIntentLabel, extractUrlIntentYouTubeVideoId, isMixedUrlIntent, isObviousSingleUrlIntent, urlIntentBulkLabel, urlIntentHomeLabel} from '@shared/urlIntent.js'
 
 describe('classifyUrlIntent', () => {
 	it.each([
 		['https://www.youtube.com/watch?v=ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}],
 		['https://youtu.be/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}],
-		['https://www.youtube.com/shorts/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}]
+		['https://www.youtube.com/shorts/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}],
+		['https://www.youtube.com/live/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}],
+		['https://m.youtube.com/live/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}],
+		['https://www.youtube.com/clip/Ugkx_1234567890abcdef', {kind: 'obvious-single', site: 'youtube'}],
+		['https://www.youtube.com/embed/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}],
+		['https://www.youtube-nocookie.com/embed/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}],
+		['https://www.youtube.com/v/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}]
 	] as const)('%s -> obvious single', (url, expected) => {
 		expect(classifyUrlIntent(url)).toMatchObject({...expected, url})
 	})
@@ -19,25 +25,48 @@ describe('classifyUrlIntent', () => {
 		expect(classifyUrlIntent(url)).toMatchObject({kind: 'obvious-collection', collection, url})
 	})
 
-	it.each(['https://www.youtube.com/watch?v=abc123&list=PLtest', 'https://www.youtube.com/watch?v=abc123&list=RDabc', 'https://m.youtube.com/watch?list=PLtest&v=abc123'])('%s -> mixed', url => {
+	it.each(['https://www.youtube.com/watch?v=abc123&list=PLtest', 'https://www.youtube.com/watch?v=abc123&list=RDabc', 'https://m.youtube.com/watch?list=PLtest&v=abc123', 'https://www.youtube.com/live/ScsahA7OzVo?list=PLtest', 'https://www.youtube.com/clip/Ugkx_123?list=PLtest'])('%s -> mixed', url => {
 		expect(classifyUrlIntent(url)).toEqual({kind: 'mixed', reason: 'youtube-video-with-list', url})
 	})
 
-	it.each(['https://vimeo.com/123', 'https://example.com/watch?v=abc&list=PLxyz', 'not a url', ''])('%s -> unknown', url => {
+	it.each(['https://vimeo.com/123', 'https://example.com/watch?v=abc&list=PLxyz', 'https://www.youtube.com/live', 'https://www.youtube.com/clip', 'not a url', ''])('%s -> unknown', url => {
 		expect(classifyUrlIntent(url)).toEqual({kind: 'unknown', url})
+	})
+
+	it('extracts YouTube video and clip IDs across all URL formats', () => {
+		expect(extractUrlIntentYouTubeVideoId(classifyUrlIntent('https://www.youtube.com/watch?v=ScsahA7OzVo'))).toBe('ScsahA7OzVo')
+		expect(extractUrlIntentYouTubeVideoId(classifyUrlIntent('https://youtu.be/ScsahA7OzVo'))).toBe('ScsahA7OzVo')
+		expect(extractUrlIntentYouTubeVideoId(classifyUrlIntent('https://www.youtube.com/shorts/ScsahA7OzVo'))).toBe('ScsahA7OzVo')
+		expect(extractUrlIntentYouTubeVideoId(classifyUrlIntent('https://www.youtube.com/live/ScsahA7OzVo'))).toBe('ScsahA7OzVo')
+		expect(extractUrlIntentYouTubeVideoId(classifyUrlIntent('https://www.youtube.com/clip/Ugkx_1234567890abcdef'))).toBe('Ugkx_1234567890abcdef')
+		expect(extractUrlIntentYouTubeVideoId(classifyUrlIntent('https://www.youtube.com/embed/ScsahA7OzVo'))).toBe('ScsahA7OzVo')
+		expect(extractUrlIntentYouTubeVideoId(classifyUrlIntent('https://www.youtube-nocookie.com/embed/ScsahA7OzVo'))).toBe('ScsahA7OzVo')
+		expect(extractUrlIntentYouTubeVideoId(classifyUrlIntent('https://www.youtube.com/playlist?list=PLtest'))).toBeNull()
+		expect(extractUrlIntentYouTubeVideoId(classifyUrlIntent('https://www.youtube.com/@arroxy'))).toBeNull()
+	})
+
+	it('derives readable intent labels from live streams, clips, and general URLs', () => {
+		expect(deriveUrlIntentLabel('https://www.youtube.com/live/ScsahA7OzVo')).toBe('YouTube ScsahA7OzVo')
+		expect(deriveUrlIntentLabel('https://www.youtube.com/clip/Ugkx_123')).toBe('YouTube Ugkx_123')
 	})
 
 	it('exposes narrow predicates and display labels from the same model', () => {
 		const single = classifyUrlIntent('https://youtu.be/abc123')
+		const live = classifyUrlIntent('https://www.youtube.com/live/ScsahA7OzVo')
+		const clip = classifyUrlIntent('https://www.youtube.com/clip/Ugkx_123')
 		const mixed = classifyUrlIntent('https://www.youtube.com/watch?v=abc123&list=PLtest')
 		const playlist = classifyUrlIntent('https://www.youtube.com/playlist?list=PLtest')
 		const unknown = classifyUrlIntent('https://vimeo.com/123')
 
 		expect(isObviousSingleUrlIntent(single)).toBe(true)
+		expect(isObviousSingleUrlIntent(live)).toBe(true)
+		expect(isObviousSingleUrlIntent(clip)).toBe(true)
 		expect(isMixedUrlIntent(mixed)).toBe(true)
 		expect(urlIntentHomeLabel(playlist)).toBe('Playlist URL')
 		expect(urlIntentHomeLabel(mixed)).toBe('Mixed URL')
 		expect(urlIntentBulkLabel(single)).toBe('single')
+		expect(urlIntentBulkLabel(live)).toBe('single')
+		expect(urlIntentBulkLabel(clip)).toBe('single')
 		expect(urlIntentBulkLabel(playlist)).toBe('playlist')
 		expect(urlIntentBulkLabel(mixed)).toBe('mixed')
 		expect(urlIntentBulkLabel(unknown)).toBe('unknown')


### PR DESCRIPTION
### Summary
Expands YouTube URL intent classification to recognize live stream (`/live/`), clip (`/clip/`), and embed (`/embed/`, `/v/`, `youtube-nocookie.com`) URLs as individual single videos.

### Changes
- **Host & Path Classification:**
  - Added support for `youtube-nocookie.com` domain in `isYouTubeHost`.
  - Added `/live/`, `/clip/`, `/embed/`, `/v/`, and `/e/` path shapes in `isYouTubeVideoPath`.
- **Identifier Extraction:**
  - Extended `extractUrlIntentYouTubeVideoId` to extract IDs from live stream and clip URL paths for UI labels, bulk intake, and metadata hydration.
  - Correctly categorizes live/clip URLs with playlist parameters (`?list=...`) as `mixed` (`youtube-video-with-list`).
- **Tests:**
  - Added test coverage in `tests/unit/url-intent.test.ts` and `tests/unit/bulk-urls.test.ts` for all new URL shapes and mixed playlist variants.

### Verification
- `bunx vitest run tests/unit/url-intent.test.ts tests/unit/bulk-urls.test.ts` (49 passed)
- `bun run typecheck`
- `bun run lint`
- `bun run packages:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-facing changes

- Recognize YouTube URLs from `youtube.com` and `youtube-nocookie.com`.
- Support `/live/`, `/clip/`, `/embed/`, `/v/`, and `/e/` video paths.
- Extract video IDs from live stream and clip URLs.
- Classify URLs with playlist parameters as `youtube-video-with-list` (`mixed`).

## Internal changes

- Extended YouTube URL detection and video ID extraction in `src/shared/urlIntent.ts`.
- Added unit coverage for new URL formats, playlist variants, labels, predicates, and bulk URL classification.

## Risk areas

- No Electron security, IPC, dependency, release, or build configuration changes are included.
- URL parsing changes could affect classification of unsupported or incomplete YouTube URLs.

## Tests and checks

- Run the unit test suite.
- Run type checking, linting, and package checks.
- Verification reported 49 passing tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->