### PR TITLE
ci: run the test suite on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,35 @@ jobs:
 
       - name: Check
         run: bun run check
+
+  # The full `check` gate runs on Linux only. This job exists for the class of
+  # bug that is invisible there: path separators, CRLF checkouts, and shell
+  # shims that spawn without a shell on POSIX but not on Windows. Everyone
+  # working on this repo develops on macOS or Linux, so without a Windows leg
+  # those regressions reach contributors before they reach CI.
+  #
+  # Scoped to the test suite rather than `bun run check`, because the rest of
+  # that gate (formatting, tooling parity, i18n catalogs, package packing) is
+  # platform-independent and already covered above.
+  test-windows:
+    name: test (windows)
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .node-version
+
+      - uses: oven-sh/setup-bun@v2.2.0
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Test
+        run: bun run test


### PR DESCRIPTION
Adds a Windows leg to CI, running the test suite on `windows-latest`.

## Why

The `check` gate runs on `ubuntu-latest` only, so the class of bug that is invisible on Linux — path separators, CRLF checkouts, shell shims that spawn fine on POSIX but not on Windows — has no gate at all. That is exactly how the last batch of Windows fixes (#173, #174, #175 → #176) arrived: reported by a contributor, not caught by CI. Everyone working on this repo develops on macOS or Linux, so those regressions are structurally invisible until someone else hits them.

Dev smoke and Cold start already cover the packaged app on Windows. Nothing covered the test suite.

## Scope

Deliberately scoped to `bun run test` rather than the full `bun run check`. Formatting, tooling parity, i18n catalogs and package packing are platform-independent and already gated on Linux; duplicating them buys nothing and adds Windows-specific failure modes to a gate that should stay boring.

Cost is wall-clock on PRs only — Actions standard runners are free for public repos, so the Windows minute multiplier does not apply here.

## What this PR is actually testing

Whether `bun run test` passes on Windows at all. The fixes in #176 were reasoned from the failure modes rather than observed, since they were written on macOS. If this job comes back red, that is the job doing its work on its first run, and the failures get fixed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-facing changes

- Adds a Windows CI job on `windows-latest`.
- Runs `bun run test` with the existing Node and Bun versions.
- Improves detection of Windows-specific issues, including path separators, CRLF checkouts, and shell shims.

## Internal changes

- Installs dependencies with the frozen lockfile.
- Leaves the existing Linux `check` job unchanged.
- Adds no public API or dependency changes.

## Risk areas

- The change affects CI only.
- It does not change Electron security, IPC boundaries, release behavior, or build outputs.
- The main risk is environment-specific CI failure on Windows.

## Tests and checks

- Run `bun run test` on `windows-latest`.
- Keep the existing Linux CI checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->