### PR TITLE
fix(hotkey): stop bouncing ambiguous YouTube URLs back to the app

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -114,6 +114,14 @@ _Avoid_: URL type, URL kind
 A source URL that expands into multiple videos queued together — including a channel or a search, which Arroxy treats as playlists. The URL classifier may still tag the source as playlist, channel, or search for routing.
 _Avoid_: collection, batch
 
+**Mixed URL**:
+A URL that names one video and a playlist at once, so the user's intent is genuinely ambiguous. Arroxy asks which one they meant where it can, and downloads the video where it cannot ask.
+_Avoid_: combo URL, dual URL, video+playlist URL
+
+**Radio**:
+A playlist YouTube generates on the fly around a video — personalised, endless, and different every session. It is not a mixed URL: it has no stable membership to download, so Arroxy resolves it to the one video it names and never asks.
+_Avoid_: mix, autoplay queue, station
+
 ### Profiles and quick download
 
 **Download profile**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -115,11 +115,11 @@ A source URL that expands into multiple videos queued together — including a c
 _Avoid_: collection, batch
 
 **Mixed URL**:
-A URL that names one video and a playlist at once, so the user's intent is genuinely ambiguous. Arroxy asks which one they meant where it can, and downloads the video where it cannot ask.
+A URL that names one video and a playlist at once, so the user's intent is genuinely ambiguous.
 _Avoid_: combo URL, dual URL, video+playlist URL
 
 **Radio**:
-A playlist YouTube generates on the fly around a video — personalised, endless, and different every session. It is not a mixed URL: it has no stable membership to download, so Arroxy resolves it to the one video it names and never asks.
+A playlist YouTube generates on the fly around a video — personalised, endless, and different every session. Not a mixed URL: its membership is not stable, so it addresses no fixed set of videos.
 _Avoid_: mix, autoplay queue, station
 
 ### Profiles and quick download

--- a/docs/adr/0007-a-hotkey-press-never-asks.md
+++ b/docs/adr/0007-a-hotkey-press-never-asks.md
@@ -1,0 +1,46 @@
+# A hotkey press never asks which half of a URL you meant
+
+A YouTube URL carrying both `v=` and `list=` names one video and a playlist at
+once. In the app, Arroxy asks which one the user meant. A global-hotkey press
+has no window to ask in, so it resolves the ambiguity itself: it downloads the
+video.
+
+Two separate rules produce that, and only one of them is a judgment call.
+
+A radio list (`list=RD…`, or any list reached via `start_radio`) is not
+ambiguous at all. YouTube generates it around the video, personalises it, and
+gives it different membership every session, so "download the playlist" names
+nothing stable — the `v=` is the only thing the URL addresses. Radio therefore
+reads as a plain single video in every surface, hotkey or not, and the mixed
+prompt never sees it. Nothing visible to a human distinguishes a radio link
+from a video link: not the URL as YouTube renders it, not the copied text, not
+the video card Arroxy draws from the probe. The ambiguity is ours to resolve
+because it was never the user's to notice.
+
+A real playlist (`list=PL…`) is genuinely ambiguous, and there the hotkey
+still picks the video. The alternative is not "download the playlist" — it is
+`needs-review`, a notification asking the user to open the app and answer a
+question. That defeats the point of a hotkey, which exists so a download can
+start without going near the app. Between silently queueing two hundred items
+and queueing the one video whose id is in the URL, the video is the cheaper
+wrong answer: it is visible in Downloads immediately, cancellable, and costs
+one file. The interactive paths keep the prompt; only the hotkey decides.
+
+## Consequences
+
+The routing rule lives in one place, read by both callers at different entry
+points. The hotkey previously carried its own copy of the intent-to-probe-mode
+mapping plus its own mixed-intent rule; both are gone. A new entry point that
+wants different behaviour for ambiguous URLs adds a branch there rather than a
+second table.
+
+The playlist half of this is the reversible half, and is expected to be
+revisited on public feedback. Users who hotkey a playlist link expecting the
+playlist will report a bug that reads as "it only downloaded one video". If
+that arrives more than isolated times, drop the `hotkey` branch in
+`policyForUrlIntent` and mixed URLs go back to `needs-review` — a two-line
+change. Radio is unaffected by that reversal, because it is fixed in the
+classifier and not in the policy.
+
+The radio half is not similarly negotiable. Reverting it would restore a
+prompt that offers a choice with no stable answer behind it.

