### PR TITLE
fix(settings): serialize every settings write and roll back to canonical state

### DIFF
--- a/src/renderer/src/store/systemSlice.ts
+++ b/src/renderer/src/store/systemSlice.ts
@@ -1,4 +1,5 @@
 import type {AppSettings, DependencyDiagnostic, DependencyId, DownloadProfile, DownloadProfileRef, HotkeyRegistrationStatus, HotkeyState} from '@shared/types.js'
+import type {SettingsPatch} from '@shared/api.js'
 import {DEFAULTS} from '@shared/constants.js'
 import {DEFAULT_DOWNLOAD_PROFILES_PREFS, normalizeDownloadProfilesPrefs, removeDownloadProfileFromPrefs, saveDownloadProfileToPrefs} from '@shared/downloadProfiles.js'
 import {i18next, pickLanguage, isRtl} from '@shared/i18n/index.js'
@@ -29,36 +30,66 @@ function handleCompletedDownloadMilestones(doneIncrements: number, prevMilestone
 	}
 }
 
-function commonPatch(get: GetState, set: SetState, patch: Partial<AppSettings['common']>): void {
-	const previous = get().settings
-	if (previous) {
-		set({settings: {...previous, common: {...previous.common, ...patch}}})
-	}
-	void window.appApi.settings.update({common: patch}).then(result => {
-		if (!result.ok) {
-			// Revert optimistic update — UI was showing patched value, but the
-			// canonical state on disk never changed. Without rollback, renderer
-			// and main process diverge until next initialize().
-			if (previous) set({settings: previous})
-			notify.settingsSaveFailed('share', result.error)
-			return
-		}
-		set({settings: result.data})
-	})
+// Every settings write goes through one queue. Writes used to run concurrently
+// and roll back on failure to a snapshot taken before the patch — which is only
+// canonical while nothing else is in flight. Overlapping, a failure rolled back
+// over a sibling's persisted value or over a newer patch to the same field, and
+// the renderer disagreed with disk until the next initialize(). Serializing
+// removes the class rather than guarding each symptom.
+let settingsWriteQueue: Promise<void> = Promise.resolve()
+
+function queueSettingsWrite(run: () => Promise<void>): Promise<void> {
+	const next = settingsWriteQueue.then(run)
+	settingsWriteQueue = next.catch(() => undefined)
+	return next
 }
 
-// Shared pattern for setCookiesPath/setProxyUrl/...: optimistic update, IPC
-// patch, on failure revert to the value captured before the patch.
-async function applyCommonPatchAsync(get: GetState, set: SetState, label: string, patch: Partial<AppSettings['common']>): Promise<void> {
-	const previous = get().settings
-	if (previous) set({settings: {...previous, common: {...previous.common, ...patch}}})
-	const result = await window.appApi.settings.update({common: patch})
+// Mirrors main's deepMerge one level down: each section named by the patch
+// merges field by field over the current one, the rest are left alone.
+function optimisticSettings(previous: AppSettings, patch: SettingsPatch): AppSettings {
+	return {
+		...previous,
+		common: patch.common ? {...previous.common, ...patch.common} : previous.common,
+		single: patch.single ? {...previous.single, ...patch.single} : previous.single,
+		playlist: patch.playlist ? {...previous.playlist, ...patch.playlist} : previous.playlist,
+		profiles: patch.profiles ? {...previous.profiles, ...patch.profiles} : previous.profiles
+	}
+}
+
+// Rollback target after a failed write. Restoring a snapshot taken before the
+// patch is what made overlapping writes unsound; main is the only thing that
+// knows what actually landed. Optimistic patches still queued behind this one
+// re-assert themselves when their own write returns.
+async function restoreCanonicalSettings(set: SetState): Promise<void> {
+	const canonical = await window.appApi.settings.get()
+	if (canonical.ok) set({settings: canonical.data})
+}
+
+// The optimistic patch is applied by the caller, synchronously: the UI has to
+// see it in the tick it acted, before this ever reaches the queue.
+async function writeSettings(set: SetState, label: string, patch: SettingsPatch): Promise<void> {
+	const result = await window.appApi.settings.update(patch)
 	if (!result.ok) {
-		if (previous) set({settings: previous})
+		await restoreCanonicalSettings(set)
 		notify.settingsSaveFailed(label, result.error)
 		return
 	}
 	set({settings: result.data})
+}
+
+function applyOptimistic(get: GetState, set: SetState, patch: SettingsPatch): void {
+	const previous = get().settings
+	if (previous) set({settings: optimisticSettings(previous, patch)})
+}
+
+function commonPatch(get: GetState, set: SetState, patch: Partial<AppSettings['common']>): void {
+	void applyCommonPatchAsync(get, set, 'share', patch)
+}
+
+// Shared pattern for setCookiesPath/setProxyUrl/...
+function applyCommonPatchAsync(get: GetState, set: SetState, label: string, patch: Partial<AppSettings['common']>): Promise<void> {
+	applyOptimistic(get, set, {common: patch})
+	return queueSettingsWrite(() => writeSettings(set, label, {common: patch}))
 }
 
 function hotkeyStatusFor(settings: AppSettings | null, state: HotkeyState): HotkeyRegistrationStatus {
@@ -84,50 +115,26 @@ async function refreshHotkeyRegistration(get: GetState, set: SetState): Promise<
 	}
 }
 
-// Hotkey writes run one at a time. Rollback restores the settings captured
-// before the patch, which is only canonical while nothing else is in flight —
-// with overlapping writes an older patch rolls back to a newer patch's
-// optimistic value, or finds itself superseded and leaves registration stuck
-// on 'pending'. Queueing removes the class instead of guarding each symptom.
-let hotkeyWriteQueue: Promise<void> = Promise.resolve()
-
 function applyHotkeyPatchAsync(get: GetState, set: SetState, label: string, patch: Partial<AppSettings['common']>): Promise<void> {
-	const run = hotkeyWriteQueue.then(() => applyHotkeyPatch(get, set, label, patch))
-	hotkeyWriteQueue = run.catch(() => undefined)
-	return run
-}
-
-async function applyHotkeyPatch(get: GetState, set: SetState, label: string, patch: Partial<AppSettings['common']>): Promise<void> {
-	const previous = get().settings
-	const previousRegistration = get().hotkeyRegistration
-	const nextEnabled = patch.hotkeyEnabled ?? previous?.common.hotkeyEnabled ?? false
+	const nextEnabled = patch.hotkeyEnabled ?? get().settings?.common.hotkeyEnabled ?? false
 	// Invalidate any refresh started before this patch: its answer describes the
 	// chord we are about to replace.
 	++hotkeyStatusRequest
-	if (previous) set({settings: {...previous, common: {...previous.common, ...patch}}})
+	applyOptimistic(get, set, {common: patch})
 	set({hotkeyRegistration: nextEnabled ? 'pending' : 'off'})
-	const result = await window.appApi.settings.update({common: patch})
-	if (!result.ok) {
-		++hotkeyStatusRequest
-		if (previous) set({settings: previous})
-		set({hotkeyRegistration: previousRegistration})
-		notify.settingsSaveFailed(label, result.error)
-		return
-	}
-	set({settings: result.data})
-	await refreshHotkeyRegistration(get, set)
+	// Both outcomes end by re-deriving registration from whatever settings the
+	// store ends up holding — canonical on success, re-read from main on
+	// failure. A pre-patch snapshot would be stale for the same reason the
+	// settings one was.
+	return queueSettingsWrite(async () => {
+		await writeSettings(set, label, {common: patch})
+		await refreshHotkeyRegistration(get, set)
+	})
 }
 
-async function applyProfilesPatchAsync(get: GetState, set: SetState, label: string, profiles: AppSettings['profiles']): Promise<void> {
-	const previous = get().settings
-	if (previous) set({settings: {...previous, profiles}})
-	const result = await window.appApi.settings.update({profiles})
-	if (!result.ok) {
-		if (previous) set({settings: previous})
-		notify.settingsSaveFailed(label, result.error)
-		return
-	}
-	set({settings: result.data})
+function applyProfilesPatchAsync(get: GetState, set: SetState, label: string, profiles: AppSettings['profiles']): Promise<void> {
+	applyOptimistic(get, set, {profiles})
+	return queueSettingsWrite(() => writeSettings(set, label, {profiles}))
 }
 
 function currentProfiles(settings: AppSettings | null): AppSettings['profiles'] {

--- a/tests/renderer/hotkey-settings.test.tsx
+++ b/tests/renderer/hotkey-settings.test.tsx
@@ -213,11 +213,10 @@ describe('HotkeySettingsSection', () => {
 	})
 
 	it('serializes overlapping hotkey writes so a failed one cannot strand the optimistic value', async () => {
-		// Rollback captures the settings seen before the patch, which is only
-		// canonical if no other patch is in flight. Overlapping writes must
-		// therefore run one at a time: a failure then rolls back to what main
-		// actually holds, and registration resolves instead of sticking at
-		// 'pending' because the older patch found itself superseded.
+		// Overlapping writes run one at a time, and a failure rolls back to what
+		// main actually holds rather than to a snapshot that predates the write
+		// before it. Registration resolves too, instead of sticking at 'pending'
+		// because the older patch found itself superseded.
 		const getState = vi.fn().mockResolvedValue(ok({accelerator: 'Ctrl+Shift+K', registered: true}))
 		mount({hotkeyEnabled: true}, {getState})
 		const persisted = buildSettings({hotkeyEnabled: true, hotkeyAccelerator: 'Ctrl+Shift+K'})
@@ -226,6 +225,8 @@ describe('HotkeySettingsSection', () => {
 			.mockResolvedValueOnce(ok(persisted))
 			.mockResolvedValueOnce(fail({kind: 'other', code: 'settings_write_failed', message: 'nope'}))
 		mockApi.settings.update = update
+		// Main kept the first write, so that is what the rollback re-reads.
+		mockApi.settings.get = vi.fn().mockResolvedValue(ok(persisted))
 
 		await act(async () => {
 			await Promise.all([useAppStore.getState().setHotkeyAccelerator('Ctrl+Shift+K'), useAppStore.getState().setHotkeyAccelerator('Ctrl+Shift+L')])

--- a/tests/renderer/settings-writes.test.tsx
+++ b/tests/renderer/settings-writes.test.tsx
@@ -1,0 +1,74 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {useAppStore} from '@renderer/store/useAppStore.js'
+import {defaultAppSettings} from '@shared/constants.js'
+import type {AppSettings} from '@shared/types.js'
+import {fail, ok} from '@shared/result.js'
+import {buildMockAppApi} from '../shared/mockAppApi.js'
+
+// Every settings write is optimistic: patch the store, send the IPC, and on
+// failure restore the settings captured before the patch. That snapshot is
+// only canonical while no other write is in flight, so these cover what
+// happens when two of them overlap.
+
+type MockApi = ReturnType<typeof buildMockAppApi>
+
+let mockApi: MockApi
+
+function buildSettings(common: Partial<AppSettings['common']> = {}): AppSettings {
+	const base = defaultAppSettings('/tmp')
+	return {...base, common: {...base.common, ...common}}
+}
+
+function mount(): void {
+	mockApi = buildMockAppApi()
+	Object.defineProperty(window, 'appApi', {writable: true, value: mockApi})
+	useAppStore.setState({initialized: true, initializing: false, settings: buildSettings()})
+}
+
+describe('settings writes', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		useAppStore.setState({settings: null})
+	})
+
+	it('does not let a failed write roll back a sibling field another write persisted', async () => {
+		// The rollback snapshot predates the sibling write, so a failure that
+		// settles last restores it wholesale and discards a value main has already
+		// committed — the renderer then disagrees with disk until initialize().
+		mount()
+		type UpdateResult = Awaited<ReturnType<MockApi['settings']['update']>>
+		let failCookies: ((value: UpdateResult) => void) | undefined
+		const persistedProxy = buildSettings({proxyUrl: 'http://proxy:8080'})
+		mockApi.settings.update = vi
+			.fn()
+			.mockImplementationOnce(() => new Promise<UpdateResult>(resolve => (failCookies = resolve)))
+			.mockImplementationOnce(() => Promise.resolve(ok(persistedProxy)))
+
+		const writes = Promise.all([useAppStore.getState().setCookiesPath('/tmp/cookies.txt'), useAppStore.getState().setProxyUrl('http://proxy:8080')])
+		await Promise.resolve()
+		failCookies?.(fail({code: 'unknown', message: 'nope'}))
+		await writes
+
+		expect(useAppStore.getState().settings?.common.proxyUrl).toBe('http://proxy:8080')
+		expect(useAppStore.getState().settings?.common.cookiesPath).toBe(buildSettings().common.cookiesPath)
+	})
+
+	it('sends overlapping settings writes one at a time', async () => {
+		mount()
+		let resolveFirst: ((value: Awaited<ReturnType<MockApi['settings']['update']>>) => void) | undefined
+		const update = vi
+			.fn()
+			.mockImplementationOnce(() => new Promise(resolve => (resolveFirst = resolve)))
+			.mockImplementationOnce(() => Promise.resolve(ok(buildSettings({proxyUrl: 'http://proxy:8080'}))))
+		mockApi.settings.update = update
+
+		const writes = Promise.all([useAppStore.getState().setCookiesPath('/tmp/cookies.txt'), useAppStore.getState().setProxyUrl('http://proxy:8080')])
+		await Promise.resolve()
+		expect(update).toHaveBeenCalledOnce()
+
+		resolveFirst?.(ok(buildSettings({cookiesPath: '/tmp/cookies.txt'})))
+		await writes
+
+		expect(update).toHaveBeenCalledTimes(2)
+	})
+})


### PR DESCRIPTION
## Summary

Four settings writers in `systemSlice.ts` shared one unsound shape: capture the whole settings object, patch optimistically, and on failure restore that snapshot. The snapshot is only canonical while nothing else is in flight, so overlapping writes let a failure roll back over a sibling's persisted field. Route all four through one queue and one helper, and roll back by re-reading canonical state from main instead of a pre-patch snapshot.

## Base branch

- [x] This PR targets `main`.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [ ] Build / CI / tooling
- [ ] Docs

## Checks

- [x] `bun run check` — 248 test files, 2911 tests, exit 0

## Testing

Covered by two new failing-first tests in `tests/renderer/settings-writes.test.tsx`, both verified to fail on `main` and pass here:

1. **Sibling field wipe.** `setCookiesPath` and `setProxyUrl` overlap; the cookies write fails and settles last. On `main` its rollback restores a snapshot that predates the proxy write, so `proxyUrl` reads back `undefined` in the renderer while main has it on disk — divergence until the next `initialize()`. Ordering matters here: an earlier draft of this test passed by luck because the failure happened to settle first.
2. **Serialization.** The second write's IPC is not sent until the first resolves.

Existing suites carried real signal too — two filename-template tests in `wizard-cookies-config.test.tsx` caught a regression from the first attempt (see below).

Manual: macOS, existing renderer suites cover the settings surfaces (cookies, proxy, pacing, filename template, profiles, hotkey); no behavioural change is expected in the success path.

## Notes for the reviewer

Two findings worth flagging, both of which changed the approach:

**Serializing alone broke the UI.** Wrapping the entire write in the queue deferred the optimistic store update by a microtask. Clearing the filename template and clicking a token chip in the same tick then appended to the *stale* template — caught by two existing tests, not by reading the diff. Optimistic UI has to be synchronous, so the optimistic patch now applies at the call site and only the IPC is queued.

**Snapshot rollback is wrong in principle, not just under concurrency.** Restoring a pre-patch snapshot is guessing at what main holds. Failures now re-read canonical settings via `settings.get()`; main is the only thing that knows what actually landed. This also removed `previousRegistration` from the hotkey path — the same stale-snapshot pattern one layer up — so both outcomes re-derive registration from the settings the store ends up holding.

`optimisticSettings` merges each section named by the patch field-by-field, matching main's `deepMerge` one level down. The previous profiles path replaced the section wholesale; callers always pass a complete profiles object, so that is equivalent in practice.

Follow-up, not in scope: `tests/shared/mockAppApi` models the IPC surface but not main's state, so `settings.get` does not reflect writes made through an overridden `settings.update`. Both tests here that exercise a failed write had to stub it. Any future failed-write test will hit the same thing.
