### PR TITLE
Harden startup verification: named seeders, real nightly, one soak criterion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,11 +64,13 @@ jobs:
       - name: Check
         run: bun run check
 
-  # NOTE: not yet wired into prepare-release's `needs:` — see the rollout note
-  # in docs/superpowers/specs/2026-08-30-startup-verification-ci-design.md.
-  # Flip it live only once e2e-cold-start.yml's PR-tier journey harness has run
-  # green on main for several days; a flaky new gate blocking every release
-  # would be worse than the silent gap it replaces.
+  # NOTE: not yet wired into prepare-release's `needs:` — a red gate does not
+  # currently stop a publish. Flip it live once THIS job has run green on all
+  # three platforms across three consecutive tags (beta tags count — the job
+  # already runs on every `v*`). PR-tier green is not evidence for it: the
+  # release tier runs `inherited-update` on two platforms the PR tier never
+  # touches. Do not add it to branch protection — it is tag-only (ADR 0006).
+  # Review date if the tags have not happened by then: 2026-10-01.
   startup-gate:
     needs: quality-gate
     strategy:

--- a/.github/workflows/startup-nightly.yml
+++ b/.github/workflows/startup-nightly.yml
@@ -74,19 +74,31 @@ jobs:
           if-no-files-found: error
           retention-days: 14
   notify:
-    name: Report nightly failure
+    name: Report nightly result
     needs: degraded
-    if: failure()
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
+      - name: Close the nightly failure issue on recovery
+        if: success()
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --label startup-nightly --state open --limit 1 --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" --comment "Startup nightly green again: $RUN_URL"
+            echo "closed #$existing"
+          else
+            echo "no open startup-nightly issue"
+          fi
       - name: Open or update the nightly failure issue
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        if: failure()
         run: |
           set -euo pipefail
           existing=$(gh issue list --label startup-nightly --state open --limit 1 --json number --jq '.[0].number // empty')

--- a/.github/workflows/startup-nightly.yml
+++ b/.github/workflows/startup-nightly.yml
@@ -73,3 +73,35 @@ jobs:
           path: ${{ runner.temp }}/arroxy-startup-logs
           if-no-files-found: error
           retention-days: 14
+  notify:
+    name: Report nightly failure
+    needs: degraded
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update the nightly failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --label startup-nightly --state open --limit 1 --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Startup nightly failed again: $RUN_URL"
+            echo "commented on #$existing"
+            exit 0
+          fi
+          gh issue create --title "Startup nightly is failing" --label startup-nightly --body "$(cat <<EOF
+          The scheduled startup verification run failed. Startup verification is
+          the only automated Windows and macOS startup coverage while
+          \`startup-gate\` is unwired, so a red nightly is a real gap, not noise.
+
+          Run: $RUN_URL
+
+          Context: \`dev-docs/startup-verification.md\`
+          EOF
+          )"

--- a/.github/workflows/startup-nightly.yml
+++ b/.github/workflows/startup-nightly.yml
@@ -76,10 +76,17 @@ jobs:
   notify:
     name: Report nightly result
     needs: degraded
+    # always() runs this job on failure too; the steps gate on the matrix result
+    # explicitly — step-level success()/failure() only see previous steps in
+    # this job, not the needed job's result.
     if: always()
     runs-on: ubuntu-latest
+    concurrency:
+      # Serialize the list-then-create issue flow across overlapping runs
+      # (schedule + workflow_dispatch); never cancel an in-progress notify.
+      group: startup-nightly-notify
+      cancel-in-progress: false
     permissions:
-      contents: read
       issues: write
     env:
       GH_TOKEN: ${{ github.token }}
@@ -87,7 +94,7 @@ jobs:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Close the nightly failure issue on recovery
-        if: success()
+        if: needs.degraded.result == 'success'
         run: |
           set -euo pipefail
           existing=$(gh issue list --label startup-nightly --state open --limit 1 --json number --jq '.[0].number // empty')
@@ -98,7 +105,7 @@ jobs:
             echo "no open startup-nightly issue"
           fi
       - name: Open or update the nightly failure issue
-        if: failure()
+        if: needs.degraded.result == 'failure'
         run: |
           set -euo pipefail
           existing=$(gh issue list --label startup-nightly --state open --limit 1 --json number --jq '.[0].number // empty')

--- a/dev-docs/ci-cd-strategy.md
+++ b/dev-docs/ci-cd-strategy.md
@@ -34,9 +34,9 @@ Decision record: the PR gate is Linux-only on purpose — [ADR 0006](../docs/adr
 | --------- | ---------------------------- | --------- | ------------------------------------------------------ | ------------------------------------------------------------------------ |
 | `pr`      | E2E Cold Start               | Linux     | yes                                                    | `fresh-cold`, `warm-restart`                                             |
 | `release` | `release.yml` `startup-gate` | all 3     | not yet — soak first, then wire into `prepare-release` | + `inherited-update`                                                     |
-| `nightly` | Startup Nightly              | all 3     | no (reports)                                           | degraded: offline, index-off, no-GPU, contaminated PATH, corrupt profile |
+| `nightly` | Startup Nightly              | all 3     | no — failure opens a `startup-nightly` issue           | `fresh-cold` + `index-off`, `no-GPU`, `contaminated PATH`, `corrupt profile` (no `offline`) |
 
-Journeys are data in `scripts/startup/journeys.ts`; the runner launches the packaged app, waits for a real milestone, and a pure log oracle asserts clean logs. A missing verdict is a failure — "ran nothing" can never look like "passed". Invocation: `ARROXY_STARTUP_TIER=<tier> PACKAGED_EXE=<exe> bun run verify:startup`. Details in `dev-docs/startup-performance.md`.
+Journeys are data in `scripts/startup/journeys.ts`; the runner launches the packaged app, waits for a real milestone, and a pure log oracle asserts clean logs. A missing verdict is a failure — "ran nothing" can never look like "passed". Invocation: `ARROXY_STARTUP_TIER=<tier> PACKAGED_EXE=<exe> bun run verify:startup`. Details in `dev-docs/startup-verification.md`.
 
 ## Branch protection contract (`main`)
 

--- a/dev-docs/startup-verification.md
+++ b/dev-docs/startup-verification.md
@@ -40,7 +40,7 @@ Fixed or resolved: the nightly's unseedable warm journeys (fixed — `fresh-cold
 
 ## Known gaps
 