--- a/src/renderer/src/store/wizard/hotkeyTrigger.ts
+++ b/src/renderer/src/store/wizard/hotkeyTrigger.ts
@@ -1,7 +1,6 @@
 import {parseBulkUrls} from '@shared/bulkUrls.js'
 import i18next from 'i18next'
 import {classifyUrlIntent} from '@shared/urlIntent.js'
-import type {UrlIntent} from '@shared/urlIntent.js'
 import {QUEUE_STATUS} from '@shared/schemas.js'
 import {isLiveQueueItem} from '@shared/queueActions.js'
 import {HOTKEY_OUTCOME_COPY} from '@shared/hotkeyOutcomes.js'
@@ -11,6 +10,7 @@ import type {GetState} from '../types.js'
 import {generateId} from '../helpers.js'
 import {rewriteYouTubeChannelRoot} from './urlIntake.js'
 import {prepareActiveProfileQueueSubmission} from './queueSubmission.js'
+import {policyForUrlIntent} from './urlIntentPolicy.js'
 
 // Renderer-side hotkey orchestration. Main presses the bell (a pre-classified
 // trigger); this module runs the same active-profile quick-download pipeline
@@ -27,18 +27,14 @@ import {prepareActiveProfileQueueSubmission} from './queueSubmission.js'
 // Hidden-window constraints shape the flow: the renderer cannot read the
 // clipboard (main already did), must not open dialogs or pop the window, and
 // must never touch the omnibox or wizard state. Anything needing user review —
-// mixed intent, playlists that want the review step, incomplete cookies setup —
-// ends as `needs-review` instead of navigating the UI.
+// playlists that want the review step, incomplete cookies setup — ends as
+// `needs-review` instead of navigating the UI.
 //
 // Parallel presses: probes are keyed per queue item, so a second hotkey on a
 // DIFFERENT URL starts its own probing row (no `busy`). Only a collision with
 // the in-app quick-download pipeline (`quickDownloadStatus === 'preparing'`)
 // reports `busy`. A second press on the SAME URL hits the live-dedupe
 // (`probing` counts as live) and reports `already-queued`.
-
-// Which playlist mode the background probe runs in, per URL intent. Keyed on
-// the intent kind union so a new intent cannot silently fall through to 'auto'.
-const PLAYLIST_MODE_BY_INTENT: Record<Exclude<UrlIntent['kind'], 'mixed'>, ProbePlaylistMode> = {'obvious-single': 'video', 'obvious-collection': 'playlist', unknown: 'auto'}
 
 export type HotkeyIntake = {kind: 'run'; url: string; playlistMode: ProbePlaylistMode} | {kind: 'outcome'; outcome: HotkeyOutcome}
 
