### PR TITLE
chore: ignore the local design and spike directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,11 @@ opencode.jsonc
 !.agents/skills/remember/**
 
 # Local agent/design artifacts
+# Anchored to the repo root on purpose: an unanchored `design/` would also swallow
+# any nested design directory that belongs in the repo, the way `test-binaries/`
+# once silently matched scripts/test-binaries/.
+/design/
+/scripts/spike/
 .superpowers/
 .backups/
 .github/skills/


### PR DESCRIPTION
Untracked scratch work — `design/` and `scripts/spike/` — throws ~288 lint errors between them, so `bun run check` could not complete on any working copy that had them. CI never saw it because its checkout is clean, which meant the gate only broke for whoever was actually working in the repo.

Anchored to the repo root on purpose: an unanchored `design/` would also swallow any nested design directory that belongs in the repo, the way `test-binaries/` once silently matched `scripts/test-binaries/`.

Verified `bun run check` completes locally after this change.