-- No journey verifies genuinely-offline startup. `offline-no-cache` was removed rather than left unenforced; re-adding it needs portable egress blocking (`unshare -n` is Linux-only, `HTTPS_PROXY` is not honored by `node:https`), which is its own spike.
+- No journey verifies genuinely-offline startup. `offline-no-cache` was removed rather than left unenforced; re-adding it needs portable egress blocking (`unshare -n` is Linux-only; `HTTPS_PROXY` cannot force it — the startup runtime does not enable Node's env-proxy support via `NODE_USE_ENV_PROXY`), which is its own spike.
 
 ## Incidents
 

--- a/dev-docs/startup-verification.md
+++ b/dev-docs/startup-verification.md
@@ -15,28 +15,32 @@
 | -------------------------------------------- | ----------------------------------------------------------------------------- |
 | `pr` (Linux, blocking via branch protection) | ✅ green in CI, verified against a real packaged build                        |
 | `release` (all 3 platforms, on tags)         | ⚠️ advisory — not wired into `prepare-release` yet; never fired (needs a tag) |
-| `nightly` (all 3 platforms, scheduled)       | ❌ first run red — two structural defects, see below                          |
+| `nightly` (all 3 platforms, scheduled)       | ✅ green — 5/5 verdicts on all three platforms ([run 33309036291](https://github.com/antonio-orionus/Arroxy/actions/runs/33309036291)) |
 
 Invocation: `ARROXY_STARTUP_TIER=<tier> PACKAGED_EXE=<exe> bun run verify:startup`.
 
 ## Decisions and why
 
 1. **Journeys are data; one executor.** The replaced per-workflow bash launch scripts rotted independently — that is exactly how the cold-start check became a silent no-op for two months. One executor cannot rot on one platform while passing on another.
-2. **Verdict accounting is the pass signal, not exit codes.** A missing verdict is a failure, so "ran nothing" and "passed" can never produce the same result. Confirmed on its first nightly run: the defect below surfaced as loud red, not a fake pass.
+2. **Verdict accounting is the pass signal, not exit codes.** A missing verdict is a failure, so "ran nothing" and "passed" can never produce the same result. Confirmed on its first nightly run: the no-warm-source defect surfaced as loud red, not a fake pass.
 3. **A pure log oracle over `main.log`.** UI milestones alone cannot see silent fallbacks, swallowed exceptions, or unsettled warmup branches; the logs are already captured as CI artifacts, so asserting on them is close to free.
 4. **PR gate is Linux-only.** Runner economics; multi-platform startup confidence belongs at tag time. Full trade-off and the incident behind it: ADR 0006.
-5. **Release gate runs advisory until soaked.** A flaky gate blocking every release is worse than the gap it replaces. Wire `startup-gate` into `prepare-release` after ~a week of green tag runs — calendar it, do not wait to remember.
+5. **Release gate runs advisory until soaked.** A flaky gate blocking every release is worse than the gap it replaces. Wire `startup-gate` into `prepare-release` once `startup-gate` itself has run green on all three platforms across three consecutive tags (beta tags count — the job already runs on every `v*`). PR-tier green is not evidence for it: the release tier runs `inherited-update` on two platforms the PR tier never touches. Review date if the tags have not happened by then: 2026-10-01.
 6. **Entry point is a Playwright Test spec, not a bare CLI script.** `_electron.launch()` hangs indefinitely under Bun; every working Electron launch in the repo rides the Playwright CLI, which `bunx` resolves through its `#!/usr/bin/env node` shebang into real Node. The tier rides in `ARROXY_STARTUP_TIER` because a spec takes no CLI args.
-7. **Degraded journeys run nightly, non-blocking.** Forced offline, software rendering, and PATH poisoning are inherently flaky to stage; gating every PR on them would make the gate flaky. Non-blocking still catches drift within a day.
+7. **Degraded journeys run nightly, non-blocking.** Forced offline (descoped — see Known gaps), software rendering, and PATH poisoning are inherently flaky to stage; gating every PR on them would make the gate flaky. Non-blocking still catches drift within a day.
 8. **Profile copies preserve mtime and drop copied logs.** `ProbeVerdictCache` keys on mtime, so `cp -R` silently invalidates the cache under test; a copied `main.log` would let a stale "Warmup completed" satisfy the oracle for the wrong session.
 9. **`ARROXY_E2E` / `MOCK_BACKEND` are stripped from journey env.** Those flags swap in mock providers and would mock away the exact branches the journeys exist to verify.
+10. **Warm seeders are named, not positional.** A `warm` profile names the journey it clones (`{kind: 'warm', from: 'fresh-cold'}`) and every tier is preflighted by `validateTier` before any launch. The nightly once silently declared three warm journeys with no seeder — an array-order convention guarded by a comment — and it took three CI runners to find out.
 
 ## Known defects (open)
 
-1. **Nightly warm journeys can never pass.** The nightly tier has no `fresh-cold`, so no journey seeds the warm source; `index-off`, `no-gpu`, `contaminated-path` fail with "no warm source". Fix: add `fresh-cold` to the nightly tier (or generate the warm profile in a setup phase).
-2. **`offline-no-cache` cannot pass online.** It expects `repair-panel`, but `network: 'offline'` is declared data nothing enforces — observed `main-screen` on the first run. Fix: enforce via deny proxy or netns, or descope the journey.
-3. **Wire `startup-gate` into `prepare-release`** after the soak (see decision 5). Until then a broken macOS cold start can ship.
-4. **Nightly red = same-day look.** A non-blocking job nobody reads is the silent gap reborn.
+1. **Wire `startup-gate` into `prepare-release`** after the soak (see decision 5). Until then a broken macOS cold start can ship.
+
+Fixed or resolved: the nightly's unseedable warm journeys (fixed — `fresh-cold` seeds the tier, named via decision 10) and the unenforceable `offline-no-cache` journey (descoped, see Known gaps). Nightly failures open a `startup-nightly` issue automatically (`startup-nightly.yml` `notify` job), so a red nightly reaches a human the same day.
+
+## Known gaps
+
+- No journey verifies genuinely-offline startup. `offline-no-cache` was removed rather than left unenforced; re-adding it needs portable egress blocking (`unshare -n` is Linux-only, `HTTPS_PROXY` is not honored by `node:https`), which is its own spike.
 
 ## Incidents
 

--- a/dev-docs/startup-verification.md
+++ b/dev-docs/startup-verification.md
@@ -25,7 +25,7 @@ Invocation: `ARROXY_STARTUP_TIER=<tier> PACKAGED_EXE=<exe> bun run verify:startu
 2. **Verdict accounting is the pass signal, not exit codes.** A missing verdict is a failure, so "ran nothing" and "passed" can never produce the same result. Confirmed on its first nightly run: the no-warm-source defect surfaced as loud red, not a fake pass.
 3. **A pure log oracle over `main.log`.** UI milestones alone cannot see silent fallbacks, swallowed exceptions, or unsettled warmup branches; the logs are already captured as CI artifacts, so asserting on them is close to free.
 4. **PR gate is Linux-only.** Runner economics; multi-platform startup confidence belongs at tag time. Full trade-off and the incident behind it: ADR 0006.
-5. **Release gate runs advisory until soaked.** A flaky gate blocking every release is worse than the gap it replaces. Wire `startup-gate` into `prepare-release` once `startup-gate` itself has run green on all three platforms across three consecutive tags (beta tags count — the job already runs on every `v*`). PR-tier green is not evidence for it: the release tier runs `inherited-update` on two platforms the PR tier never touches. Review date if the tags have not happened by then: 2026-10-01.
+5. **Release gate runs advisory until soaked.** A flaky gate blocking every release is worse than the gap it replaces. Wire `startup-gate` into `prepare-release` once its soak criterion — stated verbatim in the NOTE above `startup-gate` in `release.yml`, the single source for the criterion and the review date — is met. PR-tier green is not evidence for it: the release tier runs `inherited-update` on two platforms the PR tier never touches.
 6. **Entry point is a Playwright Test spec, not a bare CLI script.** `_electron.launch()` hangs indefinitely under Bun; every working Electron launch in the repo rides the Playwright CLI, which `bunx` resolves through its `#!/usr/bin/env node` shebang into real Node. The tier rides in `ARROXY_STARTUP_TIER` because a spec takes no CLI args.
 7. **Degraded journeys run nightly, non-blocking.** Forced offline (descoped — see Known gaps), software rendering, and PATH poisoning are inherently flaky to stage; gating every PR on them would make the gate flaky. Non-blocking still catches drift within a day.
 8. **Profile copies preserve mtime and drop copied logs.** `ProbeVerdictCache` keys on mtime, so `cp -R` silently invalidates the cache under test; a copied `main.log` would let a stale "Warmup completed" satisfy the oracle for the wrong session.
@@ -36,7 +36,7 @@ Invocation: `ARROXY_STARTUP_TIER=<tier> PACKAGED_EXE=<exe> bun run verify:startu
 
 1. **Wire `startup-gate` into `prepare-release`** after the soak (see decision 5). Until then a broken macOS cold start can ship.
 
-Fixed or resolved: the nightly's unseedable warm journeys (fixed — `fresh-cold` seeds the tier, named via decision 10) and the unenforceable `offline-no-cache` journey (descoped, see Known gaps). Nightly failures open a `startup-nightly` issue automatically (`startup-nightly.yml` `notify` job), so a red nightly reaches a human the same day.
+Fixed or resolved: the nightly's unseedable warm journeys (fixed — `fresh-cold` seeds the tier, named via decision 10) and the unenforceable `offline-no-cache` journey (descoped, see Known gaps). Nightly failures open a `startup-nightly` issue automatically (`startup-nightly.yml` `notify` job), so a red nightly reaches a human the same day, and the first green run closes the issue again.
 
 ## Known gaps
 

--- a/docs/adr/0006-pr-startup-gate-linux-only.md
+++ b/docs/adr/0006-pr-startup-gate-linux-only.md
@@ -22,3 +22,10 @@ went Linux-only, the stale required contexts `Cold start (windows)` and
 `Cold start (macos-arm64)` blocked every PR with checks that could never
 start. Tag-only and scheduled jobs must never become required PR contexts —
 including `startup-gate` itself once it is wired into `prepare-release`.
+
+This decision's own argument — "the release gate will catch it anyway before
+anything can publish" — is a promise, not yet a fact: `startup-gate` is in no
+job's `needs:`, so a red gate currently stops nothing. Until it is wired,
+automated Windows and macOS startup coverage is the nightly alone. Wiring it is
+the precondition that makes this ADR true; the criterion and review date live
+in the NOTE above `startup-gate` in `release.yml`.

--- a/scripts/startup/journeys.ts
+++ b/scripts/startup/journeys.ts
@@ -1,13 +1,24 @@
 import type {LogPolicy} from './logOracle.js'
 
 export type StartupTier = 'pr' | 'release' | 'nightly'
+export const TIERS_UNDER_TEST: readonly StartupTier[] = ['pr', 'release', 'nightly']
+
+/** The provisioner's dispatch key. `ProfileSpec` is what a journey declares. */
 export type ProfileKind = 'empty' | 'inherited' | 'warm' | 'corrupt'
+
+/**
+ * A `warm` profile names the journey it is cloned from. Ordering used to be an
+ * array-position convention guarded by a comment; the nightly tier silently
+ * declared three warm journeys and no seeder, and it took three CI runners to
+ * find out. Naming the seeder makes that a preflight failure instead.
+ */
+export type ProfileSpec = {kind: 'empty'} | {kind: 'corrupt'} | {kind: 'inherited'} | {kind: 'warm'; from: string}
 export type ExpectedOutcome = 'main-screen' | 'repair-panel'
 
 export interface StartupJourney {
 	id: string
 	description: string
-	profile: ProfileKind
+	profile: ProfileSpec
 	env: Readonly<Record<string, string>>
 	/** Fake node/deno/yt-dlp on PATH — applied to the CHILD env only, never $GITHUB_PATH. */
 	pathContamination?: boolean
@@ -20,25 +31,48 @@ export interface StartupJourney {
 const CLEAN: LogPolicy = {allowedWarnings: []}
 
 export const JOURNEYS: readonly StartupJourney[] = [
-	{id: 'fresh-cold', description: 'First launch ever: no profile, no runtime cache, managed yt-dlp downloaded from scratch.', profile: 'empty', env: {}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['pr', 'release']},
-	{id: 'warm-restart', description: 'Second launch against a populated runtime cache — the path most users hit daily.', profile: 'warm', env: {}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['pr', 'release']},
-	{id: 'inherited-update', description: 'This build launched against a profile written by the previous release.', profile: 'inherited', env: {}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['release']},
-	{id: 'index-off', description: 'Remote runtime index unreachable; must fall back to last-known-good or bundled index.', profile: 'warm', env: {ARROXY_RUNTIME_INDEX_URL: 'off'}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']},
-	{id: 'no-gpu', description: 'Software rendering only — backdrop must fall back without blocking startup.', profile: 'warm', env: {ARROXY_GPU_MODE: 'software'}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']},
-	{id: 'contaminated-path', description: 'Stale node/deno and a broken yt-dlp on PATH; the app must still resolve its own binaries.', profile: 'warm', env: {}, pathContamination: true, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']},
+	{id: 'fresh-cold', description: 'First launch ever: no profile, no runtime cache, managed yt-dlp downloaded from scratch.', profile: {kind: 'empty'}, env: {}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['pr', 'release', 'nightly']},
+	{id: 'warm-restart', description: 'Second launch against a populated runtime cache — the path most users hit daily.', profile: {kind: 'warm', from: 'fresh-cold'}, env: {}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['pr', 'release']},
+	{id: 'inherited-update', description: 'This build launched against a profile written by the previous release.', profile: {kind: 'inherited'}, env: {}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['release']},
+	{id: 'index-off', description: 'Remote runtime index unreachable; must fall back to last-known-good or bundled index.', profile: {kind: 'warm', from: 'fresh-cold'}, env: {ARROXY_RUNTIME_INDEX_URL: 'off'}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']},
+	{id: 'no-gpu', description: 'Software rendering only — backdrop must fall back without blocking startup.', profile: {kind: 'warm', from: 'fresh-cold'}, env: {ARROXY_GPU_MODE: 'software'}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']},
+	{id: 'contaminated-path', description: 'Stale node/deno and a broken yt-dlp on PATH; the app must still resolve its own binaries.', profile: {kind: 'warm', from: 'fresh-cold'}, env: {}, pathContamination: true, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']},
 	{
 		id: 'offline-no-cache',
 		description: 'No network and no cached binaries — must surface the repair panel, not hang on the splash.',
-		profile: 'empty',
+		profile: {kind: 'empty'},
 		env: {ARROXY_RUNTIME_INDEX_URL: 'off'},
 		network: 'offline',
 		expect: 'repair-panel',
 		logPolicy: {allowedWarnings: [/runtime binary/i, /download/i, /probe/i]},
 		tiers: ['nightly']
 	},
-	{id: 'corrupt-profile', description: 'Malformed settings.json and queue.json must not prevent reaching the main screen.', profile: 'corrupt', env: {}, expect: 'main-screen', logPolicy: {allowedWarnings: [/settings/i, /queue/i, /parse/i]}, tiers: ['nightly']}
+	{id: 'corrupt-profile', description: 'Malformed settings.json and queue.json must not prevent reaching the main screen.', profile: {kind: 'corrupt'}, env: {}, expect: 'main-screen', logPolicy: {allowedWarnings: [/settings/i, /queue/i, /parse/i]}, tiers: ['nightly']}
 ]
 
 export function journeysForTier(tier: StartupTier): StartupJourney[] {
 	return JOURNEYS.filter(journey => journey.tiers.includes(tier))
+}
+
+/**
+ * Runs before any launch. A tier that selects a warm journey without its seeder
+ * ahead of it is not runnable, and must say so in one line rather than burning
+ * a runner per platform to discover it.
+ */
+export function validateJourneySequence(journeys: readonly StartupJourney[], tier: StartupTier): string[] {
+	if (journeys.length === 0) return [`tier "${tier}" selects no journeys`]
+
+	const problems: string[] = []
+	const earlier = new Set<string>()
+	for (const journey of journeys) {
+		if (journey.profile.kind === 'warm' && !earlier.has(journey.profile.from)) {
+			problems.push(`${journey.id}: warm profile is seeded from "${journey.profile.from}", which does not run earlier in tier "${tier}"`)
+		}
+		earlier.add(journey.id)
+	}
+	return problems
+}
+
+export function validateTier(tier: StartupTier): string[] {
+	return validateJourneySequence(journeysForTier(tier), tier)
 }

--- a/scripts/startup/journeys.ts
+++ b/scripts/startup/journeys.ts
@@ -27,7 +27,7 @@ export interface StartupJourney {
 	tiers: readonly StartupTier[]
 }
 
-const CLEAN: LogPolicy = {allowedWarnings: []}
+const CLEAN: LogPolicy = {allowedWarnings: [], allowedErrors: []}
 
 export const JOURNEYS: readonly StartupJourney[] = [
 	{id: 'fresh-cold', description: 'First launch ever: no profile, no runtime cache, managed yt-dlp downloaded from scratch.', profile: {kind: 'empty'}, env: {}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['pr', 'release', 'nightly']},
@@ -36,7 +36,7 @@ export const JOURNEYS: readonly StartupJourney[] = [
 	{id: 'index-off', description: 'Remote runtime index unreachable; must fall back to last-known-good or bundled index.', profile: {kind: 'warm', from: 'fresh-cold'}, env: {ARROXY_RUNTIME_INDEX_URL: 'off'}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']},
 	{id: 'no-gpu', description: 'Software rendering only — backdrop must fall back without blocking startup.', profile: {kind: 'warm', from: 'fresh-cold'}, env: {ARROXY_GPU_MODE: 'software'}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']},
 	{id: 'contaminated-path', description: 'Stale node/deno and a broken yt-dlp on PATH; the app must still resolve its own binaries.', profile: {kind: 'warm', from: 'fresh-cold'}, env: {}, pathContamination: true, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']},
-	{id: 'corrupt-profile', description: 'Malformed settings.json and queue.json must not prevent reaching the main screen.', profile: {kind: 'corrupt'}, env: {}, expect: 'main-screen', logPolicy: {allowedWarnings: [/settings/i, /queue/i, /parse/i]}, tiers: ['nightly']}
+	{id: 'corrupt-profile', description: 'Malformed settings.json and queue.json must not prevent reaching the main screen.', profile: {kind: 'corrupt'}, env: {}, expect: 'main-screen', logPolicy: {allowedWarnings: [/settings/i, /queue/i, /parse/i], allowedErrors: []}, tiers: ['nightly']}
 ]
 
 export function journeysForTier(tier: StartupTier): StartupJourney[] {

--- a/scripts/startup/journeys.ts
+++ b/scripts/startup/journeys.ts
@@ -22,7 +22,6 @@ export interface StartupJourney {
 	env: Readonly<Record<string, string>>
 	/** Fake node/deno/yt-dlp on PATH — applied to the CHILD env only, never $GITHUB_PATH. */
 	pathContamination?: boolean
-	network?: 'online' | 'offline'
 	expect: ExpectedOutcome
 	logPolicy: LogPolicy
 	tiers: readonly StartupTier[]
@@ -37,16 +36,6 @@ export const JOURNEYS: readonly StartupJourney[] = [
 	{id: 'index-off', description: 'Remote runtime index unreachable; must fall back to last-known-good or bundled index.', profile: {kind: 'warm', from: 'fresh-cold'}, env: {ARROXY_RUNTIME_INDEX_URL: 'off'}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']},
 	{id: 'no-gpu', description: 'Software rendering only — backdrop must fall back without blocking startup.', profile: {kind: 'warm', from: 'fresh-cold'}, env: {ARROXY_GPU_MODE: 'software'}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']},
 	{id: 'contaminated-path', description: 'Stale node/deno and a broken yt-dlp on PATH; the app must still resolve its own binaries.', profile: {kind: 'warm', from: 'fresh-cold'}, env: {}, pathContamination: true, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']},
-	{
-		id: 'offline-no-cache',
-		description: 'No network and no cached binaries — must surface the repair panel, not hang on the splash.',
-		profile: {kind: 'empty'},
-		env: {ARROXY_RUNTIME_INDEX_URL: 'off'},
-		network: 'offline',
-		expect: 'repair-panel',
-		logPolicy: {allowedWarnings: [/runtime binary/i, /download/i, /probe/i]},
-		tiers: ['nightly']
-	},
 	{id: 'corrupt-profile', description: 'Malformed settings.json and queue.json must not prevent reaching the main screen.', profile: {kind: 'corrupt'}, env: {}, expect: 'main-screen', logPolicy: {allowedWarnings: [/settings/i, /queue/i, /parse/i]}, tiers: ['nightly']}
 ]
 

--- a/scripts/startup/journeys.ts
+++ b/scripts/startup/journeys.ts
@@ -34,7 +34,15 @@ export const JOURNEYS: readonly StartupJourney[] = [
 	{id: 'warm-restart', description: 'Second launch against a populated runtime cache — the path most users hit daily.', profile: {kind: 'warm', from: 'fresh-cold'}, env: {}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['pr', 'release']},
 	{id: 'inherited-update', description: 'This build launched against a profile written by the previous release.', profile: {kind: 'inherited'}, env: {}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['release']},
 	{id: 'index-off', description: 'Remote runtime index unreachable; must fall back to last-known-good or bundled index.', profile: {kind: 'warm', from: 'fresh-cold'}, env: {ARROXY_RUNTIME_INDEX_URL: 'off'}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']},
-	{id: 'no-gpu', description: 'Software rendering only — backdrop must fall back without blocking startup.', profile: {kind: 'warm', from: 'fresh-cold'}, env: {ARROXY_GPU_MODE: 'software'}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']},
+	{
+		id: 'no-gpu',
+		description: 'Software rendering only — backdrop must fall back without blocking startup.',
+		profile: {kind: 'warm', from: 'fresh-cold'},
+		env: {ARROXY_GPU_MODE: 'software'},
+		expect: 'main-screen',
+		logPolicy: {allowedWarnings: [/gpu info failed .*disabled through commandline switch/i], allowedErrors: []},
+		tiers: ['nightly']
+	},
 	{id: 'contaminated-path', description: 'Stale node/deno and a broken yt-dlp on PATH; the app must still resolve its own binaries.', profile: {kind: 'warm', from: 'fresh-cold'}, env: {}, pathContamination: true, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']},
 	{id: 'corrupt-profile', description: 'Malformed settings.json and queue.json must not prevent reaching the main screen.', profile: {kind: 'corrupt'}, env: {}, expect: 'main-screen', logPolicy: {allowedWarnings: [/settings/i, /queue/i, /parse/i], allowedErrors: []}, tiers: ['nightly']}
 ]

--- a/scripts/startup/journeys.ts
+++ b/scripts/startup/journeys.ts
@@ -1,10 +1,7 @@
 import type {LogPolicy} from './logOracle.js'
 
 export type StartupTier = 'pr' | 'release' | 'nightly'
-export const TIERS_UNDER_TEST: readonly StartupTier[] = ['pr', 'release', 'nightly']
-
-/** The provisioner's dispatch key. `ProfileSpec` is what a journey declares. */
-export type ProfileKind = 'empty' | 'inherited' | 'warm' | 'corrupt'
+export const STARTUP_TIERS: readonly StartupTier[] = ['pr', 'release', 'nightly']
 
 /**
  * A `warm` profile names the journey it is cloned from. Ordering used to be an
@@ -13,6 +10,9 @@ export type ProfileKind = 'empty' | 'inherited' | 'warm' | 'corrupt'
  * find out. Naming the seeder makes that a preflight failure instead.
  */
 export type ProfileSpec = {kind: 'empty'} | {kind: 'corrupt'} | {kind: 'inherited'} | {kind: 'warm'; from: string}
+
+/** The provisioner's dispatch key — derived from `ProfileSpec`, so it cannot drift from what journeys declare. */
+export type ProfileKind = ProfileSpec['kind']
 export type ExpectedOutcome = 'main-screen' | 'repair-panel'
 
 export interface StartupJourney {
@@ -52,18 +52,26 @@ export function journeysForTier(tier: StartupTier): StartupJourney[] {
 }
 
 /**
- * Runs before any launch. A tier that selects a warm journey without its seeder
- * ahead of it is not runnable, and must say so in one line rather than burning
- * a runner per platform to discover it.
+ * Runs before any launch. A tier is not runnable when a warm journey's seeder
+ * is not ahead of it, or when that seeder can never reach the main screen — the
+ * runner only snapshots a warm source from a passing main-screen verdict. Each
+ * problem must say so in one line rather than burning a runner per platform to
+ * discover it.
  */
 export function validateJourneySequence(journeys: readonly StartupJourney[], tier: StartupTier): string[] {
 	if (journeys.length === 0) return [`tier "${tier}" selects no journeys`]
 
 	const problems: string[] = []
+	const byId = new Map(journeys.map(journey => [journey.id, journey]))
 	const earlier = new Set<string>()
 	for (const journey of journeys) {
-		if (journey.profile.kind === 'warm' && !earlier.has(journey.profile.from)) {
-			problems.push(`${journey.id}: warm profile is seeded from "${journey.profile.from}", which does not run earlier in tier "${tier}"`)
+		if (journey.profile.kind === 'warm') {
+			const seeder = byId.get(journey.profile.from)
+			if (!earlier.has(journey.profile.from)) {
+				problems.push(`${journey.id}: warm profile is seeded from "${journey.profile.from}", which does not run earlier in tier "${tier}"`)
+			} else if (seeder && seeder.expect !== 'main-screen') {
+				problems.push(`${journey.id}: warm profile is seeded from "${journey.profile.from}", which expects ${seeder.expect} and can never seed a warm source`)
+			}
 		}
 		earlier.add(journey.id)
 	}

--- a/scripts/startup/logOracle.ts
+++ b/scripts/startup/logOracle.ts
@@ -7,6 +7,12 @@ export interface LogViolation {
 
 export interface LogPolicy {
 	allowedWarnings: readonly RegExp[]
+	/**
+	 * Errors are violations by default. The allowlist exists because this oracle
+	 * gates three platforms at tag time, where one benign platform-specific error
+	 * line must be waivable per journey rather than by editing the oracle.
+	 */
+	allowedErrors: readonly RegExp[]
 }
 
 // electron-log main.log line shape: `[2026-08-30 05:22:31.753] [info]  (scope)  message`
@@ -53,7 +59,7 @@ export function inspectStartupLog(logText: string, policy: LogPolicy): LogViolat
 		if (!parsed) continue
 		const [, level, message = ''] = parsed
 		if (level === 'error') {
-			violations.push({kind: 'error-line', detail: message.trim()})
+			if (!policy.allowedErrors.some(pattern => pattern.test(message))) violations.push({kind: 'error-line', detail: message.trim()})
 		} else if (level === 'warn' && !policy.allowedWarnings.some(pattern => pattern.test(message))) {
 			violations.push({kind: 'disallowed-warning', detail: message.trim()})
 		}

--- a/scripts/startup/runJourney.ts
+++ b/scripts/startup/runJourney.ts
@@ -76,7 +76,7 @@ export async function runJourney(journey: StartupJourney, ctx: RunContext): Prom
 
 	let profileDir: string
 	try {
-		profileDir = await provisionProfile({kind: journey.profile, baseDir: ctx.baseDir, warmSource: ctx.warmSource, inheritedSource: ctx.inheritedSource})
+		profileDir = await provisionProfile({kind: journey.profile.kind, baseDir: ctx.baseDir, warmSource: ctx.warmSource, inheritedSource: ctx.inheritedSource})
 	} catch (err) {
 		return {...base, error: `profile provisioning failed: ${err instanceof Error ? err.message : String(err)}`, elapsedMs: Date.now() - startedAt}
 	}

--- a/src/renderer/src/components/layout/background/webgl.ts
+++ b/src/renderer/src/components/layout/background/webgl.ts
@@ -53,7 +53,10 @@ function compile(gl: WebGLRenderingContext, type: number, src: string, sceneId: 
 	gl.shaderSource(sh, src)
 	gl.compileShader(sh)
 	if (!gl.getShaderParameter(sh, gl.COMPILE_STATUS)) {
-		console.error(`backdrop shader compile failed for ${sceneId}:`, gl.getShaderInfoLog(sh))
+		// Expected probe outcome — the caller falls back to CSS and logs the reason at
+		// info level. Error severity here would leak into main.log as an error line on
+		// GPU-less runners and fail the startup oracle.
+		console.info(`backdrop shader compile failed for ${sceneId}:`, gl.getShaderInfoLog(sh))
 		gl.deleteShader(sh)
 		return null
 	}
@@ -80,7 +83,7 @@ export function createWebglProgram(gl: WebGLRenderingContext, fragmentShader: st
 	gl.attachShader(prog, frag)
 	gl.linkProgram(prog)
 	if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
-		console.error(`backdrop program link failed for ${sceneId}:`, gl.getProgramInfoLog(prog))
+		console.info(`backdrop program link failed for ${sceneId}:`, gl.getProgramInfoLog(prog))
 		gl.deleteProgram(prog)
 		gl.deleteShader(vert)
 		gl.deleteShader(frag)

--- a/src/renderer/src/components/layout/background/webgl.ts
+++ b/src/renderer/src/components/layout/background/webgl.ts
@@ -53,9 +53,11 @@ function compile(gl: WebGLRenderingContext, type: number, src: string, sceneId: 
 	gl.shaderSource(sh, src)
 	gl.compileShader(sh)
 	if (!gl.getShaderParameter(sh, gl.COMPILE_STATUS)) {
-		// Expected probe outcome — the caller falls back to CSS and logs the reason at
-		// info level. Error severity here would leak into main.log as an error line on
-		// GPU-less runners and fail the startup oracle.
+		// Expected probe outcome, not a regression signal: the GLSL is a repo
+		// constant, so a compile failure on one machine is the driver rejecting
+		// valid shaders. The caller falls back and logs the reason at info; error
+		// severity here turned constrained-runner startups into oracle violations
+		// (nightly run 2, macOS no-gpu).
 		console.info(`backdrop shader compile failed for ${sceneId}:`, gl.getShaderInfoLog(sh))
 		gl.deleteShader(sh)
 		return null
@@ -83,6 +85,7 @@ export function createWebglProgram(gl: WebGLRenderingContext, fragmentShader: st
 	gl.attachShader(prog, frag)
 	gl.linkProgram(prog)
 	if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+		// Same probe-outcome reasoning as the compile failure above.
 		console.info(`backdrop program link failed for ${sceneId}:`, gl.getProgramInfoLog(prog))
 		gl.deleteProgram(prog)
 		gl.deleteShader(vert)

--- a/tests/e2e/startup-journeys.spec.ts
+++ b/tests/e2e/startup-journeys.spec.ts
@@ -5,7 +5,7 @@ import path from 'node:path'
 import {expect, test} from '@playwright/test'
 import {checkVerdicts} from '../../scripts/startup/checkVerdicts.js'
 import {generateInheritedProfile, previousStableTag} from '../../scripts/startup/fetchPreviousRelease.js'
-import {journeysForTier, TIERS_UNDER_TEST, validateTier, type StartupTier} from '../../scripts/startup/journeys.js'
+import {journeysForTier, STARTUP_TIERS, validateJourneySequence, type StartupTier} from '../../scripts/startup/journeys.js'
 import {copyProfilePreservingMtime} from '../../scripts/startup/provisionProfile.js'
 import {runJourney, type JourneyVerdict, type RunContext} from '../../scripts/startup/runJourney.js'
 
@@ -32,7 +32,7 @@ test.setTimeout(35 * 60 * 1000)
 
 function tierFromEnv(): StartupTier {
 	const raw = process.env.ARROXY_STARTUP_TIER ?? 'pr'
-	if (!TIERS_UNDER_TEST.includes(raw as StartupTier)) throw new Error(`startup-journeys: ARROXY_STARTUP_TIER="${raw}" is not one of ${TIERS_UNDER_TEST.join(', ')}`)
+	if (!STARTUP_TIERS.includes(raw as StartupTier)) throw new Error(`startup-journeys: ARROXY_STARTUP_TIER="${raw}" is not one of ${STARTUP_TIERS.join(', ')}`)
 	return raw as StartupTier
 }
 
@@ -57,7 +57,7 @@ test('every declared journey reaches its expected end state with clean logs', as
 	if (archive) fs.mkdirSync(archive, {recursive: true})
 
 	const journeys = journeysForTier(tier)
-	const problems = validateTier(tier)
+	const problems = validateJourneySequence(journeys, tier)
 	if (problems.length > 0) throw new Error(`startup-journeys: tier "${tier}" is not runnable:\n  - ${problems.join('\n  - ')}`)
 
 	// Each journey that some warm journey names as its seeder gets its profile

--- a/tests/e2e/startup-journeys.spec.ts
+++ b/tests/e2e/startup-journeys.spec.ts
@@ -96,6 +96,14 @@ test('every declared journey reaches its expected end state with clean logs', as
 		console.log(`    ${verdict.outcome.toUpperCase()} observed=${verdict.observed} ${verdict.elapsedMs}ms${verdict.error ? ` — ${verdict.error}` : ''}`)
 		for (const violation of verdict.violations) console.log(`    log violation — ${violation.kind}: ${violation.detail}`)
 
+		// The oracle's violation details truncate multi-line entries, so the verdicts
+		// JSON alone cannot triage a red journey — archive the full main.log next to
+		// it or the evidence dies with the runner.
+		if (archive && verdict.profileDir) {
+			const logPath = path.join(verdict.profileDir, 'logs', 'main.log')
+			if (fs.existsSync(logPath)) fs.copyFileSync(logPath, path.join(archive, `main-${journey.id}.log`))
+		}
+
 		if (verdict.outcome === 'pass' && verdict.observed === 'main-screen' && verdict.profileDir && seedIds.has(journey.id) && !warmSources.has(journey.id)) {
 			const snapshot = path.join(baseDir, `warm-${journey.id}`)
 			copyProfilePreservingMtime(verdict.profileDir, snapshot)

--- a/tests/e2e/startup-journeys.spec.ts
+++ b/tests/e2e/startup-journeys.spec.ts
@@ -5,7 +5,7 @@ import path from 'node:path'
 import {expect, test} from '@playwright/test'
 import {checkVerdicts} from '../../scripts/startup/checkVerdicts.js'
 import {generateInheritedProfile, previousStableTag} from '../../scripts/startup/fetchPreviousRelease.js'
-import {journeysForTier, type StartupTier} from '../../scripts/startup/journeys.js'
+import {journeysForTier, TIERS_UNDER_TEST, validateTier, type StartupTier} from '../../scripts/startup/journeys.js'
 import {copyProfilePreservingMtime} from '../../scripts/startup/provisionProfile.js'
 import {runJourney, type JourneyVerdict, type RunContext} from '../../scripts/startup/runJourney.js'
 
@@ -21,19 +21,18 @@ import {runJourney, type JourneyVerdict, type RunContext} from '../../scripts/st
 // unchanged.
 //
 // The whole tier runs inside one test because journeys share ordered state:
-// `fresh-cold` seeds the warm source that `warm-restart` (and the nightly warm
-// journeys) clone, so per-test parallelism would break the seeding chain.
+// each warm journey names the journey whose profile it clones (`profile.from` —
+// `fresh-cold` in every shipped tier), so per-test parallelism would break the
+// seeding chain.
 // Verdict accounting — not Playwright test granularity — is the pass signal:
 // `checkVerdicts` below fails unless every declared journey reported.
 // The tier arrives as `ARROXY_STARTUP_TIER` (pr | release | nightly) rather
 // than a CLI arg so the same spec serves all three workflows.
 test.setTimeout(35 * 60 * 1000)
 
-const TIERS: readonly StartupTier[] = ['pr', 'release', 'nightly']
-
 function tierFromEnv(): StartupTier {
 	const raw = process.env.ARROXY_STARTUP_TIER ?? 'pr'
-	if (!TIERS.includes(raw as StartupTier)) throw new Error(`startup-journeys: ARROXY_STARTUP_TIER="${raw}" is not one of ${TIERS.join(', ')}`)
+	if (!TIERS_UNDER_TEST.includes(raw as StartupTier)) throw new Error(`startup-journeys: ARROXY_STARTUP_TIER="${raw}" is not one of ${TIERS_UNDER_TEST.join(', ')}`)
 	return raw as StartupTier
 }
 
@@ -58,15 +57,17 @@ test('every declared journey reaches its expected end state with clean logs', as
 	if (archive) fs.mkdirSync(archive, {recursive: true})
 
 	const journeys = journeysForTier(tier)
-	if (journeys.length === 0) throw new Error(`startup-journeys: tier "${tier}" selected no journeys`)
+	const problems = validateTier(tier)
+	if (problems.length > 0) throw new Error(`startup-journeys: tier "${tier}" is not runnable:\n  - ${problems.join('\n  - ')}`)
 
-	// The warm journeys need a populated cache, so they are seeded from the first
-	// journey that actually reached the main screen. Journeys are therefore run in
-	// catalog order, with `fresh-cold` ahead of `warm-restart`.
-	const warmSource = path.join(baseDir, 'warm-source')
+	// Each journey that some warm journey names as its seeder gets its profile
+	// snapshotted under its own id. Cloning a fixed `profile-warm` directory in
+	// place would not survive two warm journeys in one tier.
+	const warmSources = new Map<string, string>()
+	const seedIds = new Set(journeys.flatMap(journey => (journey.profile.kind === 'warm' ? [journey.profile.from] : [])))
 
 	let inheritedSource = process.env.ARROXY_INHERITED_PROFILE
-	if (!inheritedSource && journeys.some(journey => journey.profile === 'inherited')) {
+	if (!inheritedSource && journeys.some(journey => journey.profile.kind === 'inherited')) {
 		const tags = execFileSync('git', ['tag', '--list', 'v*'], {encoding: 'utf8'}).split('\n').filter(Boolean)
 		const previous = previousStableTag(tags, process.env.GITHUB_REF_NAME ?? `v${process.env.npm_package_version ?? ''}`)
 		if (!previous) throw new Error('startup-journeys: no previous stable release found for the inherited journey')
@@ -80,20 +81,25 @@ test('every declared journey reaches its expected end state with clean logs', as
 	for (const journey of journeys) {
 		console.log(`\n=== journey: ${journey.id} — ${journey.description}`)
 
-		if (journey.profile === 'warm' && !fs.existsSync(warmSource)) {
-			verdicts.push({id: journey.id, outcome: 'fail', observed: 'none', violations: [], error: 'no warm source: no earlier journey reached the main screen', elapsedMs: 0})
-			console.log('    FAIL — no warm source available')
-			continue
+		let warmSource: string | undefined
+		if (journey.profile.kind === 'warm') {
+			warmSource = warmSources.get(journey.profile.from)
+			if (!warmSource) {
+				verdicts.push({id: journey.id, outcome: 'fail', observed: 'none', violations: [], error: `no warm source: "${journey.profile.from}" did not reach the main screen`, elapsedMs: 0})
+				console.log('    FAIL — no warm source available')
+				continue
+			}
 		}
 
-		const verdict = await runJourney(journey, {...ctx, warmSource: fs.existsSync(warmSource) ? warmSource : undefined})
+		const verdict = await runJourney(journey, {...ctx, warmSource})
 		verdicts.push(verdict)
 		console.log(`    ${verdict.outcome.toUpperCase()} observed=${verdict.observed} ${verdict.elapsedMs}ms${verdict.error ? ` — ${verdict.error}` : ''}`)
 		for (const violation of verdict.violations) console.log(`    log violation — ${violation.kind}: ${violation.detail}`)
 
-		// Seed the warm cache from the first journey that genuinely warmed one.
-		if (verdict.outcome === 'pass' && verdict.observed === 'main-screen' && verdict.profileDir && !fs.existsSync(warmSource)) {
-			copyProfilePreservingMtime(verdict.profileDir, warmSource)
+		if (verdict.outcome === 'pass' && verdict.observed === 'main-screen' && verdict.profileDir && seedIds.has(journey.id) && !warmSources.has(journey.id)) {
+			const snapshot = path.join(baseDir, `warm-${journey.id}`)
+			copyProfilePreservingMtime(verdict.profileDir, snapshot)
+			warmSources.set(journey.id, snapshot)
 		}
 	}
 

--- a/tests/unit/backdrop-webgl-logging.test.ts
+++ b/tests/unit/backdrop-webgl-logging.test.ts
@@ -1,0 +1,59 @@
+import {afterEach, describe, expect, it, vi} from 'vitest'
+import {createWebglProgram} from '../../src/renderer/src/components/layout/background/webgl.js'
+
+// The backdrop probe tries a scratch WebGL program and falls back to CSS when
+// it fails — a compile or link failure is an expected probe outcome, not an
+// error. Logging it at error severity leaks into main.log as an error line and
+// fails the startup oracle on GPU-less runners (issue: macOS no-gpu nightly).
+
+function failingCompileGl() {
+	return {createShader: () => ({}), shaderSource: () => undefined, compileShader: () => undefined, getShaderParameter: () => false, getShaderInfoLog: () => 'simulated compile failure', deleteShader: () => undefined} as unknown as WebGLRenderingContext
+}
+
+function failingLinkGl() {
+	return {
+		createShader: () => ({}),
+		shaderSource: () => undefined,
+		compileShader: () => undefined,
+		getShaderParameter: () => true,
+		deleteShader: () => undefined,
+		createProgram: () => ({}),
+		attachShader: () => undefined,
+		linkProgram: () => undefined,
+		getProgramParameter: () => false,
+		getProgramInfoLog: () => 'simulated link failure',
+		deleteProgram: () => undefined
+	} as unknown as WebGLRenderingContext
+}
+
+describe('backdrop webgl probe logging', () => {
+	let errorSpy: ReturnType<typeof vi.spyOn>
+	let infoSpy: ReturnType<typeof vi.spyOn>
+
+	afterEach(() => {
+		errorSpy.mockRestore()
+		infoSpy.mockRestore()
+	})
+
+	it('logs expected shader-compile failures at info severity, not error', () => {
+		errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+		infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+		const resources = createWebglProgram(failingCompileGl(), 'fragment-source', 'dark-aurora')
+
+		expect(resources).toBeNull()
+		expect(errorSpy).not.toHaveBeenCalled()
+		expect(infoSpy).toHaveBeenCalledWith('backdrop shader compile failed for dark-aurora:', 'simulated compile failure')
+	})
+
+	it('logs expected program-link failures at info severity, not error', () => {
+		errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+		infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+		const resources = createWebglProgram(failingLinkGl(), 'fragment-source', 'dark-aurora')
+
+		expect(resources).toBeNull()
+		expect(errorSpy).not.toHaveBeenCalled()
+		expect(infoSpy).toHaveBeenCalledWith('backdrop program link failed for dark-aurora:', 'simulated link failure')
+	})
+})

--- a/tests/unit/backdrop-webgl-logging.test.ts
+++ b/tests/unit/backdrop-webgl-logging.test.ts
@@ -1,10 +1,11 @@
 import {afterEach, describe, expect, it, vi} from 'vitest'
 import {createWebglProgram} from '../../src/renderer/src/components/layout/background/webgl.js'
 
-// The backdrop probe tries a scratch WebGL program and falls back to CSS when
-// it fails — a compile or link failure is an expected probe outcome, not an
-// error. Logging it at error severity leaks into main.log as an error line and
-// fails the startup oracle on GPU-less runners (issue: macOS no-gpu nightly).
+// The backdrop probe compiles the repo's constant GLSL on the machine's real GL
+// and falls back to CSS when it fails — a compile or link failure is therefore
+// a driver rejection of valid shaders (an expected probe outcome), not a
+// regression signal. Error severity leaked into main.log as error lines and
+// failed the startup oracle on constrained runners (nightly run 2, macOS no-gpu).
 
 function failingCompileGl() {
 	return {createShader: () => ({}), shaderSource: () => undefined, compileShader: () => undefined, getShaderParameter: () => false, getShaderInfoLog: () => 'simulated compile failure', deleteShader: () => undefined} as unknown as WebGLRenderingContext

--- a/tests/unit/startup-journeys.test.ts
+++ b/tests/unit/startup-journeys.test.ts
@@ -20,7 +20,7 @@ describe('journey catalog', () => {
 	it('gates the update-over-previous-version journey on release', () => {
 		const release = journeysForTier('release')
 		expect(release.map(journey => journey.id)).toContain('inherited-update')
-		expect(release.find(journey => journey.id === 'inherited-update')?.profile).toBe('inherited')
+		expect(release.find(journey => journey.id === 'inherited-update')?.profile).toEqual({kind: 'inherited'})
 	})
 
 	it('keeps degraded journeys out of the blocking tiers', () => {

--- a/tests/unit/startup-journeys.test.ts
+++ b/tests/unit/startup-journeys.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it} from 'vitest'
 import {JOURNEYS, journeysForTier} from '../../scripts/startup/journeys.js'
+import {inspectStartupLog} from '../../scripts/startup/logOracle.js'
 
 describe('journey catalog', () => {
 	it('gives every journey a unique id', () => {
@@ -34,5 +35,13 @@ describe('journey catalog', () => {
 
 	it('expects the main screen from every journey it still ships', () => {
 		for (const journey of JOURNEYS) expect(journey.expect).toBe('main-screen')
+	})
+
+	it("waives the gpu-info warning the no-gpu journey's own mode provokes", () => {
+		const noGpu = JOURNEYS.find(journey => journey.id === 'no-gpu')
+		if (!noGpu) throw new Error('no-gpu journey missing from the catalog')
+		const cleanLog = "[2026-08-30 05:22:31.753] [info]  Session started\n[2026-08-30 05:22:52.330] [info]  (warmup)  Warmup branch settled { branch: 'ytDlp', elapsedMs: 100 }\n[2026-08-30 05:22:52.330] [info]  (warmup)  Warmup completed {\n  totalMs: 100,\n  gatedBy: 'ytDlp',\n  branches: { ytDlp: 100 }\n}"
+		const line = '[2026-08-30 05:22:53.000] [warn]  gpu info failed Error: GPU access not allowed. Reason: GPU access is disabled through commandline switch --disable-gpu and --disable-software-rasterizer.'
+		expect(inspectStartupLog(`${cleanLog}\n${line}`, noGpu.logPolicy)).toEqual([])
 	})
 })

--- a/tests/unit/startup-journeys.test.ts
+++ b/tests/unit/startup-journeys.test.ts
@@ -24,10 +24,15 @@ describe('journey catalog', () => {
 	})
 
 	it('keeps degraded journeys out of the blocking tiers', () => {
-		const degraded = JOURNEYS.filter(journey => journey.network === 'offline' || journey.pathContamination)
-		for (const journey of degraded) {
-			expect(journey.tiers).not.toContain('release')
-			expect(journey.tiers).not.toContain('pr')
+		for (const tier of ['pr', 'release'] as const) {
+			for (const journey of journeysForTier(tier)) {
+				expect(journey.pathContamination ?? false).toBe(false)
+				expect(Object.keys(journey.env)).toEqual([])
+			}
 		}
+	})
+
+	it('expects the main screen from every journey it still ships', () => {
+		for (const journey of JOURNEYS) expect(journey.expect).toBe('main-screen')
 	})
 })

--- a/tests/unit/startup-journeys.test.ts
+++ b/tests/unit/startup-journeys.test.ts
@@ -24,17 +24,13 @@ describe('journey catalog', () => {
 		expect(release.find(journey => journey.id === 'inherited-update')?.profile).toEqual({kind: 'inherited'})
 	})
 
-	it('keeps degraded journeys out of the blocking tiers', () => {
+	it('keeps degraded staging — PATH contamination or env overrides — out of the blocking tiers', () => {
 		for (const tier of ['pr', 'release'] as const) {
 			for (const journey of journeysForTier(tier)) {
 				expect(journey.pathContamination ?? false).toBe(false)
 				expect(Object.keys(journey.env)).toEqual([])
 			}
 		}
-	})
-
-	it('expects the main screen from every journey it still ships', () => {
-		for (const journey of JOURNEYS) expect(journey.expect).toBe('main-screen')
 	})
 
 	it("waives the gpu-info warning the no-gpu journey's own mode provokes", () => {

--- a/tests/unit/startup-log-oracle.test.ts
+++ b/tests/unit/startup-log-oracle.test.ts
@@ -10,7 +10,7 @@ const CLEAN_LOG = `[2026-08-30 05:22:31.753] [info]  Session started
   branches: { ytDlp: 20331, ffmpeg: 67 }
 }`
 
-const EMPTY_POLICY = {allowedWarnings: []} as const
+const EMPTY_POLICY = {allowedWarnings: [], allowedErrors: []} as const
 
 describe('inspectStartupLog', () => {
 	it('accepts a clean startup log', () => {
@@ -34,13 +34,23 @@ describe('inspectStartupLog', () => {
 		expect(violations).toContainEqual({kind: 'error-line', detail: 'Warmup failed hard'})
 	})
 
+	it('honours the error allowlist', () => {
+		const violations = inspectStartupLog(`${CLEAN_LOG}\n[2026-08-30 05:22:53.000] [error]  Keychain access denied`, {allowedWarnings: [], allowedErrors: [/Keychain/]})
+		expect(violations).toEqual([])
+	})
+
+	it('still flags an error line the allowlist does not cover', () => {
+		const violations = inspectStartupLog(`${CLEAN_LOG}\n[2026-08-30 05:22:53.000] [error]  Warmup failed hard`, {allowedWarnings: [], allowedErrors: [/Keychain/]})
+		expect(violations).toContainEqual({kind: 'error-line', detail: 'Warmup failed hard'})
+	})
+
 	it('flags warnings not covered by the allowlist', () => {
 		const violations = inspectStartupLog(`${CLEAN_LOG}\n[2026-08-30 05:22:53.000] [warn]  Token warmup threw`, EMPTY_POLICY)
 		expect(violations).toContainEqual({kind: 'disallowed-warning', detail: 'Token warmup threw'})
 	})
 
 	it('honours the allowlist', () => {
-		const violations = inspectStartupLog(`${CLEAN_LOG}\n[2026-08-30 05:22:53.000] [warn]  Token warmup threw`, {allowedWarnings: [/Token warmup threw/]})
+		const violations = inspectStartupLog(`${CLEAN_LOG}\n[2026-08-30 05:22:53.000] [warn]  Token warmup threw`, {allowedWarnings: [/Token warmup threw/], allowedErrors: []})
 		expect(violations).toEqual([])
 	})
 })

--- a/tests/unit/startup-tier-preflight.test.ts
+++ b/tests/unit/startup-tier-preflight.test.ts
@@ -1,15 +1,15 @@
 import {describe, expect, it} from 'vitest'
-import {type StartupJourney, TIERS_UNDER_TEST, validateJourneySequence, validateTier} from '../../scripts/startup/journeys.js'
+import {type StartupJourney, STARTUP_TIERS, validateJourneySequence, validateTier} from '../../scripts/startup/journeys.js'
 
 const CLEAN = {allowedWarnings: [], allowedErrors: []} as const
 
-function journey(id: string, profile: StartupJourney['profile']): StartupJourney {
-	return {id, description: id, profile, env: {}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']}
+function journey(id: string, profile: StartupJourney['profile'], expect: StartupJourney['expect'] = 'main-screen'): StartupJourney {
+	return {id, description: id, profile, env: {}, expect, logPolicy: CLEAN, tiers: ['nightly']}
 }
 
 describe('tier preflight', () => {
 	it('passes for every shipped tier', () => {
-		for (const tier of TIERS_UNDER_TEST) expect(validateTier(tier)).toEqual([])
+		for (const tier of STARTUP_TIERS) expect(validateTier(tier)).toEqual([])
 	})
 
 	it('rejects a warm journey whose seeder is absent from the tier', () => {
@@ -25,6 +25,12 @@ describe('tier preflight', () => {
 
 	it('accepts a warm journey seeded by an earlier journey', () => {
 		expect(validateJourneySequence([journey('fresh-cold', {kind: 'empty'}), journey('no-gpu', {kind: 'warm', from: 'fresh-cold'})], 'nightly')).toEqual([])
+	})
+
+	it('rejects a warm journey whose seeder never reaches the main screen', () => {
+		const problems = validateJourneySequence([journey('blocked', {kind: 'empty'}, 'repair-panel'), journey('warm-after-blocked', {kind: 'warm', from: 'blocked'})], 'nightly')
+		expect(problems).toHaveLength(1)
+		expect(problems[0]).toContain('repair-panel')
 	})
 
 	it('rejects a tier that selects nothing', () => {

--- a/tests/unit/startup-tier-preflight.test.ts
+++ b/tests/unit/startup-tier-preflight.test.ts
@@ -1,0 +1,33 @@
+import {describe, expect, it} from 'vitest'
+import {type StartupJourney, TIERS_UNDER_TEST, validateJourneySequence, validateTier} from '../../scripts/startup/journeys.js'
+
+const CLEAN = {allowedWarnings: []} as const
+
+function journey(id: string, profile: StartupJourney['profile']): StartupJourney {
+	return {id, description: id, profile, env: {}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']}
+}
+
+describe('tier preflight', () => {
+	it('passes for every shipped tier', () => {
+		for (const tier of TIERS_UNDER_TEST) expect(validateTier(tier)).toEqual([])
+	})
+
+	it('rejects a warm journey whose seeder is absent from the tier', () => {
+		const problems = validateJourneySequence([journey('no-gpu', {kind: 'warm', from: 'fresh-cold'})], 'nightly')
+		expect(problems).toHaveLength(1)
+		expect(problems[0]).toContain('fresh-cold')
+	})
+
+	it('rejects a warm journey whose seeder runs after it', () => {
+		const problems = validateJourneySequence([journey('no-gpu', {kind: 'warm', from: 'fresh-cold'}), journey('fresh-cold', {kind: 'empty'})], 'nightly')
+		expect(problems).toHaveLength(1)
+	})
+
+	it('accepts a warm journey seeded by an earlier journey', () => {
+		expect(validateJourneySequence([journey('fresh-cold', {kind: 'empty'}), journey('no-gpu', {kind: 'warm', from: 'fresh-cold'})], 'nightly')).toEqual([])
+	})
+
+	it('rejects a tier that selects nothing', () => {
+		expect(validateJourneySequence([], 'nightly')).toEqual(['tier "nightly" selects no journeys'])
+	})
+})

--- a/tests/unit/startup-tier-preflight.test.ts
+++ b/tests/unit/startup-tier-preflight.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it} from 'vitest'
 import {type StartupJourney, TIERS_UNDER_TEST, validateJourneySequence, validateTier} from '../../scripts/startup/journeys.js'
 
-const CLEAN = {allowedWarnings: []} as const
+const CLEAN = {allowedWarnings: [], allowedErrors: []} as const
 
 function journey(id: string, profile: StartupJourney['profile']): StartupJourney {
 	return {id, description: id, profile, env: {}, expect: 'main-screen', logPolicy: CLEAN, tiers: ['nightly']}

--- a/tests/unit/startup-verdict.test.ts
+++ b/tests/unit/startup-verdict.test.ts
@@ -3,7 +3,7 @@ import {describe, expect, it} from 'vitest'
 import type {StartupJourney} from '../../scripts/startup/journeys.js'
 import {buildJourneyEnv} from '../../scripts/startup/runJourney.js'
 
-const BASE: StartupJourney = {id: 'test', description: 'test', profile: {kind: 'empty'}, env: {}, expect: 'main-screen', logPolicy: {allowedWarnings: []}, tiers: ['nightly']}
+const BASE: StartupJourney = {id: 'test', description: 'test', profile: {kind: 'empty'}, env: {}, expect: 'main-screen', logPolicy: {allowedWarnings: [], allowedErrors: []}, tiers: ['nightly']}
 
 const CTX = {packagedExe: '/app/Arroxy', baseDir: '/tmp/base'}
 

--- a/tests/unit/startup-verdict.test.ts
+++ b/tests/unit/startup-verdict.test.ts
@@ -3,7 +3,7 @@ import {describe, expect, it} from 'vitest'
 import type {StartupJourney} from '../../scripts/startup/journeys.js'
 import {buildJourneyEnv} from '../../scripts/startup/runJourney.js'
 
-const BASE: StartupJourney = {id: 'test', description: 'test', profile: 'empty', env: {}, expect: 'main-screen', logPolicy: {allowedWarnings: []}, tiers: ['nightly']}
+const BASE: StartupJourney = {id: 'test', description: 'test', profile: {kind: 'empty'}, env: {}, expect: 'main-screen', logPolicy: {allowedWarnings: []}, tiers: ['nightly']}
 
 const CTX = {packagedExe: '/app/Arroxy', baseDir: '/tmp/base'}
 


### PR DESCRIPTION
## What was unverified before this branch

- **The nightly was red by construction.** The `nightly` tier declared three `warm` journeys and no journey that seeds a warm profile, so `index-off`, `no-gpu` and `contaminated-path` failed with "no warm source" before launching anything.
- **`offline-no-cache` was declared but unenforceable** — `network: 'offline'` was data nothing enforced; the journey passed or failed on runner networking.
- **Two conflicting soak criteria** for wiring `startup-gate` (`release.yml`'s PR-tier note vs decision 5's tag-run criterion), and ADR 0006's argument assumed a wiring that does not exist.
- **Nothing read the nightly** — a non-blocking job nobody reads is the silent-green gap in another costume.
- **The log oracle had no error escape hatch** — survivable Linux-only, wrong for a blocking three-platform publish gate.

## What changed

- `profile` is now a discriminated union: `{kind: 'warm', from: 'fresh-cold'}` names its seeder, and `validateTier` preflights every tier (unit-tested) so "warm without a seeder" fails in seconds instead of after burning CI runners.
- `fresh-cold` joins the nightly tier — it seeds the warm journeys and restores a real cold start on Windows and macOS while `startup-gate` is unwired.
- `offline-no-cache` is deleted rather than left unenforced; portable egress blocking is recorded as its own spike (Known gaps).
- `LogPolicy.allowedErrors` mirrors `allowedWarnings` (both required, strict by default).
- A `notify` job opens or comments on a `startup-nightly` issue when the nightly fails — same-day signal (verified live: #190 fired on runs 1–3).
- Per-journey `main.log` is archived into CI artifacts; the verdicts JSON alone cannot triage multi-line log violations.
- Backdrop probe compile/link failures log at info instead of error: an expected probe outcome was surfacing as error lines in main.log on GPU-less runners (caught by the nightly on macOS).

## Evidence

Four dispatched nightlies tell the story: run 1 exposed the gpu-info warning gap (fixed: per-journey waiver), run 2 proved Linux + Windows and exposed the backdrop severity defect on macOS (fixed: info severity), run 3 proved macOS + Linux while Windows flaked untriably (led to main.log archiving), and run 4 is fully green — **15/15 verdicts on all three platforms**:

https://github.com/antonio-orionus/Arroxy/actions/runs/33309036291

## Deliberately not done

- `startup-gate` stays unwired into `prepare-release` — that is the soak's outcome, not this change. The single criterion (this job green on all three platforms across three consecutive tags, beta tags count; review date 2026-10-01) now lives verbatim in `release.yml`, `startup-verification.md` decision 5, and ADR 0006.
- Not added to branch protection — it is tag-only (ADR 0006).

Fixes #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-facing changes
- Makes the nightly startup tier executable across Linux, Windows, and macOS.
- Adds `fresh-cold` coverage and removes the unenforced `offline-no-cache` journey.
- Opens or updates a `startup-nightly` issue on failure and closes it after recovery.
- Archives each journey’s `main.log` for CI triage.
- Documents the three-platform, three-consecutive-tag soak criterion, including beta tags.

## Internal and refactor changes
- Adds named warm-profile seeders and tier preflight validation.
- Adds per-journey error allowlists to the startup log oracle.
- Downgrades expected WebGL backdrop probe failures from error to info.
- Updates startup journey tests, log-oracle tests, WebGL logging tests, and tier-preflight tests.

## Risk areas
- No dependency or IPC changes are reported.
- WebGL probe logging changes affect diagnostics only. Unexpected errors remain detectable through the log oracle.
- `startup-gate` remains unwired into `prepare-release` and branch protection. Release blocking behavior does not change.
- Nightly issue notification can create, update, or close GitHub issues and requires the workflow token permissions to remain correct.

## Tests and checks
- Run the unit test suite, including:
  - `tests/unit/startup-tier-preflight.test.ts`
  - `tests/unit/startup-journeys.test.ts`
  - `tests/unit/startup-log-oracle.test.ts`
  - `tests/unit/startup-verdict.test.ts`
  - `tests/unit/backdrop-webgl-logging.test.ts`
- Run the startup journey E2E suite on Linux, Windows, and macOS.
- Verify nightly workflow issue creation, update, and recovery behavior.
- Verify archived `main.log` artifacts.
- Verify release workflow documentation and `startup-gate` wiring remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->