@@ -62,13 +58,13 @@ export function intakeHotkeyTrigger(trigger: HotkeyTriggerPayload, state: {quick
 	const live = state.queue.some(item => isLiveQueueItem(item) && item.url === url)
 	if (live) return {kind: 'outcome', outcome: 'already-queued'}
 
-	const intent = classifyUrlIntent(url)
-	// Mixed intent genuinely needs a human choice. "Unknown" is every
-	// non-YouTube site — the wizard probes those happily, so the hotkey does
-	// too; only an unparseable URL is invalid.
-	if (intent.kind === 'mixed') return {kind: 'outcome', outcome: 'needs-review'}
-	const playlistMode = PLAYLIST_MODE_BY_INTENT[intent.kind]
-	return {kind: 'run', url, playlistMode}
+	// One shared rule with the omnibox, read at the `hotkey` entry point: it
+	// resolves a mixed URL to its video rather than bouncing the press back to
+	// the app. "Unknown" is every non-YouTube site — the wizard probes those
+	// happily, so the hotkey does too; only an unparseable URL is invalid.
+	const action = policyForUrlIntent(classifyUrlIntent(url), 'hotkey')
+	if (!('playlistMode' in action)) return {kind: 'outcome', outcome: 'needs-review'}
+	return {kind: 'run', url, playlistMode: action.playlistMode}
 }
 
 // Outcome for a failed probe. Cookies-config failures need the settings

--- a/src/renderer/src/store/wizard/urlIntentPolicy.ts
+++ b/src/renderer/src/store/wizard/urlIntentPolicy.ts
@@ -1,7 +1,7 @@
 import type {ProbePlaylistMode} from '@shared/types.js'
 import {urlIntentHomeLabel, type UrlIntent, type UrlIntentHomeLabel} from '@shared/urlIntent.js'
 
-export type UrlIntentEntryPoint = 'interactive-submit' | 'quick-download' | 'bulk-quick-download' | 'home-label'
+export type UrlIntentEntryPoint = 'interactive-submit' | 'quick-download' | 'bulk-quick-download' | 'hotkey' | 'home-label'
 
 export type UrlIntentPolicyAction =
 	| {kind: 'probe-video'; playlistMode: Extract<ProbePlaylistMode, 'video'>}
@@ -21,6 +21,11 @@ function probeActionForIntent(intent: UrlIntent): Extract<UrlIntentPolicyAction,
 export function policyForUrlIntent(intent: UrlIntent, entryPoint: UrlIntentEntryPoint): UrlIntentPolicyAction {
 	if (entryPoint === 'home-label') return {kind: 'show-label', label: urlIntentHomeLabel(intent)}
 	if (entryPoint === 'bulk-quick-download' && intent.kind === 'mixed') return {kind: 'open-bulk-review'}
+	// The hotkey fires against a hidden window, so there is nobody to prompt and
+	// every review path costs the user a trip back into the app. A mixed URL
+	// always names a concrete video, and queueing one unwanted video is far
+	// cheaper to undo than queueing an unwanted playlist, so the video wins.
+	if (entryPoint === 'hotkey' && intent.kind === 'mixed') return {kind: 'probe-video', playlistMode: 'video'}
 	return probeActionForIntent(intent)
 }
 

--- a/src/shared/urlIntent.ts
+++ b/src/shared/urlIntent.ts
@@ -55,6 +55,18 @@ function isYouTubeBrowseCollectionPath(segments: string[]): boolean {
 	return segments.length === 2 && segments[0] === 'browse' && isYouTubeContainerId(segments[1] ?? '')
 }
 
+// A radio/mix list (`RD…`, or any list reached via `start_radio`) is generated
+// on the fly, is personalised, and has different membership every session — so
+// "download the playlist" names nothing stable and yt-dlp would expand it to an
+// arbitrary slice. The `v=` is the only thing such a URL actually addresses.
+// Nothing on YouTube's page or in the copied link tells a human that they are
+// on a radio rather than a plain video, so the ambiguity is ours to resolve,
+// not theirs to be asked about.
+function isYouTubeRadioList(searchParams: URLSearchParams): boolean {
+	if (searchParams.has('start_radio')) return true
+	return searchParams.get('list')?.startsWith('RD') === true
+}
+
 export function classifyUrlIntent(url: string): UrlIntent {
 	const parsed = parseUrl(url)
 	if (!parsed || !isYouTubeHost(parsed.hostname)) return {kind: 'unknown', url}
@@ -64,7 +76,7 @@ export function classifyUrlIntent(url: string): UrlIntent {
 	const hasList = parsed.searchParams.has('list')
 	const hasConcreteVideo = isYouTubeVideoPath(host, segments, parsed.searchParams)
 
-	if (hasConcreteVideo && hasList) return {kind: 'mixed', url, reason: 'youtube-video-with-list'}
+	if (hasConcreteVideo && hasList) return isYouTubeRadioList(parsed.searchParams) ? {kind: 'obvious-single', url, site: 'youtube'} : {kind: 'mixed', url, reason: 'youtube-video-with-list'}
 	if (segments[0] === 'results' && parsed.searchParams.has('search_query')) return {kind: 'obvious-collection', url, collection: 'search'}
 	if (isYouTubeChannelPath(segments)) return {kind: 'obvious-collection', url, collection: 'channel'}
 	if (isYouTubeBrowseCollectionPath(segments)) return {kind: 'obvious-collection', url, collection: 'playlist'}

--- a/tests/renderer/hotkey-trigger.test.ts
+++ b/tests/renderer/hotkey-trigger.test.ts
@@ -64,8 +64,15 @@ describe('intakeHotkeyTrigger', () => {
 		expect(run({kind: 'single', url: 'not a url at all'})).toEqual({kind: 'outcome', outcome: 'invalid-clipboard'})
 	})
 
-	it('reports needs-review for mixed intent', () => {
-		expect(run({kind: 'single', url: 'https://www.youtube.com/watch?v=one&list=PL1'})).toEqual({kind: 'outcome', outcome: 'needs-review'})
+	// The hotkey has no way to ask. `v=` is guaranteed present and correct on a
+	// mixed URL, and one unwanted video is a far cheaper mistake than one
+	// unwanted 200-item playlist — so the press downloads the video it names.
+	it('downloads the video for mixed intent instead of bouncing to review', () => {
+		expect(run({kind: 'single', url: 'https://www.youtube.com/watch?v=one&list=PL1'})).toMatchObject({kind: 'run', playlistMode: 'video'})
+	})
+
+	it('runs a radio URL as a plain video', () => {
+		expect(run({kind: 'single', url: 'https://www.youtube.com/watch?v=one&list=RDone&start_radio=1'})).toMatchObject({kind: 'run', playlistMode: 'video'})
 	})
 
 	it('dedupes against live queue items by cleaned URL', () => {

--- a/tests/renderer/url-intent-policy.test.ts
+++ b/tests/renderer/url-intent-policy.test.ts
@@ -1,0 +1,30 @@
+import {describe, expect, it} from 'vitest'
+import {policyForUrlIntent} from '@renderer/store/wizard/urlIntentPolicy.js'
+import {classifyUrlIntent} from '@shared/urlIntent.js'
+
+const mixed = classifyUrlIntent('https://www.youtube.com/watch?v=one&list=PL1')
+const single = classifyUrlIntent('https://www.youtube.com/watch?v=one')
+const playlist = classifyUrlIntent('https://www.youtube.com/playlist?list=PL1')
+const unknown = classifyUrlIntent('https://vimeo.com/123')
+
+describe('policyForUrlIntent', () => {
+	it('asks the user which half of a mixed URL they meant on the interactive path', () => {
+		expect(policyForUrlIntent(mixed, 'interactive-submit')).toEqual({kind: 'show-mixed-prompt'})
+	})
+
+	// The hotkey fires against a hidden window: there is nobody to prompt, and
+	// bouncing to needs-review makes the user open the app to answer a question
+	// they almost never meant to be asked.
+	it('resolves a mixed URL to the video it names on the hotkey path', () => {
+		expect(policyForUrlIntent(mixed, 'hotkey')).toEqual({kind: 'probe-video', playlistMode: 'video'})
+	})
+
+	it.each([
+		[single, {kind: 'probe-video', playlistMode: 'video'}],
+		[playlist, {kind: 'probe-playlist', playlistMode: 'playlist'}],
+		[unknown, {kind: 'probe-auto', playlistMode: 'auto'}]
+	] as const)('agrees with the interactive path for every unambiguous intent', (intent, expected) => {
+		expect(policyForUrlIntent(intent, 'hotkey')).toEqual(expected)
+		expect(policyForUrlIntent(intent, 'interactive-submit')).toEqual(expected)
+	})
+})

--- a/tests/unit/rewrite-yt-channel-root.test.ts
+++ b/tests/unit/rewrite-yt-channel-root.test.ts
@@ -47,11 +47,17 @@ describe('rewriteYouTubeChannelRoot — appends /videos to bare channel-root URL
 })
 
 describe('isMixedYouTubeUrl — delegates to UrlIntent mixed classification', () => {
-	it.each(['https://www.youtube.com/watch?v=abc&list=PLxyz', 'https://www.youtube.com/watch?v=abc&list=RDabc', 'https://www.youtube.com/watch?list=PLxyz&v=abc', 'https://m.youtube.com/watch?v=abc&list=PLxyz', 'https://youtu.be/abc?list=PLxyz'])('returns true for mixed URL: %s', url => {
+	it.each(['https://www.youtube.com/watch?v=abc&list=PLxyz', 'https://www.youtube.com/watch?list=PLxyz&v=abc', 'https://m.youtube.com/watch?v=abc&list=PLxyz', 'https://youtu.be/abc?list=PLxyz'])('returns true for mixed URL: %s', url => {
 		expect(isMixedYouTubeUrl(url)).toBe(true)
 	})
 
 	it.each(['https://www.youtube.com/watch?v=abc', 'https://www.youtube.com/playlist?list=PLxyz', 'https://www.youtube.com/@handle', 'https://www.youtube.com/results?search_query=x'])('returns false for single-param YT URL: %s', url => {
+		expect(isMixedYouTubeUrl(url)).toBe(false)
+	})
+
+	// A radio list carries a video and a list but is not ambiguous: the list is
+	// generated per session, so the video is the only thing worth resolving.
+	it.each(['https://www.youtube.com/watch?v=abc&list=RDabc', 'https://www.youtube.com/watch?v=abc&list=RDabc&start_radio=1'])('returns false for radio URL: %s', url => {
 		expect(isMixedYouTubeUrl(url)).toBe(false)
 	})
 

--- a/tests/unit/url-intent.test.ts
+++ b/tests/unit/url-intent.test.ts
@@ -27,8 +27,31 @@ describe('classifyUrlIntent', () => {
 		expect(classifyUrlIntent(url)).toMatchObject({kind: 'obvious-collection', collection, url})
 	})
 
-	it.each(['https://www.youtube.com/watch?v=abc123&list=PLtest', 'https://www.youtube.com/watch?v=abc123&list=RDabc', 'https://m.youtube.com/watch?list=PLtest&v=abc123', 'https://www.youtube.com/live/ScsahA7OzVo?list=PLtest', 'https://www.youtube.com/clip/Ugkx_123?list=PLtest'])('%s -> mixed', url => {
+	it.each(['https://www.youtube.com/watch?v=abc123&list=PLtest', 'https://m.youtube.com/watch?list=PLtest&v=abc123', 'https://www.youtube.com/live/ScsahA7OzVo?list=PLtest', 'https://www.youtube.com/clip/Ugkx_123?list=PLtest'])('%s -> mixed', url => {
 		expect(classifyUrlIntent(url)).toEqual({kind: 'mixed', reason: 'youtube-video-with-list', url})
+	})
+
+	// A radio/mix list is generated per session and has no stable membership, so
+	// "download the playlist" is not a real option — the `v=` is the only thing
+	// the URL actually addresses. These must never reach the mixed prompt.
+	it.each([
+		'https://www.youtube.com/watch?v=abc123&list=RDabc123',
+		'https://www.youtube.com/watch?v=abc123&list=RDMMabc123',
+		'https://www.youtube.com/watch?v=abc123&list=RDAMVMabc123',
+		'https://music.youtube.com/watch?v=abc123&list=RDCLAK5uy_abc',
+		'https://www.youtube.com/watch?v=abc123&list=RDabc123&start_radio=1',
+		'https://youtu.be/abc123?list=RDabc123',
+		'https://www.youtube.com/watch?v=abc123&list=PLtest&start_radio=1'
+	])('%s -> obvious single (radio)', url => {
+		expect(classifyUrlIntent(url)).toEqual({kind: 'obvious-single', site: 'youtube', url})
+	})
+
+	it('still treats a radio list with no video behind it as a collection', () => {
+		expect(classifyUrlIntent('https://www.youtube.com/playlist?list=RDabc123')).toMatchObject({kind: 'obvious-collection', collection: 'playlist'})
+	})
+
+	it('extracts the video id from a radio URL so filenames and dedupe see it', () => {
+		expect(extractUrlIntentYouTubeVideoId(classifyUrlIntent('https://www.youtube.com/watch?v=ScsahA7OzVo&list=RDScsahA7OzVo&start_radio=1'))).toBe('ScsahA7OzVo')
 	})
 
 	it.each(['https://vimeo.com/123', 'https://example.com/watch?v=abc&list=PLxyz', 'https://www.youtube.com/live', 'https://www.youtube.com/clip', 'https://www.youtube.com/embed/videoseries', 'not a url', ''])('%s -> unknown', url => {


### PR DESCRIPTION
A global-hotkey press on a YouTube link that carries both `v=` and `list=` used to end as `needs-review` — an OS notification asking you to open the app and answer which one you meant. That defeats the point of a hotkey, which exists so a download can start without going near the app.

Two rules fix it, and they deserve different levels of confidence.

## Radio is not ambiguous (`f13c308`)

A radio list — `list=RD…`, or any list reached via `start_radio` — is generated by YouTube around the video, personalised, and has different membership every session. "Download the playlist" names nothing stable; yt-dlp would expand it to an arbitrary slice of an endless stream. The `v=` is the only thing the URL actually addresses.

Nothing visible marks these links as radio: not the URL as YouTube renders it, not the text you copy, not the video card Arroxy draws from the probe. The ambiguity was never the user's to notice, so it should not have been theirs to be asked about.

Radio now classifies as an obvious single **everywhere**, hotkey or not, and the mixed prompt never sees it. Side effect worth calling out: `extractUrlIntentYouTubeVideoId` now returns the id for these URLs, so radio downloads get proper `{id}` filenames and `[videoId]` file matching, which they did not get before. A bare `/playlist?list=RD…` with no video behind it is untouched and still enumerates.

## The hotkey decides for a real playlist (`2cb76ce`)

`&list=PL…` **is** genuinely ambiguous, and there the hotkey now picks the video anyway. The alternative was never "download the playlist" — it was `needs-review`. Between silently queueing two hundred items and queueing the one video whose id is right there in the URL, the video is the cheaper wrong answer: visible in Downloads immediately, cancellable, one file.

Interactive paths keep the prompt. Only the hotkey decides.

This also collapses a duplicated rule: the hotkey carried its own intent-to-probe-mode table *and* its own mixed-intent branch. Both are gone, replaced by a `hotkey` entry point on the shared policy, so the two callers can no longer drift apart.

## The part to watch

The playlist half is the judgment call and is **expected to be revisited on public feedback**. The failure report to look for reads as "I hotkeyed a playlist and it only downloaded one video". If that arrives more than isolated times, drop the `hotkey` branch in `policyForUrlIntent` and mixed URLs go back to `needs-review` — a two-line revert. Radio survives it untouched, because that fix lives in the classifier rather than the policy.

Written up in `docs/adr/0007-a-hotkey-press-never-asks.md` with that criterion stated, and `CONTEXT.md` gained **Mixed URL** and **Radio** glossary entries.

## Testing

`bun run check` green (2948 tests, lint, typecheck, knip, madge, package gates).

New coverage: radio across `RDMM` / `RDAMVM` / `RDCLAK` / `start_radio=1` / `youtu.be?list=RD…`; regressions pinning `&list=PL…` as still mixed and `/playlist?list=RD…` as still a collection; a new `url-intent-policy.test.ts` asserting the hotkey and interactive paths agree on every unambiguous intent and diverge only on `mixed`.

Two existing assertions flipped deliberately, both stated in the diff rather than quietly relaxed: `hotkey-trigger.test.ts` expected `needs-review` for mixed, and `rewrite-yt-channel-root.test.ts` pinned `RDabc` as mixed.

Both real links were exercised against a local build by the reporter, not by CI: the radio URL queues as a single video, and `watch?v=hHUbLv4ThOo&list=PL1N1z8AJ…` queues its video instead of bouncing. No automated coverage drives an actual hotkey press end to end — the tests above cover the intake decision, not the OS-level trigger.

## Not in scope

No CHANGELOG entry — every CHANGELOG edit for the last ten versions lands in a `release:` commit, and the file's header says sections are added when cutting a release. This belongs in the next version bump. No locale work: the change adds no i18n keys.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## User-facing changes
- Radio URLs resolve to the named video without prompting.
- Mixed video and real playlist URLs resolve to the video for hotkey downloads.
- Interactive flows still prompt for mixed URLs.

## Internal and refactor changes
- Added shared hotkey handling to `policyForUrlIntent`.
- Removed duplicated hotkey playlist routing.
- Added ADR 0007 and glossary entries for mixed URLs and radio URLs.

## Risk areas
- No Electron security, IPC boundary, dependency, release, or build configuration changes are included.
- Hotkey routing changes affect mixed-URL download behavior.

## Tests and checks
- `bun run check` passes with 2,948 tests and all listed package checks.
- Tests cover radio URL classification, playlist behavior, hotkey policy routing, and regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->