### PR TITLE
fix(settings): migrate legacy profile filename defaults

### DIFF
--- a/src/main/stores/SettingsStore.ts
+++ b/src/main/stores/SettingsStore.ts
@@ -2,6 +2,7 @@ import {randomUUID} from 'node:crypto'
 import Store from 'electron-store'
 import type {AppSettings, CommonSettings, SinglePrefs} from '@shared/types.js'
 import type {SettingsPatch} from '@shared/api.js'
+import {downloadProfilesPrefsSchema} from '@shared/schemas.js'
 
 export type {SettingsPatch}
 
@@ -140,10 +141,12 @@ export class SettingsStore {
 		const isLegacy = isLegacyShape(raw)
 		const baseline: AppSettings = isLegacy ? migrateFlatToNested(raw, this.defaults) : this.store.store
 		const profileSource = baseline.profiles ?? this.defaults.profiles
-		const profiles = profileSource.overrides === undefined ? {...profileSource, overrides: []} : profileSource
+		const parsedProfiles = downloadProfilesPrefsSchema.safeParse(profileSource)
+		const profiles = parsedProfiles.success ? parsedProfiles.data : this.defaults.profiles
+		const profilesMigrated = JSON.stringify(profiles) !== JSON.stringify(profileSource)
 		const withDefaults: AppSettings = {...baseline, profiles}
 		const cookiesMigrated: AppSettings = {...withDefaults, common: migrateCookiesMode(withDefaults.common)}
-		if (!isLegacy && cookiesMigrated.common === withDefaults.common && withDefaults.profiles === baseline.profiles) return
+		if (!isLegacy && !profilesMigrated && cookiesMigrated.common === withDefaults.common) return
 		// Replace the entire on-disk shape with the migrated one. Wiping any
 		// legacy flat keys first prevents both shapes from coexisting on disk.
 		this.store.clear()

--- a/tests/unit/settings-store.test.ts
+++ b/tests/unit/settings-store.test.ts
@@ -5,6 +5,7 @@ import {describe, expect, it} from 'vitest'
 import {RecentJobsStore} from '@main/stores/RecentJobsStore.js'
 import {SettingsStore} from '@main/stores/SettingsStore.js'
 import {defaultAppSettings} from '@shared/constants.js'
+import {BUILTIN_DOWNLOAD_PROFILES} from '@shared/downloadProfiles.js'
 import {updateSettingsSchema} from '@shared/schemas.js'
 
 describe('settings and recent stores', () => {
@@ -175,6 +176,19 @@ describe('settings and recent stores', () => {
 
 		const readBack = await store.get()
 		expect(readBack.profiles.active).toEqual({kind: 'builtin', id: 'audio-only'})
+	})
+
+	it('migrates profile overrides saved before filename templates existed', async () => {
+		const userData = await fs.mkdtemp(path.join(os.tmpdir(), 'settings-profile-filename-migrate-'))
+		const balanced = BUILTIN_DOWNLOAD_PROFILES.find(profile => profile.id === 'balanced')
+		expect(balanced).toBeDefined()
+		const {filename: _filename, ...legacyOverride} = balanced!
+		await fs.writeFile(path.join(userData, 'settings.json'), JSON.stringify({...baseDefaults, profiles: {active: {kind: 'builtin', id: 'balanced'}, custom: [], overrides: [legacyOverride]}}), 'utf-8')
+
+		const store = new SettingsStore(userData, baseDefaults)
+		const settings = await store.get()
+
+		expect(settings.profiles.overrides[0]?.filename).toEqual({kind: 'default'})
 	})
 
 	it('merges binaryOverrides patches by key — partial patch leaves siblings intact', async () => {

--- a/tests/unit/settings-store.test.ts
+++ b/tests/unit/settings-store.test.ts
@@ -189,6 +189,10 @@ describe('settings and recent stores', () => {
 		const settings = await store.get()
 
 		expect(settings.profiles.overrides[0]?.filename).toEqual({kind: 'default'})
+
+		const reloadedStore = new SettingsStore(userData, baseDefaults)
+		const reloaded = await reloadedStore.get()
+		expect(reloaded.profiles.overrides[0]?.filename).toEqual({kind: 'default'})
 	})
 
 	it('merges binaryOverrides patches by key — partial patch leaves siblings intact', async () => {


### PR DESCRIPTION
## Bug Description

Quick Download could fail after a successful probe with `Cannot read properties of undefined (reading 'kind')` for users carrying customized profile settings from older Arroxy releases.

## Root Cause

Profiles persisted before filename templates existed do not contain a `filename` field. Although the current Zod schema supplies `{ kind: 'default' }`, `SettingsStore` returned persisted profile preferences without parsing them, so queue preparation later accessed `profile.filename.kind` on `undefined`.

## Fix

- Parse persisted download-profile preferences through `downloadProfilesPrefsSchema` during startup migration.
- Persist schema defaults when an older profile shape is normalized.
- Fall back to default profile preferences if persisted profile data is invalid instead of crashing Quick Download.
- Add a regression test using a pre-filename-template profile override.

## How to Verify

1. Start Arroxy with a profile override persisted without the `filename` field.
2. Confirm startup migrates it to `filename: { kind: 'default' }`.
3. Use Quick Download and confirm queue preparation completes without the `.kind` exception.

## Test Plan

- [x] Regression test fails before the fix and passes afterward.
- [x] `bunx vitest run --project node tests/unit/settings-store.test.ts` — 18 passed.
- [x] `bunx vitest run --project jsdom tests/renderer/probe-orchestrator.test.tsx` — 71 passed.
- [x] `bun run check` — 235 test files / 2,796 tests passed, including format, lint, types, Knip, Madge, i18n, and package gates.

## Risk Assessment

Low — the change is confined to startup normalization of download-profile preferences and uses the existing schema as the source of truth.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-facing changes
- Migrates legacy download profiles that lack `filename` settings.
- Prevents Quick Download from failing on migrated profiles.
- Uses default preferences when persisted profile data is invalid.

## Internal changes
- Validates profiles with `downloadProfilesPrefsSchema.safeParse()`.
- Persists normalized schema defaults.
- Adds a regression test for legacy profiles.

## Risk areas
- No Electron security, IPC, dependency, or build configuration changes.
- Migration changes affect persisted settings. Invalid data falls back to default profiles.

## Tests and checks
- Run the settings-store unit tests.
- Run renderer checks.
- Run the full project checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->