### PR TITLE
fix(subfolder): escape reserved device names and sanitize trailing dots in playlist folders

### DIFF
--- a/src/shared/subfolder.ts
+++ b/src/shared/subfolder.ts
@@ -10,7 +10,7 @@
 // in path APIs on POSIX.
 // eslint-disable-next-line no-control-regex -- control bytes are intentionally matched here
 const FORBIDDEN_CHARS = /[<>:"/\\|?*\x00-\x1F]/
-const RESERVED_NAMES = /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\..*)?$/i
+const RESERVED_NAMES = /^(CON|PRN|AUX|NUL|COM[0-9]|LPT[0-9]|CONIN\$|CONOUT\$)(\..*)?$/i
 
 export const SUBFOLDER_NAME_MAX = 64
 
@@ -36,14 +36,15 @@ export function joinSubfolder(base: string, sub: string): string {
 // Sanitize a playlist title for use as a folder name. Strips or replaces
 // characters that are illegal on Windows/macOS/Linux and trims whitespace.
 export function safeFolderName(title: string): string {
-	return (
-		title
-			.replace(/[<>:"/\\|?*\x00-\x1F]/g, '_') // eslint-disable-line no-control-regex
-			.replace(/\s+/g, ' ')
-			.trim()
-			.replace(/[. ]+$/, '') // no trailing dots or spaces (Windows)
-			.slice(0, SUBFOLDER_NAME_MAX) || 'Playlist'
-	)
+	const sanitized = title
+		.replace(/[<>:"/\\|?*\x00-\x1F]/g, '_') // eslint-disable-line no-control-regex
+		.replace(/\s+/g, ' ')
+		.trim()
+		.replace(/[. ]+$/, '') // no trailing dots or spaces (Windows)
+		.slice(0, SUBFOLDER_NAME_MAX)
+		.replace(/[. ]+$/, '') // Slicing can re-expose a trailing dot or space that Windows drops.
+	if (!sanitized || sanitized === '.' || sanitized === '..') return 'Playlist'
+	return escapeReservedName(sanitized)
 }
 
 /**

--- a/tests/unit/subfolder.test.ts
+++ b/tests/unit/subfolder.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {isValidSubfolder, effectiveOutputDir, joinSubfolder, playlistBaseDir, splitDir} from '@shared/subfolder.js'
+import {effectiveOutputDir, escapeReservedName, isValidSubfolder, joinSubfolder, playlistBaseDir, safeFolderName, splitDir} from '@shared/subfolder.js'
 
 describe('isValidSubfolder', () => {
 	it('accepts ordinary names', () => {
@@ -25,8 +25,12 @@ describe('isValidSubfolder', () => {
 
 	it('rejects DOS reserved names regardless of case', () => {
 		expect(isValidSubfolder('CON')).toBe(false)
+		expect(isValidSubfolder('com0')).toBe(false)
 		expect(isValidSubfolder('com1')).toBe(false)
+		expect(isValidSubfolder('lpt0')).toBe(false)
 		expect(isValidSubfolder('lpt9.txt')).toBe(false)
+		expect(isValidSubfolder('CONIN$')).toBe(false)
+		expect(isValidSubfolder('conout$')).toBe(false)
 	})
 
 	it('rejects names ending in . (Windows) — trailing spaces are trimmed first so they pass', () => {
@@ -38,6 +42,56 @@ describe('isValidSubfolder', () => {
 	it('rejects names exceeding 64 chars', () => {
 		expect(isValidSubfolder('a'.repeat(65))).toBe(false)
 		expect(isValidSubfolder('a'.repeat(64))).toBe(true)
+	})
+})
+
+describe('escapeReservedName', () => {
+	it('escapes reserved DOS names with trailing underscore', () => {
+		expect(escapeReservedName('CON')).toBe('CON_')
+		expect(escapeReservedName('aux')).toBe('aux_')
+		expect(escapeReservedName('NUL.mp4')).toBe('NUL.mp4_')
+		expect(escapeReservedName('com0')).toBe('com0_')
+		expect(escapeReservedName('lpt9')).toBe('lpt9_')
+		expect(escapeReservedName('conin$')).toBe('conin$_')
+	})
+
+	it('leaves unreserved names untouched', () => {
+		expect(escapeReservedName('Music')).toBe('Music')
+		expect(escapeReservedName('Console')).toBe('Console')
+		expect(escapeReservedName('Auxiliary')).toBe('Auxiliary')
+	})
+})
+
+describe('safeFolderName', () => {
+	it('sanitizes ordinary playlist titles', () => {
+		expect(safeFolderName('Top Hits 2026')).toBe('Top Hits 2026')
+		expect(safeFolderName('Rock / Pop : Live? *2026*')).toBe('Rock _ Pop _ Live_ _2026_')
+	})
+
+	it('escapes reserved device names into valid folder names', () => {
+		expect(safeFolderName('CON')).toBe('CON_')
+		expect(safeFolderName('aux')).toBe('aux_')
+		expect(safeFolderName('NUL')).toBe('NUL_')
+		expect(safeFolderName('com1')).toBe('com1_')
+	})
+
+	it('strips trailing dots and spaces that Windows disallows', () => {
+		expect(safeFolderName('Chill Mix....')).toBe('Chill Mix')
+		expect(safeFolderName('Study Session   ')).toBe('Study Session')
+		expect(safeFolderName('Soundtrack. . .')).toBe('Soundtrack')
+	})
+
+	it('strips trailing dots re-exposed after length truncation', () => {
+		const longTitleWithTrailingDots = `${'a'.repeat(60)}....`
+		expect(safeFolderName(longTitleWithTrailingDots)).toBe('a'.repeat(60))
+	})
+
+	it('falls back to Playlist when sanitized title is empty or dots', () => {
+		expect(safeFolderName('')).toBe('Playlist')
+		expect(safeFolderName('   ')).toBe('Playlist')
+		expect(safeFolderName('...')).toBe('Playlist')
+		expect(safeFolderName('..')).toBe('Playlist')
+		expect(safeFolderName('.')).toBe('Playlist')
 	})
 })
 
@@ -87,6 +141,10 @@ describe('playlistBaseDir', () => {
 
 	it('falls back to the playlist title when the explicit subfolder is invalid', () => {
 		expect(playlistBaseDir('/home/user', true, 'CON', 'Road Trip')).toBe('/home/user/Road Trip')
+	})
+
+	it('escapes reserved device names in fallback playlist title', () => {
+		expect(playlistBaseDir('/home/user', false, '', 'CON')).toBe('/home/user/CON_')
 	})
 })
 


### PR DESCRIPTION
### Summary
Hardens playlist folder name sanitization in `safeFolderName` to escape Windows reserved device names, strip trailing dots/spaces, and safely handle edge cases.

### Changes
- **Reserved Name Matching:**
  - Expanded `RESERVED_NAMES` regex in `subfolder.ts` to include `COM0`-`COM9`, `LPT0`-`LPT9`, `CONIN$`, and `CONOUT$`.
  - Applied `escapeReservedName` in `safeFolderName` so playlist titles matching reserved device names (e.g. `CON`, `NUL`, `AUX`) are escaped with a trailing underscore (`CON_`) instead of failing directory creation on Windows.
- **Trailing Character Sanitization:**
  - Stripped trailing dots and spaces in `safeFolderName` both before and after length truncation.
  - Added fallback to `'Playlist'` if sanitization reduces the title to empty, `.`, or `..`.
- **Tests:**
  - Added unit test coverage in `tests/unit/subfolder.test.ts` for `safeFolderName`, `escapeReservedName`, `isValidSubfolder`, and `playlistBaseDir`.

### Verification
- `bunx vitest run tests/unit/subfolder.test.ts tests/unit/filename-template.test.ts` (129 passed)
- `bun run typecheck`
- `bun run lint`
- `bun run packages:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-facing changes
- Improve playlist folder-name sanitization for Windows reserved device names.
- Remove trailing dots and spaces before and after truncation.
- Use `Playlist` when sanitization produces an empty name, `.` or `..`.

## Internal changes
- Expand reserved-name detection to include `COM0`–`COM9`, `LPT0`–`LPT9`, `CONIN$`, and `CONOUT$`.
- Escape reserved names instead of returning them unchanged.
- Add unit coverage for sanitization, subfolder validation, and playlist base-directory handling.

## Risk areas
- Changes affect only folder-name generation and validation.
- No Electron security, IPC boundary, dependency, or release/build changes are reported.
- Verify that reserved-name escaping does not create invalid or conflicting paths.

## Tests and checks
- Run the unit test suite.
- Run type checking, linting, and package checks.
- Reported verification: 129 tests passed, with type checking, linting, and package checks successful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->