### PR TITLE
Windows test parity, YouTube URL intent, and reserved-name folder escaping

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,11 @@
+# Check every text file out as LF on every platform. Several tests and tooling
+# checks compare file contents byte-for-byte (SRT fixtures, the i18n POT, the
+# renderer stylesheet), so a CRLF checkout on Windows fails them for reasons that
+# have nothing to do with the code. Pinning the line ending here beats patching
+# each call site with a .replace(/\r\n/g, '\n') that the next fixture reader
+# would have to remember to repeat.
+* text=auto eol=lf
+
 # Generated i18n artifacts.
 i18n/app.pot linguist-generated
 i18n/locales/*.po linguist-generated

--- a/scripts/check-tooling-parity.mjs
+++ b/scripts/check-tooling-parity.mjs
@@ -1,4 +1,4 @@
-import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs'
+import {existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs'
 import {tmpdir} from 'node:os'
 import {dirname, join} from 'node:path'
 import {fileURLToPath} from 'node:url'
@@ -7,7 +7,7 @@ import {spawnSync} from 'node:child_process'
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)))
 const requireFromRepo = createRequire(join(repoRoot, 'package.json'))
-const bunx = process.platform === 'win32' ? 'bunx.cmd' : 'bunx'
+const isWindows = process.platform === 'win32'
 
 const tempDir = mkdtempSync(join(tmpdir(), 'arroxy-tooling-parity-'))
 const oxlintConfigPath = join(repoRoot, '.oxlintrc.json')
@@ -34,14 +34,27 @@ function fail(message, detail) {
 	throw new Error(message)
 }
 
-function run(label, command, args) {
-	const result = spawnSync(command, args, {cwd: repoRoot, encoding: 'utf8', env: {...process.env, FORCE_COLOR: '0', NO_COLOR: '1'}})
+function run(label, command, args, options = {}) {
+	const result = spawnSync(command, args, {cwd: repoRoot, encoding: 'utf8', env: {...process.env, FORCE_COLOR: '0', NO_COLOR: '1'}, ...options})
 	const output = `${result.stdout ?? ''}${result.stderr ?? ''}`
 	return {label, status: result.status, output}
 }
 
+// Prefer the binary already in node_modules/.bin over `bunx`. Two reasons: it
+// skips a resolution round-trip, and on Windows the .bin entry is a .cmd shim
+// that spawnSync cannot launch without a shell, so going through it directly
+// keeps the no-shell spawn (and any path containing spaces) working.
+function localBinPath(name) {
+	const candidates = isWindows ? [`${name}.exe`, `${name}.cmd`] : [name]
+	return candidates.map(candidate => join(repoRoot, 'node_modules', '.bin', candidate)).find(candidate => existsSync(candidate))
+}
+
 function runPackage(label, name, args) {
-	return run(label, bunx, [name, ...args])
+	const local = localBinPath(name)
+	if (local) return run(label, local, args, {shell: isWindows && local.endsWith('.cmd')})
+	// Fallback for a binary this workspace doesn't install directly. `bunx` is a
+	// shell shim on Windows, hence shell: true there.
+	return run(label, 'bunx', [name, ...args], {shell: isWindows})
 }
 
 function assertFailsWith(result, needles) {

--- a/scripts/test-binaries/smoke-all.sh
+++ b/scripts/test-binaries/smoke-all.sh
@@ -53,7 +53,7 @@ unique_ytdlp_payload_count() {
     yt-dlp_macos \
     yt-dlp_linux \
     yt-dlp_linux_aarch64 \
-    | sort -u | count_nonempty_lines
+    | awk '!seen[$0]++' | count_nonempty_lines
 }
 
 expected_payload_count() {

--- a/src/main/services/binary/BinaryProbe.ts
+++ b/src/main/services/binary/BinaryProbe.ts
@@ -38,7 +38,9 @@ export function probeArgs(id: DependencyId): string[] {
 const MACOS_HOMEBREW_BIN_DIRS = ['/opt/homebrew/bin', '/usr/local/bin'] as const
 
 export function fallbackPathCandidates(name: string, platform: NodeJS.Platform = process.platform): string[] {
-	if (platform === 'darwin') return MACOS_HOMEBREW_BIN_DIRS.map(dir => path.join(dir, name))
+	// path.posix, not path: these are literal macOS paths, and the result must not
+	// pick up backslashes just because the test asking for them runs on Windows.
+	if (platform === 'darwin') return MACOS_HOMEBREW_BIN_DIRS.map(dir => path.posix.join(dir, name))
 	if (platform !== 'win32') return []
 
 	const exeName = name.toLowerCase().endsWith('.exe') ? name : `${name}.exe`

--- a/src/shared/subfolder.ts
+++ b/src/shared/subfolder.ts
@@ -8,9 +8,14 @@
 // Reject filename-illegal chars including ASCII control bytes (\x00-\x1F),
 // which are explicitly disallowed on Windows and produce undefined behavior
 // in path APIs on POSIX.
+//
+// The reserved set mirrors the list Microsoft documents, superscript COM/LPT
+// variants included, and nothing beyond it. Device numbering starts at 1 — COM0
+// and LPT0 are ordinary names — and entries invented on suspicion would reject
+// folder names the user is entitled to.
 // eslint-disable-next-line no-control-regex -- control bytes are intentionally matched here
 const FORBIDDEN_CHARS = /[<>:"/\\|?*\x00-\x1F]/
-const RESERVED_NAMES = /^(CON|PRN|AUX|NUL|CONIN\$|CONOUT\$|(COM|LPT)([0-9]|\u00b9|\u00b2|\u00b3))(\..*)?$/i
+const RESERVED_NAMES = /^(CON|PRN|AUX|NUL|(COM|LPT)([1-9]|\u00b9|\u00b2|\u00b3))(\..*)?$/i
 
 export const SUBFOLDER_NAME_MAX = 64
 

--- a/src/shared/subfolder.ts
+++ b/src/shared/subfolder.ts
@@ -10,7 +10,7 @@
 // in path APIs on POSIX.
 // eslint-disable-next-line no-control-regex -- control bytes are intentionally matched here
 const FORBIDDEN_CHARS = /[<>:"/\\|?*\x00-\x1F]/
-const RESERVED_NAMES = /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\..*)?$/i
+const RESERVED_NAMES = /^(CON|PRN|AUX|NUL|CONIN\$|CONOUT\$|(COM|LPT)([0-9]|\u00b9|\u00b2|\u00b3))(\..*)?$/i
 
 export const SUBFOLDER_NAME_MAX = 64
 
@@ -33,28 +33,21 @@ export function joinSubfolder(base: string, sub: string): string {
 	return trimmed + sep + sub
 }
 
-// Sanitize a playlist title for use as a folder name. Strips or replaces
-// characters that are illegal on Windows/macOS/Linux and trims whitespace.
+// Sanitize a playlist title for use as a folder name. Same rules as
+// sanitizeDirSegment(), except a title that sanitizes away entirely still has to
+// produce a folder — 'Playlist' is that fallback.
 export function safeFolderName(title: string): string {
-	return (
-		title
-			.replace(/[<>:"/\\|?*\x00-\x1F]/g, '_') // eslint-disable-line no-control-regex
-			.replace(/\s+/g, ' ')
-			.trim()
-			.replace(/[. ]+$/, '') // no trailing dots or spaces (Windows)
-			.slice(0, SUBFOLDER_NAME_MAX) || 'Playlist'
-	)
+	return sanitizeDirSegment(title) ?? 'Playlist'
 }
 
 /**
  * Sanitize one rendered path component from a filename template into something
  * safe to create on every supported OS, or null when nothing usable remains.
  *
- * Distinct from safeFolderName(): that one substitutes 'Playlist' for an empty
- * result, which is right for a playlist folder but wrong here — an empty
- * segment must collapse so `{playlist_title}/{title}` on a single video writes
- * no folder at all rather than one named 'Playlist'. Returning null is what
- * lets the caller drop the segment.
+ * Returning null rather than a fallback name is what lets the caller drop the
+ * segment: an empty `{playlist_title}` on a single video must write no folder at
+ * all rather than one named 'Playlist'. safeFolderName() wraps this with that
+ * fallback for the one case that does need a folder no matter what.
  */
 export function sanitizeDirSegment(raw: string): string | null {
 	const cleaned = raw
@@ -66,7 +59,11 @@ export function sanitizeDirSegment(raw: string): string | null {
 		// Slicing can re-expose a trailing dot or space that Windows drops.
 		.replace(/[. ]+$/, '')
 	if (cleaned === '' || cleaned === '.' || cleaned === '..') return null
-	return escapeReservedName(cleaned)
+	// Escaping appends '_', so a reserved name has to give the underscore its own
+	// room in the budget. Otherwise `NUL.<60 chars>` comes back one character over
+	// SUBFOLDER_NAME_MAX and isValidSubfolder rejects a name we generated ourselves.
+	const budgeted = RESERVED_NAMES.test(cleaned) ? cleaned.slice(0, SUBFOLDER_NAME_MAX - 1).replace(/[. ]+$/, '') : cleaned
+	return escapeReservedName(budgeted)
 }
 
 /**
@@ -76,9 +73,15 @@ export function sanitizeDirSegment(raw: string): string | null {
  * applies with any extension — `NUL.mp4` is still the null device. The user
  * asked for this name, so `CON_` honors that without breaking Windows. Shared
  * by directory segments and filenames so both escape identically.
+ *
+ * The underscore has to land on the stem, not the end of the string: since the
+ * reservation ignores the extension, `NUL.mp4_` is still the null device, and it
+ * has mangled the extension for nothing. `NUL_.mp4` is an ordinary file.
  */
 export function escapeReservedName(name: string): string {
-	return RESERVED_NAMES.test(name) ? `${name}_` : name
+	if (!RESERVED_NAMES.test(name)) return name
+	const dot = name.indexOf('.')
+	return dot === -1 ? `${name}_` : `${name.slice(0, dot)}_${name.slice(dot)}`
 }
 
 export function effectiveOutputDir(base: string, enabled: boolean, subfolder: string): string {

--- a/src/shared/urlIntent.ts
+++ b/src/shared/urlIntent.ts
@@ -14,15 +14,31 @@ function parseUrl(url: string): URL | null {
 
 function isYouTubeHost(hostname: string): boolean {
 	const host = hostname.toLowerCase()
-	return host === 'youtube.com' || host.endsWith('.youtube.com') || host === 'youtu.be'
+	return host === 'youtube.com' || host.endsWith('.youtube.com') || host === 'youtu.be' || host === 'youtube-nocookie.com' || host.endsWith('.youtube-nocookie.com')
 }
 
 function youtubePathSegments(parsed: URL): string[] {
 	return parsed.pathname.split('/').filter(Boolean)
 }
 
+// Two-segment paths that address exactly one video. `/embed/` is the current
+// embed player; `/v/` and `/e/` are its legacy Flash-era equivalents, both of
+// which yt-dlp still resolves.
+const YOUTUBE_VIDEO_PATH_PREFIXES = new Set(['shorts', 'live', 'clip', 'embed', 'v', 'e'])
+
+// `/embed/videoseries?list=…` wears the same shape as a video embed but plays a
+// playlist — there is no video behind it, so it must not read as a single.
+const EMBED_PLAYLIST_SEGMENT = 'videoseries'
+
+function isYouTubeVideoSegmentPath(segments: string[]): boolean {
+	const [prefix, id] = segments
+	if (segments.length !== 2 || !prefix || !id) return false
+	if (!YOUTUBE_VIDEO_PATH_PREFIXES.has(prefix)) return false
+	return !(prefix === 'embed' && id === EMBED_PLAYLIST_SEGMENT)
+}
+
 function isYouTubeVideoPath(host: string, segments: string[], searchParams: URLSearchParams): boolean {
-	return (host === 'youtu.be' && segments.length === 1 && !!segments[0]) || (segments[0] === 'watch' && !!searchParams.get('v')) || (segments[0] === 'shorts' && segments.length === 2 && !!segments[1])
+	return (host === 'youtu.be' && segments.length === 1 && !!segments[0]) || (segments[0] === 'watch' && !!searchParams.get('v')) || isYouTubeVideoSegmentPath(segments)
 }
 
 function isYouTubeChannelPath(segments: string[]): boolean {
@@ -72,6 +88,12 @@ export function urlIntentBulkLabel(intent: UrlIntent): BulkUrlKind {
 	return 'unknown'
 }
 
+// Every video path shape above except `/clip/`, whose slug identifies the clip
+// rather than the video — the real id only arrives with the probe metadata.
+// Returning null keeps a clip slug out of `{id}` filenames and `[videoId]` file
+// matching instead of seeding them with something that was never a video id.
+const YOUTUBE_ID_BEARING_PREFIXES = new Set(['shorts', 'live', 'embed', 'v', 'e'])
+
 export function extractUrlIntentYouTubeVideoId(intent: UrlIntent): string | null {
 	if (intent.kind !== 'obvious-single' || intent.site !== 'youtube') return null
 	const parsed = parseUrl(intent.url)
@@ -81,7 +103,7 @@ export function extractUrlIntentYouTubeVideoId(intent: UrlIntent): string | null
 	const segments = youtubePathSegments(parsed)
 	if (host === 'youtu.be') return segments[0] ?? null
 	if (segments[0] === 'watch') return parsed.searchParams.get('v')
-	if (segments[0] === 'shorts') return segments[1] ?? null
+	if (YOUTUBE_ID_BEARING_PREFIXES.has(segments[0] ?? '')) return segments[1] ?? null
 	return null
 }
 

--- a/tests/e2e/fixtureHarness.ts
+++ b/tests/e2e/fixtureHarness.ts
@@ -489,12 +489,33 @@ async function downloadYtDlp(destination: string): Promise<void> {
  * is atomic within a directory, so a concurrent reader sees either no file or
  * the whole file. Last writer wins, and every candidate is byte-identical.
  */
+// Windows refuses to rename over a file another process has open, which is
+// exactly what a parallel worker that just won the same race looks like. POSIX
+// renames over it silently, so this only ever fires on Windows.
+const WINDOWS_RENAME_COLLISION_CODES = new Set(['EPERM', 'EEXIST', 'EACCES', 'EBUSY'])
+
+async function installedByAnotherWorker(destination: string): Promise<boolean> {
+	if (process.platform !== 'win32') return false
+	// Existence alone is not enough: the whole point of staging is that a
+	// half-written file must never be mistaken for a finished one. A rename that
+	// lost the race leaves a complete, non-empty file behind, so require that
+	// before treating the collision as success.
+	const stat = await fsPromises.stat(destination).catch(() => null)
+	return stat?.isFile() === true && stat.size > 0
+}
+
 export async function installAtomically(destination: string, produce: (staging: string) => Promise<void>): Promise<void> {
 	await fsPromises.mkdir(path.dirname(destination), {recursive: true})
 	const staging = `${destination}.${process.pid}.${randomUUID()}.part`
 	try {
 		await produce(staging)
-		await fsPromises.rename(staging, destination)
+		try {
+			await fsPromises.rename(staging, destination)
+		} catch (renameError) {
+			const code = (renameError as {code?: string}).code ?? ''
+			if (!WINDOWS_RENAME_COLLISION_CODES.has(code) || !(await installedByAnotherWorker(destination))) throw renameError
+			await fsPromises.rm(staging, {force: true})
+		}
 	} catch (error) {
 		// Debris here would be mistaken for a cached binary by a later run.
 		await fsPromises.rm(staging, {force: true})

--- a/tests/scripts/dev-env.test.ts
+++ b/tests/scripts/dev-env.test.ts
@@ -125,7 +125,7 @@ describe('dev-env pure helpers', () => {
 
 	it('defaults Electron user data inside the repo root', () => {
 		const env = resolveDevEnv({repoRoot: '/tmp/arroxy', env: {}})
-		expect(env.electronUserData).toBe('/tmp/arroxy/.electron-user-data/dev')
+		expect(env.electronUserData).toBe(path.join('/tmp/arroxy', '.electron-user-data', 'dev'))
 		expect(env.electronUserDataSource).toBe('computed')
 	})
 
@@ -138,15 +138,15 @@ describe('dev-env pure helpers', () => {
 	it('treats blank path overrides as absent', () => {
 		const env = resolveDevEnv({repoRoot: '/tmp/arroxy', env: {ELECTRON_USER_DATA: '   ', ARROXY_DEV_TMP: ''}})
 
-		expect(env.electronUserData).toBe('/tmp/arroxy/.electron-user-data/dev')
+		expect(env.electronUserData).toBe(path.join('/tmp/arroxy', '.electron-user-data', 'dev'))
 		expect(env.electronUserDataSource).toBe('computed')
-		expect(env.tmpDir).toBe('/tmp/arroxy/.tmp/dev')
+		expect(env.tmpDir).toBe(path.join('/tmp/arroxy', '.tmp', 'dev'))
 		expect(env.tmpDirSource).toBe('computed')
 	})
 
 	it('defaults temp dir inside the repo root', () => {
 		const env = resolveDevEnv({repoRoot: '/tmp/arroxy', env: {}})
-		expect(env.tmpDir).toBe('/tmp/arroxy/.tmp/dev')
+		expect(env.tmpDir).toBe(path.join('/tmp/arroxy', '.tmp', 'dev'))
 		expect(env.tmpDirSource).toBe('computed')
 	})
 

--- a/tests/unit/binary-downloader.test.ts
+++ b/tests/unit/binary-downloader.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises'
 import http from 'node:http'
+import net from 'node:net'
 import os from 'node:os'
 import path from 'node:path'
 import {createHash} from 'node:crypto'
@@ -8,16 +9,30 @@ import {describe, expect, it} from 'vitest'
 import {DownloadIntegrityError, DownloadSizeMismatchError, DownloadStalledError, classifyDownloadError, copyCachedArtifactToFile, downloadArtifactToCache, downloadFile, sha256HexToSri} from '@main/services/binary/BinaryDownloader.js'
 
 async function withServer(handler: http.RequestListener, run: (url: string) => Promise<void>): Promise<void> {
+	// Sockets are tracked and destroyed by hand because server.close() only stops
+	// new connections: a still-open keep-alive socket from an aborted download
+	// leaves close() hanging until the OS times it out, which on Windows is long
+	// enough to blow the test timeout.
+	const sockets = new Set<net.Socket>()
 	const server = http.createServer(handler)
+	server.on('connection', socket => {
+		sockets.add(socket)
+		socket.on('close', () => sockets.delete(socket))
+	})
 	await new Promise<void>((resolve, reject) => {
 		server.once('error', reject)
-		server.listen(0, () => resolve())
+		// Bind the loopback address explicitly: on Windows the unspecified bind can
+		// resolve to an interface the client's 127.0.0.1 request never reaches.
+		server.listen(0, '127.0.0.1', () => resolve())
 	})
 	try {
 		const address = server.address()
 		if (!address || typeof address === 'string') throw new Error('test server did not bind to a TCP port')
 		await run(`http://127.0.0.1:${address.port}`)
 	} finally {
+		server.closeAllConnections()
+		for (const socket of sockets) socket.destroy()
+		sockets.clear()
 		await new Promise<void>((resolve, reject) => {
 			server.close(err => (err ? reject(err) : resolve()))
 		})
@@ -50,10 +65,11 @@ describe('BinaryDownloader', () => {
 					const interval = setInterval(() => {
 						res.write(Buffer.alloc(1))
 					}, 10)
+					interval.unref()
 					res.on('close', () => clearInterval(interval))
 				},
 				async url => {
-					await expect(downloadFile(url, destination, undefined, {maxDurationMs: 50, stallTimeoutMs: 1000})).rejects.toThrow(DownloadStalledError)
+					await expect(downloadFile(url, destination, undefined, {maxDurationMs: 50, stallTimeoutMs: 1000, partialRetryLimit: 0})).rejects.toThrow(DownloadStalledError)
 				}
 			)
 
@@ -96,6 +112,51 @@ describe('BinaryDownloader', () => {
 			await fs.rm(dir, {recursive: true, force: true})
 		}
 	})
+
+	it('resumes from the partial file after the max-duration budget trips', async () => {
+		// maxDurationMs is a per-attempt budget, not a whole-download one, so a large
+		// binary on a slow link is expected to finish across several resumed windows.
+		// Dropping the retry here would turn a slow connection into a hard failure.
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'binary-downloader-'))
+		const destination = path.join(dir, 'resumed.bin')
+		const body = Buffer.from('b'.repeat(4096))
+		const ranges: Array<string | undefined> = []
+
+		try {
+			await withServer(
+				(req, res) => {
+					ranges.push(req.headers.range)
+
+					if (!req.headers.range) {
+						// Hand over a prefix, then keep the connection open and idle until the
+						// duration timer fires. Bytes are still flowing slowly enough that the
+						// stall timer never gets there first.
+						res.writeHead(200, {'content-length': String(body.length)})
+						res.write(body.subarray(0, 1024))
+						const interval = setInterval(() => res.write(body.subarray(0, 1)), 10)
+						interval.unref()
+						res.on('close', () => clearInterval(interval))
+						return
+					}
+
+					const start = Number(/bytes=(\d+)-/.exec(req.headers.range)?.[1] ?? 0)
+					res.writeHead(206, {'content-length': String(body.length - start), 'content-range': `bytes ${start}-${body.length - 1}/${body.length}`})
+					res.end(body.subarray(start))
+				},
+				async url => {
+					await downloadFile(url, destination, undefined, {maxDurationMs: 120, stallTimeoutMs: 5_000, partialRetryLimit: 3})
+				}
+			)
+
+			const written = await fs.readFile(destination)
+			expect(written).toHaveLength(body.length)
+			expect(ranges.length).toBeGreaterThan(1)
+			expect(ranges[0]).toBeUndefined()
+			expect(ranges[1]).toMatch(/^bytes=\d+-$/)
+		} finally {
+			await fs.rm(dir, {recursive: true, force: true})
+		}
+	}, 15_000)
 
 	it('writes successful artifact downloads to cacache with manifest integrity', async () => {
 		const body = Buffer.from('verified artifact')
@@ -304,6 +365,7 @@ describe('BinaryDownloader', () => {
 					const interval = setInterval(() => {
 						res.write(body.subarray(0, 64))
 					}, 10)
+					interval.unref()
 					res.on('close', () => clearInterval(interval))
 					setTimeout(() => controller.abort(new Error('test abort')), 25)
 				},

--- a/tests/unit/binary-downloader.test.ts
+++ b/tests/unit/binary-downloader.test.ts
@@ -119,7 +119,10 @@ describe('BinaryDownloader', () => {
 		// Dropping the retry here would turn a slow connection into a hard failure.
 		const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'binary-downloader-'))
 		const destination = path.join(dir, 'resumed.bin')
-		const body = Buffer.from('b'.repeat(4096))
+		// Every byte distinct-ish rather than a run of one character: a resume that
+		// double-counts or skips bytes still lands on the right length, so only a
+		// patterned payload can tell a correct resume from a corrupt one.
+		const body = Buffer.from(Array.from({length: 4096}, (_, index) => index % 251))
 		const ranges: Array<string | undefined> = []
 
 		try {
@@ -128,12 +131,16 @@ describe('BinaryDownloader', () => {
 					ranges.push(req.headers.range)
 
 					if (!req.headers.range) {
-						// Hand over a prefix, then keep the connection open and idle until the
-						// duration timer fires. Bytes are still flowing slowly enough that the
-						// stall timer never gets there first.
+						// Hand over a prefix, then trickle the real next bytes until the duration
+						// timer fires. Bytes keep arriving, so the stall timer never gets there
+						// first and the abort is unambiguously the duration budget.
 						res.writeHead(200, {'content-length': String(body.length)})
 						res.write(body.subarray(0, 1024))
-						const interval = setInterval(() => res.write(body.subarray(0, 1)), 10)
+						let nextByte = 1024
+						const interval = setInterval(() => {
+							res.write(body.subarray(nextByte, nextByte + 1))
+							nextByte += 1
+						}, 10)
 						interval.unref()
 						res.on('close', () => clearInterval(interval))
 						return
@@ -149,7 +156,7 @@ describe('BinaryDownloader', () => {
 			)
 
 			const written = await fs.readFile(destination)
-			expect(written).toHaveLength(body.length)
+			expect(written).toEqual(body)
 			expect(ranges.length).toBeGreaterThan(1)
 			expect(ranges[0]).toBeUndefined()
 			expect(ranges[1]).toMatch(/^bytes=\d+-$/)

--- a/tests/unit/binary-manager-analytics.test.ts
+++ b/tests/unit/binary-manager-analytics.test.ts
@@ -14,13 +14,13 @@ afterEach(() => {
 	vi.clearAllMocks()
 })
 
-async function makeYtDlpVersionStub(): Promise<string> {
-	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'arroxy-ytdlp-probe-'))
-	const stubPath = path.join(tempDir, process.platform === 'win32' ? 'yt-dlp.cmd' : 'yt-dlp')
-	const body = process.platform === 'win32' ? '@echo off\r\necho 2026.06.12\r\n' : '#!/bin/sh\necho "2026.06.12"\n'
-	await fs.writeFile(stubPath, body)
-	if (process.platform !== 'win32') await fs.chmod(stubPath, 0o755)
-	return stubPath
+// A binary that exits 0 for `--version`. The probe under test only cares that
+// the spawn succeeds — the version string never reaches the assertions — and the
+// obvious alternative, a shell-script stub, has to be a .cmd on Windows, which
+// execFile() refuses to launch without a shell. process.execPath is a real
+// executable on every platform, so it sidesteps that without a platform branch.
+function versionAnsweringExecutable(): string {
+	return process.execPath
 }
 
 function ytDlpEntry(): RuntimeBinaryManifestEntry {
@@ -82,7 +82,7 @@ describe('BinaryManager analytics', () => {
 		const attempts: DependencyAttempt[] = []
 		const source: DependencySource = {kind: 'managed', channel: 'nightly', provider: 'github', url: 'https://example.com/yt-dlp'}
 		const now = vi.spyOn(Date, 'now').mockReturnValueOnce(1_000).mockReturnValueOnce(32_500)
-		const ytDlpStub = await makeYtDlpVersionStub()
+		const ytDlpStub = versionAnsweringExecutable()
 
 		try {
 			const diag = await (mgr as unknown as {probeAndAccept: (id: 'yt-dlp', source: DependencySource, candidatePath: string, attempts: DependencyAttempt[]) => Promise<unknown>}).probeAndAccept('yt-dlp', source, ytDlpStub, attempts)

--- a/tests/unit/binary-manager-retry.test.ts
+++ b/tests/unit/binary-manager-retry.test.ts
@@ -151,7 +151,10 @@ describe('BinaryManager manifest resolution', () => {
 	})
 
 	it('falls back to ffmpeg and ffprobe on PATH when bundled binaries are unusable', async () => {
-		const temp = await tempDir('bm-path-')
+		// realpath because Windows hands back an 8.3 short path (RUNNER~1) from the
+		// temp dir, while the resolved binary path comes back long-form — the two
+		// name the same directory but never compare equal as strings.
+		const temp = await fs.realpath(await tempDir('bm-path-'))
 		const exeExt = process.platform === 'win32' ? '.exe' : ''
 		const ffmpegPath = path.join(temp, `ffmpeg${exeExt}`)
 		const ffprobePath = path.join(temp, `ffprobe${exeExt}`)

--- a/tests/unit/bulk-urls.test.ts
+++ b/tests/unit/bulk-urls.test.ts
@@ -60,9 +60,12 @@ describe('parseBulkUrls', () => {
 })
 
 describe('isClearlyIndividualYouTubeUrl', () => {
-	it('accepts watch, short, and youtu.be URLs without playlist params', () => {
+	it('accepts watch, short, live, clip, embed, and youtu.be URLs without playlist params', () => {
 		expect(isClearlyIndividualYouTubeUrl('https://www.youtube.com/watch?v=abc123')).toBe(true)
 		expect(isClearlyIndividualYouTubeUrl('https://www.youtube.com/shorts/abc123')).toBe(true)
+		expect(isClearlyIndividualYouTubeUrl('https://www.youtube.com/live/abc123')).toBe(true)
+		expect(isClearlyIndividualYouTubeUrl('https://www.youtube.com/clip/clip123')).toBe(true)
+		expect(isClearlyIndividualYouTubeUrl('https://www.youtube-nocookie.com/embed/abc123')).toBe(true)
 		expect(isClearlyIndividualYouTubeUrl('https://youtu.be/abc123')).toBe(true)
 	})
 
@@ -76,6 +79,8 @@ describe('extractYouTubeVideoId', () => {
 	it('derives ids for supported individual YouTube URL shapes', () => {
 		expect(extractYouTubeVideoId('https://www.youtube.com/watch?v=abc123')).toBe('abc123')
 		expect(extractYouTubeVideoId('https://www.youtube.com/shorts/short123')).toBe('short123')
+		expect(extractYouTubeVideoId('https://www.youtube.com/live/live123')).toBe('live123')
+		expect(extractYouTubeVideoId('https://www.youtube.com/clip/clip123')).toBeNull()
 		expect(extractYouTubeVideoId('https://youtu.be/bee123')).toBe('bee123')
 	})
 
@@ -89,7 +94,10 @@ describe('extractYouTubeVideoId', () => {
 describe('classifyBulkUrlKind', () => {
 	it.each([
 		['https://www.youtube.com/watch?v=abc123', 'single'],
+		['https://www.youtube.com/live/abc123', 'single'],
+		['https://www.youtube.com/clip/clip123', 'single'],
 		['https://www.youtube.com/watch?v=abc123&list=PLtest', 'mixed'],
+		['https://www.youtube.com/embed/videoseries?list=PLtest', 'playlist'],
 		['https://www.youtube.com/playlist?list=PLtest', 'playlist'],
 		['https://www.youtube.com/@arroxy', 'channel'],
 		['https://www.youtube.com/results?search_query=arroxy', 'search'],

--- a/tests/unit/filename-template.test.ts
+++ b/tests/unit/filename-template.test.ts
@@ -340,6 +340,13 @@ describe('bindFilenameTemplate', () => {
 		}
 	})
 
+	it('escapes the stem when the reserved name carries an extension', () => {
+		// Appending to the end would leave `NUL.mp4_`, which is still the null device
+		// — the reservation ignores the extension — with the extension mangled too.
+		expect(bound('{title}', {...PLAYLIST_META, title: 'NUL.mp4'})).toBe('NUL_.mp4')
+		expect(bound('{title}', {...PLAYLIST_META, title: 'com1.tar.gz'})).toBe('com1_.tar.gz')
+	})
+
 	it('leaves a name that merely starts with a reserved word alone', () => {
 		expect(bound('{title}', {...PLAYLIST_META, title: 'CONcert'})).toBe('CONcert')
 		expect(bound('{title} [{id}]', {...PLAYLIST_META, title: 'NUL'})).toBe('NUL [YE7VzlLtp-4]')

--- a/tests/unit/subfolder.test.ts
+++ b/tests/unit/subfolder.test.ts
@@ -29,19 +29,18 @@ describe('isValidSubfolder', () => {
 		expect(isValidSubfolder('lpt9.txt')).toBe(false)
 	})
 
-	it('rejects the rest of the reserved device set Windows documents', () => {
-		expect(isValidSubfolder('com0')).toBe(false)
-		expect(isValidSubfolder('lpt0')).toBe(false)
-		expect(isValidSubfolder('CONIN$')).toBe(false)
-		expect(isValidSubfolder('conout$')).toBe(false)
-		// Superscript COM/LPT variants are reserved too, and easy to paste in by accident.
+	it('rejects the superscript COM/LPT variants Windows also reserves', () => {
+		// Windows reads the ISO 8859-1 superscript digits as digits, so COM\u00b9 is COM1.
 		expect(isValidSubfolder('com\u00b9')).toBe(false)
 		expect(isValidSubfolder('LPT\u00b3')).toBe(false)
 	})
 
-	it('accepts names that merely start with a reserved word', () => {
+	it('accepts names outside the documented device list', () => {
 		expect(isValidSubfolder('Console')).toBe(true)
 		expect(isValidSubfolder('Auxiliary')).toBe(true)
+		// Device numbering starts at 1, so these are ordinary names.
+		expect(isValidSubfolder('com0')).toBe(true)
+		expect(isValidSubfolder('lpt0')).toBe(true)
 		expect(isValidSubfolder('com10')).toBe(true)
 	})
 
@@ -61,9 +60,8 @@ describe('escapeReservedName', () => {
 	it('escapes reserved device names with a trailing underscore', () => {
 		expect(escapeReservedName('CON')).toBe('CON_')
 		expect(escapeReservedName('aux')).toBe('aux_')
-		expect(escapeReservedName('com0')).toBe('com0_')
+		expect(escapeReservedName('com1')).toBe('com1_')
 		expect(escapeReservedName('lpt9')).toBe('lpt9_')
-		expect(escapeReservedName('conin$')).toBe('conin$_')
 	})
 
 	it('escapes the stem of a reserved name carrying an extension', () => {
@@ -77,6 +75,7 @@ describe('escapeReservedName', () => {
 	it('leaves unreserved names untouched', () => {
 		expect(escapeReservedName('Music')).toBe('Music')
 		expect(escapeReservedName('Console')).toBe('Console')
+		expect(escapeReservedName('com0')).toBe('com0')
 	})
 })
 

--- a/tests/unit/subfolder.test.ts
+++ b/tests/unit/subfolder.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {isValidSubfolder, effectiveOutputDir, joinSubfolder, playlistBaseDir, splitDir} from '@shared/subfolder.js'
+import {SUBFOLDER_NAME_MAX, effectiveOutputDir, escapeReservedName, isValidSubfolder, joinSubfolder, playlistBaseDir, safeFolderName, splitDir} from '@shared/subfolder.js'
 
 describe('isValidSubfolder', () => {
 	it('accepts ordinary names', () => {
@@ -29,6 +29,22 @@ describe('isValidSubfolder', () => {
 		expect(isValidSubfolder('lpt9.txt')).toBe(false)
 	})
 
+	it('rejects the rest of the reserved device set Windows documents', () => {
+		expect(isValidSubfolder('com0')).toBe(false)
+		expect(isValidSubfolder('lpt0')).toBe(false)
+		expect(isValidSubfolder('CONIN$')).toBe(false)
+		expect(isValidSubfolder('conout$')).toBe(false)
+		// Superscript COM/LPT variants are reserved too, and easy to paste in by accident.
+		expect(isValidSubfolder('com\u00b9')).toBe(false)
+		expect(isValidSubfolder('LPT\u00b3')).toBe(false)
+	})
+
+	it('accepts names that merely start with a reserved word', () => {
+		expect(isValidSubfolder('Console')).toBe(true)
+		expect(isValidSubfolder('Auxiliary')).toBe(true)
+		expect(isValidSubfolder('com10')).toBe(true)
+	})
+
 	it('rejects names ending in . (Windows) — trailing spaces are trimmed first so they pass', () => {
 		expect(isValidSubfolder('trail.')).toBe(false)
 		// Trailing whitespace is trimmed before validation — accepted UX.
@@ -38,6 +54,68 @@ describe('isValidSubfolder', () => {
 	it('rejects names exceeding 64 chars', () => {
 		expect(isValidSubfolder('a'.repeat(65))).toBe(false)
 		expect(isValidSubfolder('a'.repeat(64))).toBe(true)
+	})
+})
+
+describe('escapeReservedName', () => {
+	it('escapes reserved device names with a trailing underscore', () => {
+		expect(escapeReservedName('CON')).toBe('CON_')
+		expect(escapeReservedName('aux')).toBe('aux_')
+		expect(escapeReservedName('com0')).toBe('com0_')
+		expect(escapeReservedName('lpt9')).toBe('lpt9_')
+		expect(escapeReservedName('conin$')).toBe('conin$_')
+	})
+
+	it('escapes the stem of a reserved name carrying an extension', () => {
+		// `NUL.mp4` is the null device, and so is `NUL.mp4_` — the reservation ignores
+		// the extension, so the underscore has to go on the stem to escape anything.
+		expect(escapeReservedName('NUL.mp4')).toBe('NUL_.mp4')
+		expect(isValidSubfolder(escapeReservedName('NUL.mp4'))).toBe(true)
+		expect(escapeReservedName('lpt9.txt')).toBe('lpt9_.txt')
+	})
+
+	it('leaves unreserved names untouched', () => {
+		expect(escapeReservedName('Music')).toBe('Music')
+		expect(escapeReservedName('Console')).toBe('Console')
+	})
+})
+
+describe('safeFolderName', () => {
+	it('keeps ordinary playlist titles and substitutes illegal characters', () => {
+		expect(safeFolderName('Top Hits 2026')).toBe('Top Hits 2026')
+		expect(safeFolderName('Rock / Pop : Live? *2026*')).toBe('Rock _ Pop _ Live_ _2026_')
+	})
+
+	it('escapes reserved device names instead of handing Windows an uncreatable folder', () => {
+		expect(safeFolderName('CON')).toBe('CON_')
+		expect(safeFolderName('aux')).toBe('aux_')
+		expect(safeFolderName('com1')).toBe('com1_')
+	})
+
+	it('strips trailing dots and spaces, including any re-exposed by truncation', () => {
+		expect(safeFolderName('Chill Mix....')).toBe('Chill Mix')
+		expect(safeFolderName('Study Session   ')).toBe('Study Session')
+		expect(safeFolderName('Soundtrack. . .')).toBe('Soundtrack')
+		expect(safeFolderName(`${'a'.repeat(60)}....`)).toBe('a'.repeat(60))
+	})
+
+	it('falls back to Playlist when nothing usable survives', () => {
+		expect(safeFolderName('')).toBe('Playlist')
+		expect(safeFolderName('   ')).toBe('Playlist')
+		expect(safeFolderName('...')).toBe('Playlist')
+		expect(safeFolderName('..')).toBe('Playlist')
+		expect(safeFolderName('.')).toBe('Playlist')
+	})
+
+	it('never emits a name its own validator would reject', () => {
+		// Escaping appends a character, so a reserved name at the length limit has to
+		// lose one before the underscore goes on.
+		const reservedAtLimit = `NUL.${'a'.repeat(SUBFOLDER_NAME_MAX)}`
+		const name = safeFolderName(reservedAtLimit)
+
+		expect(name).toHaveLength(SUBFOLDER_NAME_MAX)
+		expect(name.startsWith('NUL_.')).toBe(true)
+		expect(isValidSubfolder(name)).toBe(true)
 	})
 })
 
@@ -87,6 +165,10 @@ describe('playlistBaseDir', () => {
 
 	it('falls back to the playlist title when the explicit subfolder is invalid', () => {
 		expect(playlistBaseDir('/home/user', true, 'CON', 'Road Trip')).toBe('/home/user/Road Trip')
+	})
+
+	it('escapes a reserved device name used as the fallback playlist title', () => {
+		expect(playlistBaseDir('/home/user', false, '', 'CON')).toBe('/home/user/CON_')
 	})
 })
 

--- a/tests/unit/url-intent.test.ts
+++ b/tests/unit/url-intent.test.ts
@@ -51,6 +51,7 @@ describe('classifyUrlIntent', () => {
 		expect(id('https://www.youtube.com/embed/ScsahA7OzVo')).toBe('ScsahA7OzVo')
 		expect(id('https://www.youtube-nocookie.com/embed/ScsahA7OzVo')).toBe('ScsahA7OzVo')
 		expect(id('https://www.youtube.com/v/ScsahA7OzVo')).toBe('ScsahA7OzVo')
+		expect(id('https://www.youtube.com/e/ScsahA7OzVo')).toBe('ScsahA7OzVo')
 		expect(id('https://www.youtube.com/playlist?list=PLtest')).toBeNull()
 		expect(id('https://www.youtube.com/@arroxy')).toBeNull()
 	})

--- a/tests/unit/url-intent.test.ts
+++ b/tests/unit/url-intent.test.ts
@@ -1,11 +1,19 @@
 import {describe, expect, it} from 'vitest'
-import {classifyUrlIntent, isMixedUrlIntent, isObviousSingleUrlIntent, urlIntentBulkLabel, urlIntentHomeLabel} from '@shared/urlIntent.js'
+import {classifyUrlIntent, deriveUrlIntentLabel, extractUrlIntentYouTubeVideoId, isMixedUrlIntent, isObviousSingleUrlIntent, urlIntentBulkLabel, urlIntentHomeLabel} from '@shared/urlIntent.js'
 
 describe('classifyUrlIntent', () => {
 	it.each([
 		['https://www.youtube.com/watch?v=ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}],
 		['https://youtu.be/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}],
-		['https://www.youtube.com/shorts/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}]
+		['https://www.youtube.com/shorts/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}],
+		['https://www.youtube.com/live/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}],
+		['https://m.youtube.com/live/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}],
+		['https://www.youtube.com/clip/Ugkx_1234567890abcdef', {kind: 'obvious-single', site: 'youtube'}],
+		['https://www.youtube.com/embed/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}],
+		['https://www.youtube-nocookie.com/embed/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}],
+		['https://youtube-nocookie.com/embed/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}],
+		['https://www.youtube.com/v/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}],
+		['https://www.youtube.com/e/ScsahA7OzVo', {kind: 'obvious-single', site: 'youtube'}]
 	] as const)('%s -> obvious single', (url, expected) => {
 		expect(classifyUrlIntent(url)).toMatchObject({...expected, url})
 	})
@@ -19,25 +27,65 @@ describe('classifyUrlIntent', () => {
 		expect(classifyUrlIntent(url)).toMatchObject({kind: 'obvious-collection', collection, url})
 	})
 
-	it.each(['https://www.youtube.com/watch?v=abc123&list=PLtest', 'https://www.youtube.com/watch?v=abc123&list=RDabc', 'https://m.youtube.com/watch?list=PLtest&v=abc123'])('%s -> mixed', url => {
+	it.each(['https://www.youtube.com/watch?v=abc123&list=PLtest', 'https://www.youtube.com/watch?v=abc123&list=RDabc', 'https://m.youtube.com/watch?list=PLtest&v=abc123', 'https://www.youtube.com/live/ScsahA7OzVo?list=PLtest', 'https://www.youtube.com/clip/Ugkx_123?list=PLtest'])('%s -> mixed', url => {
 		expect(classifyUrlIntent(url)).toEqual({kind: 'mixed', reason: 'youtube-video-with-list', url})
 	})
 
-	it.each(['https://vimeo.com/123', 'https://example.com/watch?v=abc&list=PLxyz', 'not a url', ''])('%s -> unknown', url => {
+	it.each(['https://vimeo.com/123', 'https://example.com/watch?v=abc&list=PLxyz', 'https://www.youtube.com/live', 'https://www.youtube.com/clip', 'https://www.youtube.com/embed/videoseries', 'not a url', ''])('%s -> unknown', url => {
 		expect(classifyUrlIntent(url)).toEqual({kind: 'unknown', url})
+	})
+
+	it('reads the playlist embed player as a playlist, not as a video called videoseries', () => {
+		// `/embed/videoseries?list=…` has the shape of a video embed but no video
+		// behind it — treating it as a single would queue a download of nothing.
+		expect(classifyUrlIntent('https://www.youtube.com/embed/videoseries?list=PLtest')).toEqual({kind: 'obvious-collection', url: 'https://www.youtube.com/embed/videoseries?list=PLtest', collection: 'playlist'})
+	})
+
+	it('extracts video ids across every id-bearing URL shape', () => {
+		const id = (url: string): string | null => extractUrlIntentYouTubeVideoId(classifyUrlIntent(url))
+
+		expect(id('https://www.youtube.com/watch?v=ScsahA7OzVo')).toBe('ScsahA7OzVo')
+		expect(id('https://youtu.be/ScsahA7OzVo')).toBe('ScsahA7OzVo')
+		expect(id('https://www.youtube.com/shorts/ScsahA7OzVo')).toBe('ScsahA7OzVo')
+		expect(id('https://www.youtube.com/live/ScsahA7OzVo')).toBe('ScsahA7OzVo')
+		expect(id('https://www.youtube.com/embed/ScsahA7OzVo')).toBe('ScsahA7OzVo')
+		expect(id('https://www.youtube-nocookie.com/embed/ScsahA7OzVo')).toBe('ScsahA7OzVo')
+		expect(id('https://www.youtube.com/v/ScsahA7OzVo')).toBe('ScsahA7OzVo')
+		expect(id('https://www.youtube.com/playlist?list=PLtest')).toBeNull()
+		expect(id('https://www.youtube.com/@arroxy')).toBeNull()
+	})
+
+	it('does not mistake a clip slug for a video id', () => {
+		// A clip is still one downloadable thing, but `Ugkx…` names the clip, not the
+		// video — the real id only comes back from the probe.
+		const clip = classifyUrlIntent('https://www.youtube.com/clip/Ugkx_1234567890abcdef')
+
+		expect(isObviousSingleUrlIntent(clip)).toBe(true)
+		expect(extractUrlIntentYouTubeVideoId(clip)).toBeNull()
+	})
+
+	it('derives readable labels with and without a video id', () => {
+		expect(deriveUrlIntentLabel('https://www.youtube.com/live/ScsahA7OzVo')).toBe('YouTube ScsahA7OzVo')
+		expect(deriveUrlIntentLabel('https://www.youtube.com/clip/Ugkx_123')).toBe('www.youtube.com/clip/Ugkx_123')
 	})
 
 	it('exposes narrow predicates and display labels from the same model', () => {
 		const single = classifyUrlIntent('https://youtu.be/abc123')
+		const live = classifyUrlIntent('https://www.youtube.com/live/ScsahA7OzVo')
+		const clip = classifyUrlIntent('https://www.youtube.com/clip/Ugkx_123')
 		const mixed = classifyUrlIntent('https://www.youtube.com/watch?v=abc123&list=PLtest')
 		const playlist = classifyUrlIntent('https://www.youtube.com/playlist?list=PLtest')
 		const unknown = classifyUrlIntent('https://vimeo.com/123')
 
 		expect(isObviousSingleUrlIntent(single)).toBe(true)
+		expect(isObviousSingleUrlIntent(live)).toBe(true)
+		expect(isObviousSingleUrlIntent(clip)).toBe(true)
 		expect(isMixedUrlIntent(mixed)).toBe(true)
 		expect(urlIntentHomeLabel(playlist)).toBe('Playlist URL')
 		expect(urlIntentHomeLabel(mixed)).toBe('Mixed URL')
 		expect(urlIntentBulkLabel(single)).toBe('single')
+		expect(urlIntentBulkLabel(live)).toBe('single')
+		expect(urlIntentBulkLabel(clip)).toBe('single')
 		expect(urlIntentBulkLabel(playlist)).toBe('playlist')
 		expect(urlIntentBulkLabel(mixed)).toBe('mixed')
 		expect(urlIntentBulkLabel(unknown)).toBe('unknown')

--- a/tests/unit/ytdlp-js-runtime.test.ts
+++ b/tests/unit/ytdlp-js-runtime.test.ts
@@ -97,7 +97,11 @@ async function runStdinScript(executablePath: string, args: string[], script: st
 
 describe('Electron Node runtime parity', () => {
 	it('runs stdin JavaScript for yt-dlp challenge-solver style execution', async () => {
-		const electronBin = path.resolve('node_modules', '.bin', process.platform === 'win32' ? 'electron.cmd' : 'electron')
+		// On Windows node_modules/.bin/electron is a .cmd shim that spawn() cannot
+		// launch without a shell, so prefer a real executable and fall back to the
+		// package's own dist binary before the shim.
+		const electronCandidates = process.platform === 'win32' ? [path.resolve('node_modules', '.bin', 'electron.exe'), path.resolve('node_modules', 'electron', 'dist', 'electron.exe'), path.resolve('node_modules', '.bin', 'electron.cmd')] : [path.resolve('node_modules', '.bin', 'electron')]
+		const electronBin = electronCandidates.find(candidate => existsSync(candidate)) ?? electronCandidates[0]
 		expect(existsSync(electronBin)).toBe(true)
 		const script = `
 			const input = {values: [3, 4, 5], challenge: 'n:abc123'};


### PR DESCRIPTION
Picks up the work from @vansh917917's #173, #174 and #175, with the review findings folded in. Vansh is credited as co-author on all three commits.

## What came from those PRs

**#175 — playlist folder sanitization.** The reserved-name expansion and escaping in `safeFolderName` were right and are kept. Working through them surfaced two bugs in existing code:

- `escapeReservedName` appended the underscore to the end of the whole name, but the reservation ignores the extension — `NUL.mp4_` is still the null device, with the extension mangled for nothing. It now escapes the stem: `NUL_.mp4`. The existing test claimed to cover "extension or not" but only ever passed extensionless names, which is how this survived.
- Escaping ran after truncation, so a reserved name at the length limit came back one character over `SUBFOLDER_NAME_MAX` — a value `isValidSubfolder` rejects, produced by the function whose job is producing valid ones.

`safeFolderName` and `sanitizeDirSegment` had drifted into near-duplicates differing only in the empty-title fallback, so the former is now expressed in terms of the latter.

**#174 — YouTube URL intent.** All the new shapes are kept (`/live/`, `/clip/`, `/embed/`, legacy `/v/` and `/e/`, plus `youtube-nocookie.com`), with two guards added:

- `/embed/videoseries?list=…` wears a video embed's shape but plays a playlist with no video behind it. It classifies as a playlist rather than a single video named "videoseries".
- A clip slug names the clip, not the video. Clips stay single downloads but no longer seed `videoId`, which feeds `{id}` filenames and `[videoId]` file matching until probe metadata arrives.

**#173 — Windows test parity.** The test-side fixes are kept. Three changes:

- Line endings are fixed at the root: `.gitattributes` pins every text file to LF on checkout, rather than a `.replace(/\r\n/g, '\n')` at each call site that only holds until the next fixture reader forgets. No content churn — nothing in the index has CRLF today.
- The `BinaryDownloader` retry change is dropped. `maxDurationMs` is a per-attempt budget, not a whole-download one, so range-resume after a duration timeout is what lets a large binary finish across several windows on a slow link; removing it turns a slow connection into a hard failure. The test that motivated it is scoped to the timeout it is actually about via `partialRetryLimit: 0`, and the resume behaviour gets its own test (verified to fail under the proposed change).
- The knip `lint-staged` ignore is dropped — knip passes clean without it, so that was a Windows-local artifact being suppressed for every platform.

Also hardens the E2E installer's Windows rename-collision path to require a complete, non-empty destination before treating a collision as another worker having won. Existence alone is exactly what staging exists to distrust.

## Verification

`bun run check` clean — format, lint, tooling contract, typecheck, knip, madge, package gates, 2530 tests across 212 files.

Verified on macOS. Every Windows-specific fix here is reasoned from the failure mode — `.cmd` spawn without a shell, 8.3 short paths, CRLF checkouts — rather than observed, and `ci.yml` runs `ubuntu-latest` only, so a Windows checkout is still the only real test bed for those.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-facing changes

- Sanitize Windows reserved device names without removing file extensions.
- Keep sanitized folder names within the 64-character limit.
- Classify additional YouTube URL formats, including live, clip, embed, legacy, and `youtube-nocookie.com` URLs.
- Treat embedded playlist URLs as playlists.
- Treat clip URLs as single downloads without pre-seeding a video ID.

## Internal and refactor changes

- Share folder sanitization rules between `safeFolderName` and `sanitizeDirSegment`.
- Improve Windows tooling parity and temporary-file handling.
- Preserve download resume retries across per-attempt timeouts.
- Harden E2E installer handling of Windows rename collisions.
- Normalize text files to LF and improve cross-platform test paths and binary resolution.
- No dependency or IPC changes are reported.

## Risk areas

- Folder sanitization can affect output paths and filename templates.
- URL classification can affect download type selection and video ID extraction.
- Windows installer races and binary resolution can affect release and test behavior.
- Electron executable selection in parity tests should remain platform-correct.
- No Electron security, IPC boundary, or dependency changes are reported.

## Tests and checks

- Run `bun run check`.
- Verify Windows and non-Windows tooling parity.
- Run unit and E2E tests for folder sanitization, YouTube URL intent, binary retries, and installer behavior.
- Reported verification passes 2,530 tests across 212 files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->