### PR TITLE
build(deps-dev): bump oxlint-tsgolint to 7.0.2001

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "arroxy",
@@ -70,7 +69,7 @@
         "lint-staged": "17.3.0",
         "madge": "8.0.0",
         "oxlint": "1.78.0",
-        "oxlint-tsgolint": "0.23.0",
+        "oxlint-tsgolint": "7.0.2001",
         "react-doctor": "0.9.11",
         "tailwindcss": "4.3.3",
         "typescript": "6.0.3",
@@ -526,17 +525,17 @@
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.24.2", "", { "os": "win32", "cpu": "x64" }, "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw=="],
 
-    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.23.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw=="],
+    "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@7.0.2001", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CUJEdbSZ54+Xy9OXqOhWLTKZKV0BBiV7C2i/ygyVmXtkUNXx5YCzN8DpSSshTAKktoL7S+tnQ/ftFG/i7X896w=="],
 
-    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@0.23.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-kjJ8B+7n4tB9VJdxS5A9GdJt6/bYpzbu4lXp2uO1S3sRmCB5gDEABlGoiePNApRWaW+xqL4b4xgiE727jSLhuA=="],
+    "@oxlint-tsgolint/darwin-x64": ["@oxlint-tsgolint/darwin-x64@7.0.2001", "", { "os": "darwin", "cpu": "x64" }, "sha512-pXfBb5BqONCcgrXQNUZWXgiYmRSWJzd97S8i41VVOh6ut0tyo+cJ5FKFpczDHxiVNfj/3e7c9B4MtztNdpIVCw=="],
 
-    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@0.23.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-6dCZuKNu135seMXilkRk9SpCx6i1XgmiipYGalLij5WVRX6ZYS8c4xI7preN/zv9fCXhsQclTIMDu2Y/cytTjw=="],
+    "@oxlint-tsgolint/linux-arm64": ["@oxlint-tsgolint/linux-arm64@7.0.2001", "", { "os": "linux", "cpu": "arm64" }, "sha512-roP7zujb/QDPzDwEKsFFpzNHHy91/Y7oX9vQXk78ekyZtcQj1QXDIMH33gjDdHBfRl4K9pZ36xhRgrP4Zr+R8A=="],
 
-    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@0.23.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3bdilnyA7kmSTjK27rvjIjSxL5SIg3wt7vwNiRkouWB83ytssyKnuGvxSYJxgMEmFpSutzaBzcCUM2jDtPGcgA=="],
+    "@oxlint-tsgolint/linux-x64": ["@oxlint-tsgolint/linux-x64@7.0.2001", "", { "os": "linux", "cpu": "x64" }, "sha512-UDezNqdECVmngu2TPnjaS1YoAmcTaBoI5lV9vk3VahBxoi+I5r9k3iJTT7qZoYWOXTD/7T7bNcwRgrocR6BscQ=="],
 
-    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@0.23.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-j+OEp44SVYiQ+ZD+uttsX7u6L9SvmbbQ77SO1pSFCcJlsVMeCk8qZsjhKfGKuT/jIA+ipOJMVs/+pqUfObBWNw=="],
+    "@oxlint-tsgolint/win32-arm64": ["@oxlint-tsgolint/win32-arm64@7.0.2001", "", { "os": "win32", "cpu": "arm64" }, "sha512-uJZhqB6pdXLuN+AD1F5082byyQti/NPmJA77GtcFlmT2HzRelqbNls3SaIqxpjdFgvSBF9g0yOKGBkGFg7kX8Q=="],
 
-    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.23.0", "", { "os": "win32", "cpu": "x64" }, "sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ=="],
+    "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@7.0.2001", "", { "os": "win32", "cpu": "x64" }, "sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog=="],
 
     "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.78.0", "", { "os": "android", "cpu": "arm" }, "sha512-Bu819lmAfZMUHErrpe0cEWj3iaefuUODHSU8+UbXy67V/r7/7f4K3FL0NmbD85E+wiFLDYuhP8Zlv0XnVeXshw=="],
 
@@ -1824,7 +1823,7 @@
 
     "oxlint-plugin-react-doctor": ["oxlint-plugin-react-doctor@0.9.11", "", { "dependencies": { "@shaderfrog/glsl-parser": "^7.0.1", "@typescript-eslint/types": "^8.59.3", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "lightningcss": "^1.33.0", "oxc-parser": "^0.142.0" } }, "sha512-ZhW15wfFjQlUwAO6zG3jVZKse4/PBTCArhbibiidHmTlvOpPHPM1AjdYG13023pfsbbtVdy7Tb7KHfqbKt8rHg=="],
 
