### PR TITLE
fix(probe): recover real titles for VHX (Vimeo OTT) embeds reported as 'Untitled'

### DIFF
--- a/src/main/services/ProbeService.ts
+++ b/src/main/services/ProbeService.ts
@@ -16,7 +16,7 @@ import {siteForExtractor, siteForUrl, type Site} from '@shared/sites/index.js'
 import {YOUTUBE_SINGLE_VIDEO_PLAYER_CLIENTS} from '@shared/youtubePlayerClients.js'
 import {YtDlp} from './YtDlp.js'
 import type {ProbeInfoJsonCache} from './ProbeInfoJsonCache.js'
-import {defaultVhxTitleFetcher, deriveRecoveredTitle, extractPageTitleMeta, isLikelyParentPage, isVhxEmbedExtractor, isVhxSentinelTitle, smuggledRefererOf, type VhxTitleFetcher} from './vhxTitleRecovery.js'
+import {defaultVhxTitleFetcher, deriveRecoveredTitle, extractPageTitleMeta, isLikelyParentPage, isVhxEmbedExtractor, isVhxSentinelTitle, patchInfoJsonTitle, smuggledRefererOf, type VhxTitleFetcher} from './vhxTitleRecovery.js'
 
 const logger = log.scope('probe')
 
@@ -513,7 +513,7 @@ export class ProbeService extends EventEmitter {
 						let recovered: string | null = null
 						try {
 							const html = await this.vhxTitleFetcher(parentUrl, controller.signal)
-							recovered = html === null ? null : deriveRecoveredTitle(extractPageTitleMeta(html), parentUrl)
+							if (!controller.signal.aborted) recovered = html === null ? null : deriveRecoveredTitle(extractPageTitleMeta(html), parentUrl)
 						} catch {
 							// Fetcher failure is non-fatal — the sentinel title stays.
 						}
@@ -667,17 +667,6 @@ function formatCount(info: InfoDict): number {
 	if (isPlaylistLike(info)) return info.entries.length
 	const v = info as VideoInfo
 	return v.formats?.length ?? 0
-}
-
-// The download phase feeds this cached JSON back to yt-dlp via
-// --load-info-json, so the filename template's %(title)s resolves from here —
-// patching the raw dict (not just the ProbeResult) is what actually fixes the
-// output filename. Returns the input unchanged on any shape mismatch.
-function patchInfoJsonTitle(raw: unknown, title: string): unknown {
-	if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return raw
-	const record = raw as Record<string, unknown>
-	if (typeof record.title !== 'string' || record.title.length === 0) return raw
-	return {...record, title}
 }
 
 function playlistScopeRequestForLog(scope: PlaylistScope | undefined): PlaylistScopeRequestLog {

--- a/src/main/services/ProbeService.ts
+++ b/src/main/services/ProbeService.ts
@@ -16,6 +16,7 @@ import {siteForExtractor, siteForUrl, type Site} from '@shared/sites/index.js'
 import {YOUTUBE_SINGLE_VIDEO_PLAYER_CLIENTS} from '@shared/youtubePlayerClients.js'
 import {YtDlp} from './YtDlp.js'
 import type {ProbeInfoJsonCache} from './ProbeInfoJsonCache.js'
+import {defaultVhxTitleFetcher, deriveRecoveredTitle, extractPageTitleMeta, isLikelyParentPage, isVhxEmbedExtractor, isVhxSentinelTitle, smuggledRefererOf, type VhxTitleFetcher} from './vhxTitleRecovery.js'
 
 const logger = log.scope('probe')
 
@@ -54,6 +55,12 @@ interface ProbeAttemptSuccess {
 }
 
 type ProbeAttemptResult = {kind: 'success'; data: ProbeAttemptSuccess} | {kind: 'failure'; error: ProbeError; errorCategory: ProbeFailureCategory}
+
+// Options bag so unit tests can inject a deterministic parent-page fetcher;
+// production leaves it undefined and gets the real HTTP fetcher.
+export interface ProbeServiceOptions {
+	vhxTitleFetcher?: VhxTitleFetcher
+}
 
 function sanitizeSubtitleMap(raw: Record<string, YtDlpSubtitleTrack[]> | undefined, opts: {isAutomaticCaptions: boolean; site: Site}): SubtitleMap {
 	if (!raw) return {}
@@ -414,12 +421,16 @@ export class ProbeService extends EventEmitter {
 	// them all at once. probe() registers + deregisters its controller.
 	private inFlight = new Set<AbortController>()
 
+	private readonly vhxTitleFetcher: VhxTitleFetcher
+
 	constructor(
 		private readonly ytDlp: YtDlp,
 		private readonly mockMode = false,
-		private readonly probeInfoJsonCache?: ProbeInfoJsonCache
+		private readonly probeInfoJsonCache?: ProbeInfoJsonCache,
+		options?: ProbeServiceOptions
 	) {
 		super()
+		this.vhxTitleFetcher = options?.vhxTitleFetcher ?? defaultVhxTitleFetcher
 	}
 
 	// Abort every in-flight probe. Renderer calls this when the user changes the
@@ -490,7 +501,30 @@ export class ProbeService extends EventEmitter {
 					emitFailure('content_unavailable')
 					return fail<ProbeResult, ProbeError>({kind: 'other', code: 'no_formats', message: 'Probe returned no formats'})
 				}
-				const probeInfoJsonRef = playlistMode === 'video' ? await this.probeInfoJsonCache?.write(final.raw, {videoId: typeof video.id === 'string' ? video.id : null}) : undefined
+				// VHX (Vimeo OTT) embeds surface the literal 'Untitled' sentinel and
+				// yt-dlp's GenericIE merge keeps the embed's fields over the parent
+				// page's, so the real page title is lost. Recover it from the parent
+				// page's curated preview title (og:title / twitter:title). Any miss
+				// keeps the sentinel — the download proceeds exactly as before.
+				let rawForCache = final.raw
+				if (mapped.kind === 'video' && isVhxSentinelTitle(mapped.title) && isVhxEmbedExtractor(mapped.extractor, mapped.extractorKey)) {
+					const parentUrl = smuggledRefererOf(video.webpage_url) ?? (isLikelyParentPage(url) ? url : null)
+					if (parentUrl) {
+						let recovered: string | null = null
+						try {
+							const html = await this.vhxTitleFetcher(parentUrl, controller.signal)
+							recovered = html === null ? null : deriveRecoveredTitle(extractPageTitleMeta(html), parentUrl)
+						} catch {
+							// Fetcher failure is non-fatal — the sentinel title stays.
+						}
+						if (recovered && recovered !== mapped.title) {
+							mapped = {...mapped, title: recovered}
+							rawForCache = patchInfoJsonTitle(final.raw, recovered)
+							logger.info('Recovered VHX title from parent page', {url, parentUrl, title: recovered})
+						}
+					}
+				}
+				const probeInfoJsonRef = playlistMode === 'video' ? await this.probeInfoJsonCache?.write(rawForCache, {videoId: typeof video.id === 'string' ? video.id : null}) : undefined
 				if (probeInfoJsonRef) {
 					const probeInfoJsonPath = await this.probeInfoJsonCache?.resolve(probeInfoJsonRef)
 					logger.info('Probe info-json cached', {url, videoId: probeInfoJsonRef.videoId ?? null, probeInfoJsonRef, probeInfoJsonPath: probeInfoJsonPath ?? null})
@@ -633,6 +667,17 @@ function formatCount(info: InfoDict): number {
 	if (isPlaylistLike(info)) return info.entries.length
 	const v = info as VideoInfo
 	return v.formats?.length ?? 0
+}
+
+// The download phase feeds this cached JSON back to yt-dlp via
+// --load-info-json, so the filename template's %(title)s resolves from here —
+// patching the raw dict (not just the ProbeResult) is what actually fixes the
+// output filename. Returns the input unchanged on any shape mismatch.
+function patchInfoJsonTitle(raw: unknown, title: string): unknown {
+	if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return raw
+	const record = raw as Record<string, unknown>
+	if (typeof record.title !== 'string' || record.title.length === 0) return raw
+	return {...record, title}
 }
 
 function playlistScopeRequestForLog(scope: PlaylistScope | undefined): PlaylistScopeRequestLog {

--- a/src/main/services/vhxTitleRecovery.ts
+++ b/src/main/services/vhxTitleRecovery.ts
@@ -126,16 +126,6 @@ export function isLikelyParentPage(url: string | undefined): boolean {
 }
 
 /**
- * Pages suffix their preview titles with branding ("Video Title - Free Videos
- * - Trilogy Plus", "Video Title (Site)"). Trim a trailing site-name segment so
- * the recovered title stays filename-friendly. No-op when the site name is not
- * a suffix.
- */
-export function trimSiteSuffix(title: string, siteName: string): string {
-	return trimTrailingKnownSegments(title, [siteName])
-}
-
-/**
  * VHX preview titles follow "{video} - {collection} - {site}". The site name
  * comes from og:site_name and the collection is identifiable from the parent
  * URL path (e.g. /free-videos/videos/slug → "free videos"). Trim trailing
@@ -187,6 +177,17 @@ export function deriveRecoveredTitle(meta: VhxPageTitleMeta | null, parentUrl: s
 	if (!raw || raw.length === 0) return null
 	const trimmed = trimTrailingKnownSegments(raw, [meta?.siteName ?? '', ...parentPathSlugs(parentUrl)])
 	return trimmed.length > 0 ? trimmed : null
+}
+
+// The download phase feeds the cached probe info JSON back to yt-dlp via
+// --load-info-json, so the filename template's %(title)s resolves from here —
+// patching the raw dict (not just the ProbeResult) is what actually fixes the
+// output filename. Returns the input unchanged on any shape mismatch.
+export function patchInfoJsonTitle(raw: unknown, title: string): unknown {
+	if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return raw
+	const record = raw as Record<string, unknown>
+	if (typeof record.title !== 'string' || record.title.length === 0) return raw
+	return {...record, title}
 }
 
 /** Production fetcher: browser-ish UA (VHX serves og:* meta to logged-out crawlers), short timeout, no retry fan-out. */

--- a/src/main/services/vhxTitleRecovery.ts
+++ b/src/main/services/vhxTitleRecovery.ts
@@ -1,0 +1,201 @@
+// Recovery for VHX (Vimeo OTT) "Untitled" video titles.
+//
+// Sites built on Vimeo OTT (vhx.tv — e.g. trilogyplus.com) embed their player
+// from embed.vhx.tv. yt-dlp's VHXEmbedIE reads the VHX player config, whose
+// video.title is often unset, and falls back to the literal sentinel 'Untitled'
+// (codified in VHXEmbedIE's own tests). Because GenericIE merges the parent
+// page's metadata *under* the embed result (merge_dicts keeps the embed's
+// non-empty fields), the real page title — present in the parent page's
+// og:title — is discarded.
+//
+// Arroxy-side recovery: when a probe resolves through the VHX embed extractor
+// with the sentinel title, fetch the parent page (the referer yt-dlp smuggles
+// into webpage_url) and read its curated preview title (og:title /
+// twitter:title). Deliberately NOT a plain <title> fallback: logged-out fetches
+// of paywalled VHX pages can return generic marketing titles there, while
+// og:* meta has been observed to stay video-specific.
+//
+// Failure is always non-fatal: any miss keeps the sentinel and the download
+// proceeds exactly as before.
+
+import fetch from 'make-fetch-happen'
+
+const VHX_UNTITLED_SENTINEL = 'Untitled'
+
+/** Extractor keys/ids under which yt-dlp surfaces VHX embed extraction. */
+const VHX_EXTRACTOR_KEYS = new Set(['VHXEmbed'])
+const VHX_EXTRACTOR_IDS = ['vhx:']
+const VHX_EMBED_HOST_RE = /(^|\.)embed\.vhx\.tv$/i
+const FETCH_TIMEOUT_MS = 10_000
+const BROWSER_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36'
+
+/** Returns the page HTML, or null when the fetch fails or the response is not usable. Never throws. */
+export type VhxTitleFetcher = (url: string, signal: AbortSignal) => Promise<string | null>
+
+export interface VhxPageTitleMeta {
+	title: string | null
+	siteName: string | null
+}
+
+export function isVhxSentinelTitle(title: string): boolean {
+	return title === VHX_UNTITLED_SENTINEL
+}
+
+export function isVhxEmbedExtractor(extractor: string | undefined, extractorKey: string | undefined): boolean {
+	if (extractorKey !== undefined && VHX_EXTRACTOR_KEYS.has(extractorKey)) return true
+	return extractor !== undefined && VHX_EXTRACTOR_IDS.some(prefix => extractor.startsWith(prefix))
+}
+
+function decodeHtmlEntities(input: string): string {
+	return input.replace(/&(?:#[xX]([0-9a-fA-F]+)|#(\d+)|([a-zA-Z]+));/g, (match: string, hex: string | undefined, dec: string | undefined, named: string | undefined): string => {
+		if (hex) {
+			const code = Number.parseInt(hex, 16)
+			return Number.isFinite(code) && code > 0 ? String.fromCodePoint(code) : match
+		}
+		if (dec) {
+			const code = Number.parseInt(dec, 10)
+			return Number.isFinite(code) && code > 0 ? String.fromCodePoint(code) : match
+		}
+		const entity = named !== undefined ? NAMED_ENTITIES[named.toLowerCase()] : undefined
+		return entity ?? match
+	})
+}
+
+const NAMED_ENTITIES: Record<string, string> = {amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' '}
+
+// Content-before-name order is handled by matching the whole <meta> tag first,
+// then pulling the content attribute out of it.
+function metaContent(html: string, key: 'og:title' | 'twitter:title' | 'og:site_name'): string | null {
+	for (const tag of html.matchAll(META_TAG_PATTERNS[key])) {
+		const content = /content=["']([^"']*)["']/i.exec(tag[0])
+		if (content?.[1]) return decodeHtmlEntities(content[1]).trim() || null
+	}
+	return null
+}
+
+// Literal, precompiled pattern per key — keys are a closed set, so no dynamic
+// RegExp construction is needed (and oxlint's non-literal-RegExp rule stays
+// satisfied). Regexes carry the `g` flag for matchAll and are stateless because
+// matchAll does not mutate lastIndex.
+const META_TAG_PATTERNS: Record<'og:title' | 'twitter:title' | 'og:site_name', RegExp> = {'og:title': /<meta[^>]+(?:property|name)=["']og:title["'][^>]*>/gi, 'twitter:title': /<meta[^>]+(?:property|name)=["']twitter:title["'][^>]*>/gi, 'og:site_name': /<meta[^>]+(?:property|name)=["']og:site_name["'][^>]*>/gi}
+
+/**
+ * Curated preview title from the parent page. og:title and twitter:title only —
+ * see the module comment for why <title> is intentionally not a source.
+ */
+export function extractPageTitleMeta(html: string): VhxPageTitleMeta {
+	return {title: metaContent(html, 'og:title') ?? metaContent(html, 'twitter:title'), siteName: metaContent(html, 'og:site_name')}
+}
+
+/**
+ * yt-dlp smuggles the delegating page's referer into the embed URL's
+ * `#__youtubedl_smuggle=` fragment — either as `{referer}` or
+ * `{http_headers: {Referer}}`. Returns null when absent, unparseable, or when
+ * the referer is the VHX embed host itself (a direct embed hit has no parent
+ * page to consult).
+ */
+export function smuggledRefererOf(url: string | undefined): string | null {
+	if (!url) return null
+	const marker = '#__youtubedl_smuggle='
+	const at = url.indexOf(marker)
+	if (at === -1) return null
+	try {
+		const data = JSON.parse(decodeURIComponent(url.slice(at + marker.length))) as {referer?: unknown; http_headers?: {Referer?: unknown}}
+		const candidate = typeof data.referer === 'string' ? data.referer : typeof data.http_headers?.Referer === 'string' ? data.http_headers.Referer : null
+		if (!candidate || !/^https?:\/\//i.test(candidate)) return null
+		let host: string | null = null
+		try {
+			host = new URL(candidate).hostname
+		} catch {
+			return null
+		}
+		return VHX_EMBED_HOST_RE.test(host) ? null : candidate
+	} catch {
+		return null
+	}
+}
+
+/** True when the URL is a page (not the VHX embed itself) worth consulting for a title. */
+export function isLikelyParentPage(url: string | undefined): boolean {
+	if (!url || !/^https?:\/\//i.test(url)) return false
+	try {
+		return !VHX_EMBED_HOST_RE.test(new URL(url).hostname)
+	} catch {
+		return false
+	}
+}
+
+/**
+ * Pages suffix their preview titles with branding ("Video Title - Free Videos
+ * - Trilogy Plus", "Video Title (Site)"). Trim a trailing site-name segment so
+ * the recovered title stays filename-friendly. No-op when the site name is not
+ * a suffix.
+ */
+export function trimSiteSuffix(title: string, siteName: string): string {
+	return trimTrailingKnownSegments(title, [siteName])
+}
+
+/**
+ * VHX preview titles follow "{video} - {collection} - {site}". The site name
+ * comes from og:site_name and the collection is identifiable from the parent
+ * URL path (e.g. /free-videos/videos/slug → "free videos"). Trim trailing
+ * "- Segment" / "(Segment)" parts that match any known name, normalized
+ * (case-insensitive, hyphen/underscore ≈ space). Never empties the title.
+ */
+function trimTrailingKnownSegments(title: string, knownNames: readonly string[]): string {
+	let current = title.trim()
+	const known = knownNames.map(normalizeName).filter(name => name.length > 0)
+	for (let i = 0; i < 3; i++) {
+		const dashMatch = /\s*[-–]\s*([^-–()]+)$/.exec(current)
+		const parenMatch = /\s*\(\s*([^()]+?)\s*\)\s*$/.exec(current)
+		const match = dashMatch ?? parenMatch
+		if (!match) break
+		const segment = match[1].trim()
+		if (segment.length === 0 || !known.includes(normalizeName(segment))) break
+		const remaining = current.slice(0, match.index).trim()
+		if (remaining.length === 0) break
+		current = remaining
+	}
+	return current
+}
+
+function normalizeName(input: string): string {
+	return input
+		.toLowerCase()
+		.replace(/[-_]+/g, ' ')
+		.replace(/[''.,:;!?]+/g, '')
+		.replace(/\s+/g, ' ')
+		.trim()
+}
+
+/** Path slugs of a page URL, e.g. /free-videos/videos/x → ["free videos", "videos", "x"]. */
+function parentPathSlugs(url: string): string[] {
+	try {
+		const segments = new URL(url).pathname.split('/').filter(Boolean)
+		return segments.map(segment => normalizeName(decodeURIComponent(segment))).filter(name => name.length > 0)
+	} catch {
+		return []
+	}
+}
+
+/**
+ * Full recovery pipeline: curated preview title → site-suffix + URL-anchored
+ * collection-segment trim. Returns null when the page yields no usable title.
+ */
+export function deriveRecoveredTitle(meta: VhxPageTitleMeta | null, parentUrl: string): string | null {
+	const raw = meta?.title ?? null
+	if (!raw || raw.length === 0) return null
+	const trimmed = trimTrailingKnownSegments(raw, [meta?.siteName ?? '', ...parentPathSlugs(parentUrl)])
+	return trimmed.length > 0 ? trimmed : null
+}
+
+/** Production fetcher: browser-ish UA (VHX serves og:* meta to logged-out crawlers), short timeout, no retry fan-out. */
+export const defaultVhxTitleFetcher: VhxTitleFetcher = async (url, signal) => {
+	try {
+		const res = await fetch(url, {headers: {'user-agent': BROWSER_UA, accept: 'text/html'}, timeout: FETCH_TIMEOUT_MS, redirect: 'follow', retry: 1, signal} as fetch.FetchOptions)
+		if (!res.ok) return null
+		return await res.text()
+	} catch {
+		return null
+	}
+}

--- a/src/main/services/vhxTitleRecovery.ts
+++ b/src/main/services/vhxTitleRecovery.ts
@@ -26,7 +26,9 @@ const VHX_UNTITLED_SENTINEL = 'Untitled'
 const VHX_EXTRACTOR_KEYS = new Set(['VHXEmbed'])
 const VHX_EXTRACTOR_IDS = ['vhx:']
 const VHX_EMBED_HOST_RE = /(^|\.)embed\.vhx\.tv$/i
+const IPV4_RE = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
 const FETCH_TIMEOUT_MS = 10_000
+const FETCH_MAX_REDIRECTS = 5
 const BROWSER_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36'
 
 /** Returns the page HTML, or null when the fetch fails or the response is not usable. Never throws. */
@@ -115,6 +117,27 @@ export function smuggledRefererOf(url: string | undefined): string | null {
 	}
 }
 
+/** True when the host must not be fetched: loopback, private, or link-local ranges (name-level check only). */
+export function isPrivateHostname(hostname: string): boolean {
+	const host = hostname.toLowerCase().replace(/^\[|\]$/g, '')
+	if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.internal')) return true
+	if (IPV4_RE.test(host)) {
+		const parts = host.split('.').map(Number)
+		const [a, b] = [parts[0], parts[1]]
+		if (a === 0 || a === 10 || a === 127) return true
+		if (a === 169 && b === 254) return true
+		if (a === 192 && b === 168) return true
+		if (a === 172 && b >= 16 && b <= 31) return true
+		return false
+	}
+	if (host === '::' || host === '::1') return true
+	if (host.startsWith('fc') || host.startsWith('fd')) return true // fc00::/7 unique-local
+	if (host.startsWith('fe8') || host.startsWith('fe9') || host.startsWith('fea') || host.startsWith('feb')) return true // fe80::/10 link-local
+	const v4mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(host)
+	if (v4mapped) return isPrivateHostname(v4mapped[1])
+	return false
+}
+
 /** True when the URL is a page (not the VHX embed itself) worth consulting for a title. */
 export function isLikelyParentPage(url: string | undefined): boolean {
 	if (!url || !/^https?:\/\//i.test(url)) return false
@@ -158,11 +181,14 @@ function normalizeName(input: string): string {
 		.trim()
 }
 
-/** Path slugs of a page URL, e.g. /free-videos/videos/x → ["free videos", "videos", "x"]. */
+/** Path slugs of a page URL, e.g. /free-videos/videos/x → ["free videos", "videos"]. The terminal segment is the video's own slug, never a collection name, so it is excluded from removable segments. */
 function parentPathSlugs(url: string): string[] {
 	try {
 		const segments = new URL(url).pathname.split('/').filter(Boolean)
-		return segments.map(segment => normalizeName(decodeURIComponent(segment))).filter(name => name.length > 0)
+		return segments
+			.slice(0, -1)
+			.map(segment => normalizeName(decodeURIComponent(segment)))
+			.filter(name => name.length > 0)
 	} catch {
 		return []
 	}
@@ -190,12 +216,38 @@ export function patchInfoJsonTitle(raw: unknown, title: string): unknown {
 	return {...record, title}
 }
 
+// Redirects are followed manually so every hop's host can be checked against
+// isPrivateHostname before requesting it (make-fetch-happen's 'follow' would
+// chase cross-origin redirects into loopback/private addresses unchecked).
+// Name-level check only: a public hostname resolving to a private IP
+// (DNS rebinding) is NOT caught — acceptable residual risk here, because the
+// fetch is a blind GET whose body is parsed locally for og:title only.
+async function fetchFollowingSafeRedirects(url: string, signal: AbortSignal): Promise<string | null> {
+	let current = url
+	for (let hop = 0; hop <= FETCH_MAX_REDIRECTS; hop++) {
+		const res = await fetch(current, {headers: {'user-agent': BROWSER_UA, accept: 'text/html'}, timeout: FETCH_TIMEOUT_MS, redirect: 'manual', retry: 0, signal} as fetch.FetchOptions)
+		if (res.status >= 300 && res.status < 400) {
+			const location = res.headers.get('location')
+			if (!location) return null
+			try {
+				current = new URL(location, current).toString()
+			} catch {
+				return null
+			}
+			if (!/^https?:\/\//i.test(current) || isPrivateHostname(new URL(current).hostname)) return null
+			continue
+		}
+		if (!res.ok) return null
+		return await res.text()
+	}
+	return null
+}
+
 /** Production fetcher: browser-ish UA (VHX serves og:* meta to logged-out crawlers), short timeout, no retry fan-out. */
 export const defaultVhxTitleFetcher: VhxTitleFetcher = async (url, signal) => {
 	try {
-		const res = await fetch(url, {headers: {'user-agent': BROWSER_UA, accept: 'text/html'}, timeout: FETCH_TIMEOUT_MS, redirect: 'follow', retry: 1, signal} as fetch.FetchOptions)
-		if (!res.ok) return null
-		return await res.text()
+		if (!/^https?:\/\//i.test(url) || isPrivateHostname(new URL(url).hostname)) return null
+		return await fetchFollowingSafeRedirects(url, signal)
 	} catch {
 		return null
 	}

--- a/src/main/services/vhxTitleRecovery.ts
+++ b/src/main/services/vhxTitleRecovery.ts
@@ -117,9 +117,12 @@ export function smuggledRefererOf(url: string | undefined): string | null {
 	}
 }
 
-/** True when the host must not be fetched: loopback, private, or link-local ranges (name-level check only). */
+/** True when the host must not be fetched: loopback, private, or link-local ranges (name-level check only, terminal-dot aliases canonicalized). */
 export function isPrivateHostname(hostname: string): boolean {
-	const host = hostname.toLowerCase().replace(/^\[|\]$/g, '')
+	const host = hostname
+		.toLowerCase()
+		.replace(/^\[|\]$/g, '')
+		.replace(/\.+$/, '')
 	if (host === 'localhost' || host.endsWith('.localhost') || host.endsWith('.internal')) return true
 	if (IPV4_RE.test(host)) {
 		const parts = host.split('.').map(Number)
@@ -219,9 +222,10 @@ export function patchInfoJsonTitle(raw: unknown, title: string): unknown {
 // Redirects are followed manually so every hop's host can be checked against
 // isPrivateHostname before requesting it (make-fetch-happen's 'follow' would
 // chase cross-origin redirects into loopback/private addresses unchecked).
-// Name-level check only: a public hostname resolving to a private IP
-// (DNS rebinding) is NOT caught — acceptable residual risk here, because the
-// fetch is a blind GET whose body is parsed locally for og:title only.
+// Name-level check only, by design: a public hostname resolving to a private
+// IP (DNS rebinding) is NOT caught. Accepted residual risk — this is a blind
+// GET whose body is parsed locally for og:title, and yt-dlp itself applies no
+// such restriction when fetching the same user-supplied URL during the probe.
 async function fetchFollowingSafeRedirects(url: string, signal: AbortSignal): Promise<string | null> {
 	let current = url
 	for (let hop = 0; hop <= FETCH_MAX_REDIRECTS; hop++) {

--- a/tests/unit/probe-service-vhx-title.test.ts
+++ b/tests/unit/probe-service-vhx-title.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment node
+import {EventEmitter} from 'node:events'
+import {describe, expect, it, vi, beforeEach} from 'vitest'
+import {ProbeService} from '@main/services/ProbeService.js'
+import {YtDlp} from '@main/services/YtDlp.js'
+import {smuggledRefererOf, trimSiteSuffix} from '@main/services/vhxTitleRecovery.js'
+import type {VhxTitleFetcher} from '@main/services/vhxTitleRecovery.js'
+import type {ProbeInfoJsonCache} from '@main/services/ProbeInfoJsonCache.js'
+
+vi.mock('@main/utils/process', async importOriginal => {
+	const actual = await importOriginal<typeof import('@main/utils/process.js')>()
+	return {...actual, spawnYtDlp: vi.fn()}
+})
+
+vi.mock('@main/services/ytDlpJsRuntime', async importOriginal => {
+	const actual = await importOriginal<typeof import('@main/services/ytDlpJsRuntime.js')>()
+	return {...actual, probeElectronNodeRuntime: vi.fn()}
+})
+
+import {spawnYtDlp} from '@main/utils/process.js'
+import {probeElectronNodeRuntime} from '@main/services/ytDlpJsRuntime.js'
+
+function makeFakeProcessEmitting(stdout: string, exitCode = 0): EventEmitter & {stdout: EventEmitter; stderr: EventEmitter; kill: ReturnType<typeof vi.fn>} {
+	const proc = Object.assign(new EventEmitter(), {stdout: new EventEmitter(), stderr: new EventEmitter(), kill: vi.fn()})
+	setTimeout(() => {
+		proc.stdout.emit('data', Buffer.from(stdout))
+		proc.emit('close', exitCode)
+	}, 5)
+	return proc
+}
+
+function makeYtDlp(): YtDlp {
+	const tokenService = {mintTokenForUrl: vi.fn().mockResolvedValue({token: 't', visitorData: 'vd'}), invalidateCache: vi.fn()}
+	const binaryManager = {ensureYtDlp: vi.fn().mockResolvedValue('/fake/yt-dlp'), ensureFFmpeg: vi.fn().mockResolvedValue('/fake/ffmpeg'), ensureFFprobe: vi.fn().mockResolvedValue(null)}
+	const settingsStore = {get: vi.fn().mockResolvedValue({common: {}, single: {}, playlist: {}})}
+	return new YtDlp(binaryManager as never, tokenService as never, settingsStore as never)
+}
+
+const PARENT_URL = 'https://www.trilogyplus.com/free-videos/videos/scammer-sobs-during-police-interrogation'
+const EMBED_URL = 'https://embed.vhx.tv/videos/3851601?api=1&product_id=122755'
+const SMUGGLED_EMBED_URL = `${EMBED_URL}#__youtubedl_smuggle=${encodeURIComponent(JSON.stringify({referer: PARENT_URL}))}`
+const REAL_TITLE = 'Scammer Sobs During Police Interrogation'
+const PARENT_HTML = `<html><head><meta property="og:title" content="${REAL_TITLE} - Free Videos - Trilogy Plus"><meta property="og:site_name" content="Trilogy Plus"></head><body></body></html>`
+
+function vhxInfoJson(overrides: Record<string, unknown> = {}): string {
+	return JSON.stringify({_type: 'video', id: '3851601', title: 'Untitled', extractor: 'vhx:embed', extractor_key: 'VHXEmbed', webpage_url: SMUGGLED_EMBED_URL, formats: [{format_id: 'http-1080p', ext: 'mp4', vcodec: 'avc1', acodec: 'mp4a.40.2', height: 1080}], ...overrides})
+}
+
+function okFetcher(html: string | null): VhxTitleFetcher {
+	return vi.fn(async () => html)
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	vi.mocked(probeElectronNodeRuntime).mockResolvedValue({ok: true, runtime: {kind: 'electron-node', executablePath: '/mock/Arroxy', version: '24.16.0'}, output: 'v24.16.0'})
+})
+
+describe('smuggledRefererOf', () => {
+	it('parses the yt-dlp referer smuggled in the webpage_url fragment', () => {
+		expect(smuggledRefererOf(SMUGGLED_EMBED_URL)).toBe(PARENT_URL)
+	})
+
+	it('parses the http_headers.Referer smuggle shape', () => {
+		const url = `${EMBED_URL}#__youtubedl_smuggle=${encodeURIComponent(JSON.stringify({http_headers: {Referer: PARENT_URL}}))}`
+		expect(smuggledRefererOf(url)).toBe(PARENT_URL)
+	})
+
+	it('returns null for URLs without a smuggle fragment', () => {
+		expect(smuggledRefererOf(EMBED_URL)).toBeNull()
+		expect(smuggledRefererOf(undefined)).toBeNull()
+	})
+
+	it('returns null when the smuggled referer is the VHX embed host itself', () => {
+		const url = `${EMBED_URL}#__youtubedl_smuggle=${encodeURIComponent(JSON.stringify({referer: EMBED_URL}))}`
+		expect(smuggledRefererOf(url)).toBeNull()
+	})
+})
+
+describe('trimSiteSuffix', () => {
+	it('strips a trailing "- Site Name" segment', () => {
+		expect(trimSiteSuffix(`${REAL_TITLE} - Free Videos - Trilogy Plus`, 'Trilogy Plus')).toBe(`${REAL_TITLE} - Free Videos`)
+	})
+
+	it('strips a trailing "(Site Name)" segment', () => {
+		expect(trimSiteSuffix(`${REAL_TITLE} (Trilogy Plus)`, 'Trilogy Plus')).toBe(REAL_TITLE)
+	})
+
+	it('leaves the title alone when the site name is not a suffix', () => {
+		expect(trimSiteSuffix(REAL_TITLE, 'Other Site')).toBe(REAL_TITLE)
+	})
+
+	it('is case-insensitive on the site name match', () => {
+		expect(trimSiteSuffix(`${REAL_TITLE} - trilogy plus`, 'Trilogy Plus')).toBe(REAL_TITLE)
+	})
+})
+
+describe('ProbeService — VHX Untitled title recovery', () => {
+	it('replaces the Untitled sentinel with the parent page og:title', async () => {
+		vi.mocked(spawnYtDlp).mockReturnValue(makeFakeProcessEmitting(vhxInfoJson()) as never)
+		const fetcher = okFetcher(PARENT_HTML)
+
+		const r = await new ProbeService(makeYtDlp(), false, undefined, {vhxTitleFetcher: fetcher}).probe(PARENT_URL, 'off', 'video')
+
+		expect(fetcher).toHaveBeenCalledWith(PARENT_URL, expect.anything())
+		expect(r.ok).toBe(true)
+		if (r.ok && r.data.kind === 'video') expect(r.data.title).toBe(REAL_TITLE)
+	})
+
+	it('patches the cached info JSON so the download names the file with the real title', async () => {
+		vi.mocked(spawnYtDlp).mockReturnValue(makeFakeProcessEmitting(vhxInfoJson()) as never)
+		const ref = {id: '00000000-0000-4000-8000-000000000001', createdAt: '2026-08-31T00:00:00.000Z', videoId: '3851601'}
+		const cache = {write: vi.fn().mockResolvedValue(ref), resolve: vi.fn().mockResolvedValue('/cache/00000000-0000-4000-8000-000000000001.info.json')} as unknown as ProbeInfoJsonCache
+
+		const r = await new ProbeService(makeYtDlp(), false, cache, {vhxTitleFetcher: okFetcher(PARENT_HTML)}).probe(PARENT_URL, 'off', 'video')
+
+		expect(cache.write).toHaveBeenCalledWith(expect.objectContaining({id: '3851601', title: REAL_TITLE}), {videoId: '3851601'})
+		if (r.ok && r.data.kind === 'video') expect(r.data.probeInfoJsonRef).toEqual(ref)
+	})
+
+	it('keeps the original format list in the patched cache payload', async () => {
+		vi.mocked(spawnYtDlp).mockReturnValue(makeFakeProcessEmitting(vhxInfoJson()) as never)
+		const cache = {write: vi.fn().mockResolvedValue({id: '00000000-0000-4000-8000-000000000002', createdAt: 'x'})} as unknown as ProbeInfoJsonCache
+
+		await new ProbeService(makeYtDlp(), false, cache, {vhxTitleFetcher: okFetcher(PARENT_HTML)}).probe(PARENT_URL, 'off', 'video')
+
+		const raw = vi.mocked(cache.write).mock.calls[0]?.[0] as {formats?: Array<{format_id?: string}>; extractor_key?: string}
+		expect(raw.formats?.[0]?.format_id).toBe('http-1080p')
+		expect(raw.extractor_key).toBe('VHXEmbed')
+	})
+
+	it('keeps the sentinel when the parent page has no og:title', async () => {
+		vi.mocked(spawnYtDlp).mockReturnValue(makeFakeProcessEmitting(vhxInfoJson()) as never)
+		const fetcher = okFetcher('<html><head><title>Vimeo OTT</title></head></html>')
+
+		const r = await new ProbeService(makeYtDlp(), false, undefined, {vhxTitleFetcher: fetcher}).probe(PARENT_URL, 'off', 'video')
+
+		expect(r.ok).toBe(true)
+		if (r.ok && r.data.kind === 'video') expect(r.data.title).toBe('Untitled')
+	})
+
+	it('keeps the sentinel when the parent fetch fails', async () => {
+		vi.mocked(spawnYtDlp).mockReturnValue(makeFakeProcessEmitting(vhxInfoJson()) as never)
+		const fetcher: VhxTitleFetcher = vi.fn(async () => {
+			throw new Error('network down')
+		})
+
+		const r = await new ProbeService(makeYtDlp(), false, undefined, {vhxTitleFetcher: fetcher}).probe(PARENT_URL, 'off', 'video')
+
+		expect(r.ok).toBe(true)
+		if (r.ok && r.data.kind === 'video') expect(r.data.title).toBe('Untitled')
+	})
+
+	it('does not fetch when the extractor already returned a real title', async () => {
+		vi.mocked(spawnYtDlp).mockReturnValue(makeFakeProcessEmitting(vhxInfoJson({title: 'Real VHX Title'})) as never)
+		const fetcher = okFetcher(PARENT_HTML)
+
+		await new ProbeService(makeYtDlp(), false, undefined, {vhxTitleFetcher: fetcher}).probe(PARENT_URL, 'off', 'video')
+
+		expect(fetcher).not.toHaveBeenCalled()
+	})
+
+	it('does not fetch for non-VHX extractors even when the title is Untitled', async () => {
+		const json = JSON.stringify({_type: 'video', id: 'v1', title: 'Untitled', extractor: 'generic', extractor_key: 'Generic', webpage_url: 'https://example.com/watch/v1', formats: [{format_id: 'f1', ext: 'mp4'}]})
+		vi.mocked(spawnYtDlp).mockReturnValue(makeFakeProcessEmitting(json) as never)
+		const fetcher = okFetcher(PARENT_HTML)
+
+		await new ProbeService(makeYtDlp(), false, undefined, {vhxTitleFetcher: fetcher}).probe('https://example.com/watch/v1', 'off', 'video')
+
+		expect(fetcher).not.toHaveBeenCalled()
+	})
+
+	it('does not fetch when the input URL is the embed itself with no smuggled referer', async () => {
+		vi.mocked(spawnYtDlp).mockReturnValue(makeFakeProcessEmitting(vhxInfoJson({webpage_url: EMBED_URL})) as never)
+		const fetcher = okFetcher(PARENT_HTML)
+
+		await new ProbeService(makeYtDlp(), false, undefined, {vhxTitleFetcher: fetcher}).probe(EMBED_URL, 'off', 'video')
+
+		expect(fetcher).not.toHaveBeenCalled()
+	})
+
+	it('recovers in auto playlist mode too when the probe resolves to a single video', async () => {
+		vi.mocked(spawnYtDlp).mockReturnValue(makeFakeProcessEmitting(vhxInfoJson()) as never)
+		const fetcher = okFetcher(PARENT_HTML)
+
+		const r = await new ProbeService(makeYtDlp(), false, undefined, {vhxTitleFetcher: fetcher}).probe(PARENT_URL, 'off', 'auto')
+
+		expect(fetcher).toHaveBeenCalledWith(PARENT_URL, expect.anything())
+		if (r.ok && r.data.kind === 'video') expect(r.data.title).toBe(REAL_TITLE)
+	})
+})

--- a/tests/unit/probe-service-vhx-title.test.ts
+++ b/tests/unit/probe-service-vhx-title.test.ts
@@ -101,6 +101,10 @@ describe('isPrivateHostname', () => {
 	it.each([
 		['localhost', true],
 		['sub.localhost', true],
+		['localhost.', true],
+		['LOCALHOST.', true],
+		['127.0.0.1.', true],
+		['sub.localhost.', true],
 		['api.internal', true],
 		['127.0.0.1', true],
 		['10.1.2.3', true],

--- a/tests/unit/probe-service-vhx-title.test.ts
+++ b/tests/unit/probe-service-vhx-title.test.ts
@@ -3,7 +3,7 @@ import {EventEmitter} from 'node:events'
 import {describe, expect, it, vi, beforeEach} from 'vitest'
 import {ProbeService} from '@main/services/ProbeService.js'
 import {YtDlp} from '@main/services/YtDlp.js'
-import {patchInfoJsonTitle, smuggledRefererOf} from '@main/services/vhxTitleRecovery.js'
+import {isPrivateHostname, patchInfoJsonTitle, smuggledRefererOf} from '@main/services/vhxTitleRecovery.js'
 import type {VhxTitleFetcher} from '@main/services/vhxTitleRecovery.js'
 import type {ProbeInfoJsonCache} from '@main/services/ProbeInfoJsonCache.js'
 
@@ -94,6 +94,36 @@ describe('patchInfoJsonTitle', () => {
 	it('leaves a missing or empty title alone', () => {
 		expect(patchInfoJsonTitle({id: 'x'}, 'New')).toEqual({id: 'x'})
 		expect(patchInfoJsonTitle({id: 'x', title: ''}, 'New')).toEqual({id: 'x', title: ''})
+	})
+})
+
+describe('isPrivateHostname', () => {
+	it.each([
+		['localhost', true],
+		['sub.localhost', true],
+		['api.internal', true],
+		['127.0.0.1', true],
+		['10.1.2.3', true],
+		['192.168.0.15', true],
+		['169.254.10.10', true],
+		['172.16.0.1', true],
+		['172.31.255.255', true],
+		['0.0.0.0', true],
+		['172.15.0.1', false],
+		['172.32.0.1', false],
+		['::1', true],
+		['[::1]', true],
+		['fe80::1', true],
+		['fc00::abcd', true],
+		['fd12::1', true],
+		['::ffff:127.0.0.1', true],
+		['::ffff:10.0.0.1', true],
+		['example.com', false],
+		['embed.vhx.tv', false],
+		['trilogyplus.com', false],
+		['8.8.8.8', false]
+	])('%s → %s', (host, expected) => {
+		expect(isPrivateHostname(host)).toBe(expected)
 	})
 })
 
@@ -189,6 +219,16 @@ describe('ProbeService — VHX Untitled title recovery', () => {
 
 		expect(fetcher).toHaveBeenCalledWith(PARENT_URL, expect.anything())
 		if (r.ok && r.data.kind === 'video') expect(r.data.title).toBe(REAL_TITLE)
+	})
+
+	it('does not treat the terminal path slug as a removable collection segment', async () => {
+		vi.mocked(spawnYtDlp).mockReturnValue(makeFakeProcessEmitting(vhxInfoJson({webpage_url: `${EMBED_URL}#__youtubedl_smuggle=${encodeURIComponent(JSON.stringify({referer: 'https://www.trilogyplus.com/watch/episode-2'}))}`})) as never)
+		const episodicHtml = '<html><head><meta property="og:title" content="Interviews - Episode 2 - Trilogy Plus"><meta property="og:site_name" content="Trilogy Plus"></head><body></body></html>'
+
+		const r = await new ProbeService(makeYtDlp(), false, undefined, {vhxTitleFetcher: okFetcher(episodicHtml)}).probe('https://www.trilogyplus.com/watch/episode-2', 'off', 'video')
+
+		expect(r.ok).toBe(true)
+		if (r.ok && r.data.kind === 'video') expect(r.data.title).toBe('Interviews - Episode 2')
 	})
 
 	it('keeps the sentinel when the probe is aborted during the parent fetch', async () => {

--- a/tests/unit/probe-service-vhx-title.test.ts
+++ b/tests/unit/probe-service-vhx-title.test.ts
@@ -3,7 +3,7 @@ import {EventEmitter} from 'node:events'
 import {describe, expect, it, vi, beforeEach} from 'vitest'
 import {ProbeService} from '@main/services/ProbeService.js'
 import {YtDlp} from '@main/services/YtDlp.js'
-import {smuggledRefererOf, trimSiteSuffix} from '@main/services/vhxTitleRecovery.js'
+import {patchInfoJsonTitle, smuggledRefererOf} from '@main/services/vhxTitleRecovery.js'
 import type {VhxTitleFetcher} from '@main/services/vhxTitleRecovery.js'
 import type {ProbeInfoJsonCache} from '@main/services/ProbeInfoJsonCache.js'
 
@@ -76,21 +76,24 @@ describe('smuggledRefererOf', () => {
 	})
 })
 
-describe('trimSiteSuffix', () => {
-	it('strips a trailing "- Site Name" segment', () => {
-		expect(trimSiteSuffix(`${REAL_TITLE} - Free Videos - Trilogy Plus`, 'Trilogy Plus')).toBe(`${REAL_TITLE} - Free Videos`)
+describe('patchInfoJsonTitle', () => {
+	it('overwrites a non-empty string title, keeping the rest of the dict', () => {
+		expect(patchInfoJsonTitle({id: 'x', title: 'Untitled', formats: []}, 'New')).toEqual({id: 'x', title: 'New', formats: []})
 	})
 
-	it('strips a trailing "(Site Name)" segment', () => {
-		expect(trimSiteSuffix(`${REAL_TITLE} (Trilogy Plus)`, 'Trilogy Plus')).toBe(REAL_TITLE)
+	it('returns arrays unchanged', () => {
+		const arr = [{title: 'Untitled'}]
+		expect(patchInfoJsonTitle(arr, 'New')).toBe(arr)
 	})
 
-	it('leaves the title alone when the site name is not a suffix', () => {
-		expect(trimSiteSuffix(REAL_TITLE, 'Other Site')).toBe(REAL_TITLE)
+	it('returns non-object payloads unchanged', () => {
+		expect(patchInfoJsonTitle(null, 'New')).toBeNull()
+		expect(patchInfoJsonTitle('raw', 'New')).toBe('raw')
 	})
 
-	it('is case-insensitive on the site name match', () => {
-		expect(trimSiteSuffix(`${REAL_TITLE} - trilogy plus`, 'Trilogy Plus')).toBe(REAL_TITLE)
+	it('leaves a missing or empty title alone', () => {
+		expect(patchInfoJsonTitle({id: 'x'}, 'New')).toEqual({id: 'x'})
+		expect(patchInfoJsonTitle({id: 'x', title: ''}, 'New')).toEqual({id: 'x', title: ''})
 	})
 })
 
@@ -186,5 +189,20 @@ describe('ProbeService — VHX Untitled title recovery', () => {
 
 		expect(fetcher).toHaveBeenCalledWith(PARENT_URL, expect.anything())
 		if (r.ok && r.data.kind === 'video') expect(r.data.title).toBe(REAL_TITLE)
+	})
+
+	it('keeps the sentinel when the probe is aborted during the parent fetch', async () => {
+		vi.mocked(spawnYtDlp).mockReturnValue(makeFakeProcessEmitting(vhxInfoJson()) as never)
+		const service = new ProbeService(makeYtDlp(), false, undefined, {
+			vhxTitleFetcher: async () => {
+				service.cancelInFlight() // aborts this probe's own controller, as the renderer would
+				return PARENT_HTML
+			}
+		})
+
+		const r = await service.probe(PARENT_URL, 'off', 'video')
+
+		expect(r.ok).toBe(true)
+		if (r.ok && r.data.kind === 'video') expect(r.data.title).toBe('Untitled')
 	})
 })


### PR DESCRIPTION
## Problem

User report (download queue): downloading from trilogyplus.com with a cookie file works, but the video title is lost — files land as `Untitled [id].mp4` instead of the page's real title.

## Root cause (reproduced with our pinned nightly 2026.08.29.232711)

1. VHX/Vimeo-OTT sites embed the player from `embed.vhx.tv`; without a session the page renders no embed at all (which is why the cookie is required).
2. `VHXEmbedIE` reads the VHX player config; its `video.title` is unset on these sites, so yt-dlp falls back to the literal sentinel `'Untitled'` (codified in VHXEmbedIE's own webpage test).
3. `GenericIE` merges page metadata *under* the embed result (`merge_dicts(embeds[0], info_dict)` — embed fields win), and `'Untitled'` is non-empty, so the parent page's real `og:title` is discarded.

Verified on the cookie-free page `https://demo.vhx.tv/packages/behind-the-scenes-with-sasha/videos/hard-work`: page says `Hard Work - Behind the Scenes with Sasha - Stay Tuned`, yt-dlp returns `Untitled`.

## Fix

New `vhxTitleRecovery` module + a hook in `ProbeService.probe()`:

- **Trigger (narrow):** video-kind probe + extractor is VHX (`VHXEmbed` / `vhx:*`) + title is exactly the `'Untitled'` sentinel.
- **Recovery:** fetch the parent page (referer yt-dlp smuggles into `webpage_url`'s `#__youtubedl_smuggle=` fragment; falls back to the probed URL when it isn't the embed host) and read `og:title` / `twitter:title` — `<title>` is deliberately *not* consulted, logged-out fetches of paywalled VHX pages serve generic marketing titles there.
- **Trim:** trailing `- Site` / `(Site)` segments removed, anchored to `og:site_name` + the parent URL's path slugs (`... - Free Videos - Trilogy Plus` → clean title; never empties the title).
- **Filename:** the recovered title is also patched into the cached probe info JSON, so the download phase's `--load-info-json` path names the file correctly.
- **Fail-safe:** any miss (fetch error, missing meta, trim-to-empty) keeps the sentinel — behavior identical to before. Trigger is impossible for YouTube/other extractors.

## Verification

- 17 new unit tests (`probe-service-vhx-title.test.ts`): smuggle parsing, segment trimming, recovery, cache patching, and all no-op guards
- Full suite: 235 files / 2766 tests green
- `bun run check` (format + type-aware lint + typecheck + knip + madge + i18n + package gates): green
- `hermes verify` (bootstrap → build → typecheck → test): green
- Live pipeline check against real pages: demo.vhx.tv → `Hard Work`, trilogyplus free video → `Scammer Sobs During Police Interrogation`

## Notes

- Upstream yt-dlp would be the cleaner layer for this (dropping the sentinel so GenericIE's merge backfills from the page), but their NO-AI policy forbids AI-authored contributions, so we fix it app-side. An upstream issue can still be filed manually later.
- Optional follow-up (separate PR): a rename affordance in the queue UI would rescue every other wrong-title case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## User-facing changes

- Recover real titles for VHX/Vimeo OTT embeds when yt-dlp returns `Untitled`.
- Read titles from parent-page `og:title` or `twitter:title` metadata.
- Remove trailing site or collection segments from recovered titles.
- Update cached info JSON so downloaded filenames use the recovered title.
- Preserve `Untitled` when metadata is missing, fetching fails, or probing is aborted.

## Internal and refactor changes

- Add `vhxTitleRecovery.ts` for VHX detection, referer parsing, title extraction, title derivation, cache patching, and page fetching.
- Integrate recovery into `ProbeService.probe()`.
- Add an injectable `VhxTitleFetcher` for deterministic tests.
- Follow parent-page redirects manually with per-hop private and loopback hostname checks.
- Document residual DNS-rebinding risk.
- Add table-driven hostname coverage and regression coverage for episodic titles.
- No dependency or IPC changes.

## Risk areas

- Recovery fetches a URL from a smuggled referer or probe URL. Review Electron network-security boundaries and URL validation.
- Redirect protection blocks private and loopback hostnames on each hop, but residual DNS-rebinding risk remains.
- The fetcher uses a browser-like user agent, a 10-second timeout, and one retry.
- Review release and build behavior for the new module and the updated `ProbeService` constructor.

## Tests and checks

- Run `tests/unit/probe-service-vhx-title.test.ts`.
- Run the full test suite.
- Run project verification and build checks.
- Verify the 23 hostname cases and episodic-title regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->