-    "oxlint-tsgolint": ["oxlint-tsgolint@0.23.0", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.23.0", "@oxlint-tsgolint/darwin-x64": "0.23.0", "@oxlint-tsgolint/linux-arm64": "0.23.0", "@oxlint-tsgolint/linux-x64": "0.23.0", "@oxlint-tsgolint/win32-arm64": "0.23.0", "@oxlint-tsgolint/win32-x64": "0.23.0" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA=="],
+    "oxlint-tsgolint": ["oxlint-tsgolint@7.0.2001", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "7.0.2001", "@oxlint-tsgolint/darwin-x64": "7.0.2001", "@oxlint-tsgolint/linux-arm64": "7.0.2001", "@oxlint-tsgolint/linux-x64": "7.0.2001", "@oxlint-tsgolint/win32-arm64": "7.0.2001", "@oxlint-tsgolint/win32-x64": "7.0.2001" }, "bin": { "tsgolint": "./bin/tsgolint.js" } }, "sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg=="],
 
     "p-cancelable": ["p-cancelable@2.1.1", "", {}, "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="],
 

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -72,6 +72,11 @@ export default defineConfig(({mode}) => {
 			},
 			build: {
 				externalizeDeps: true,
+				// electron-vite 5 reads `build.rollupOptions` only — it has no
+				// `rolldownOptions` support and merges user config into its own
+				// `rollupOptions` default. Renaming to the non-deprecated Vite 8
+				// alias would silently drop the `external` override below.
+				// oxlint-disable-next-line typescript/no-deprecated
 				rollupOptions: {
 					// Keep the main bundle self-contained for native ESM on Windows.
 					// Electron's main process uses Node's ESM loader, which resolves
@@ -96,6 +101,11 @@ export default defineConfig(({mode}) => {
 			build: {
 				externalizeDeps: true,
 				lib: {entry: path.resolve('src/preload/index.cts')},
+				// electron-vite 5 reads `build.rollupOptions` only — it has no
+				// `rolldownOptions` support and merges user config into its own
+				// `rollupOptions` default. Renaming to the non-deprecated Vite 8
+				// alias would silently drop the `external` override below.
+				// oxlint-disable-next-line typescript/no-deprecated
 				rollupOptions: {
 					// Same shape as main: rolldown re-bundles deps when output is CJS
 					// unless we re-assert externals here. Crucially, `electron` lives in

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
 		"lint-staged": "17.3.0",
 		"madge": "8.0.0",
 		"oxlint": "1.78.0",
-		"oxlint-tsgolint": "0.23.0",
+		"oxlint-tsgolint": "7.0.2001",
 		"react-doctor": "0.9.11",
 		"tailwindcss": "4.3.3",
 		"typescript": "6.0.3",

--- a/tests/renderer/playlist-defects.test.tsx
+++ b/tests/renderer/playlist-defects.test.tsx
@@ -26,7 +26,7 @@ function multiProfileFixture(id: string, name: string, dir: string): DownloadPro
 		embed: {chapters: true, metadata: true, thumbnail: false, description: false, thumbnailSidecar: false},
 		createdAt: '2026-08-12T00:00:00.000Z',
 		updatedAt: '2026-08-12T00:00:00.000Z'
-	} as DownloadProfile
+	}
 }
 
 const MP_ARCHIVE = multiProfileFixture('archive', 'Archive 4K', '/downloads/archive')

--- a/tests/renderer/step-playlist-profiles.test.tsx
+++ b/tests/renderer/step-playlist-profiles.test.tsx
@@ -38,7 +38,7 @@ function profile(id: string, name: string, icon: DownloadProfile['icon']): Downl
 		embed: {chapters: true, metadata: true, thumbnail: false, description: false, thumbnailSidecar: false},
 		createdAt: '2026-08-12T00:00:00.000Z',
 		updatedAt: '2026-08-12T00:00:00.000Z'
-	} as DownloadProfile
+	}
 }
 
 const ARCHIVE = profile('archive', 'Archive 4K', 'archive')

--- a/tests/unit/binary-manager-analytics.test.ts
+++ b/tests/unit/binary-manager-analytics.test.ts
@@ -38,7 +38,7 @@ async function runFailingManifestResolution(err: unknown): Promise<void> {
 				materialize: vi.fn(async () => {
 					throw err
 				})
-			} as never
+			}
 		})
 
 		await mgr.resolveYtDlp()

--- a/tests/unit/playlist-profile-assignments.test.ts
+++ b/tests/unit/playlist-profile-assignments.test.ts
@@ -16,7 +16,7 @@ function profile(id: string, name: string): DownloadProfile {
 		embed: {chapters: true, metadata: true, thumbnail: false, description: false, thumbnailSidecar: false},
 		createdAt: '2026-08-12T00:00:00.000Z',
 		updatedAt: '2026-08-12T00:00:00.000Z'
-	} as DownloadProfile
+	}
 }
 
 const ARCHIVE = profile('archive', 'Archive 4K')


### PR DESCRIPTION
Supersedes #159, which was stale (branched 2026-08-10) and red on both `audit` and `check`.

The `audit` failure there was staleness only — those advisories are already fixed on main. This branch is cut from current main, so it starts clean.

The version jump is a **versioning-scheme change** tracking TypeScript 7 / tsgolint, not seven major releases. It runs fine against the TypeScript 6.0.3 we are still on, so this does not depend on #158.

## Findings fixed

The newer type-aware rules surface six real findings:

**Four redundant `as` assertions in tests.** Three are `} as DownloadProfile` inside factory functions already annotated `: DownloadProfile`; one is `as never` on a `runtimeBinaryMaterializer` stub that is already structurally compatible. Removing them restores genuine excess- and missing-property checking at those sites, so this is a small type-safety win rather than a lint appeasement.

**Two `no-deprecated` hits on `build.rollupOptions`** in `electron.vite.config.ts`. These are **suppressed, not renamed** — the obvious fix is actively unsafe here:

- `electron-vite@5.0.0` contains zero references to `rolldownOptions`. It reads `build.rollupOptions` exclusively, builds its own default, and `mergeConfig`s user config into it.
- Renaming to the non-deprecated Vite 8 alias would put our `external` overrides in a key nothing reads, silently falling back to electron-vite's defaults.
- For the **main** build that re-externalizes npm deps — the documented Windows `ERR_UNSUPPORTED_ESM_URL_SCHEME` asar-resolution bug the existing comment warns about.
- For **preload** it would inline `node_modules/electron` (the npm postinstall shim, not the runtime module), breaking `ipcRenderer`/`contextBridge` at load.

Both would typecheck cleanly and fail only at runtime on packaged Windows, so the suppression carries a comment explaining why it must stay.

## Verification

`bun run check` passes end to end (exit 0) — format, lint, tooling contract, typecheck, knip, madge, package gates, and the full 2530-test suite.